### PR TITLE
feat(SPEC-002): folio management con idempotencia

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh project *)",
+      "Bash(gh api graphql -f 'query= *)"
+    ]
+  }
+}

--- a/.claude/skills/generate-spec/SKILL.md
+++ b/.claude/skills/generate-spec/SKILL.md
@@ -25,8 +25,18 @@ Si el requerimiento no cumple el DoR → listar las preguntas pendientes antes d
 2. Lee las rules: `.claude/rules/backend.md`, `.claude/rules/frontend.md`, `.claude/rules/database.md`
 3. Explora código existente — no duplicar modelos ni endpoints existentes
 4. Valida DoR (arriba) — si hay ambigüedades, lista preguntas antes de continuar
-5. Usa plantilla: `.github/skills/generate-spec/spec-template.md` EXACTAMENTE
-6. Guarda en `.claude/specs/<nombre-en-kebab-case>.spec.md`
+5. **Crea rama gitflow** antes de escribir cualquier archivo:
+   ```bash
+   git checkout main && git pull
+   git checkout -b feature/<nombre-feature>
+   ```
+6. Usa plantilla: `.github/skills/generate-spec/spec-template.md` EXACTAMENTE
+7. Guarda en `.claude/specs/<nombre-en-kebab-case>.spec.md`
+8. Commitea la spec en la rama:
+   ```bash
+   git add .claude/specs/<nombre-feature>.spec.md
+   git commit -m "spec: add <nombre-feature> SPEC-### (DRAFT)"
+   ```
 
 ## Frontmatter obligatorio
 

--- a/.claude/specs/folio-management.spec.md
+++ b/.claude/specs/folio-management.spec.md
@@ -1,9 +1,10 @@
 ---
 id: SPEC-002
-status: APPROVED
+status: IMPLEMENTED
 feature: folio-management
 created: 2026-04-21
 updated: 2026-04-21
+implemented: 2026-04-21
 approved: 2026-04-21
 author: spec-generator
 version: "1.0"

--- a/.claude/specs/folio-management.spec.md
+++ b/.claude/specs/folio-management.spec.md
@@ -1,9 +1,10 @@
 ---
 id: SPEC-002
-status: DRAFT
+status: APPROVED
 feature: folio-management
 created: 2026-04-21
 updated: 2026-04-21
+approved: 2026-04-21
 author: spec-generator
 version: "1.0"
 related-specs: ["SPEC-001"]

--- a/.claude/specs/folio-management.spec.md
+++ b/.claude/specs/folio-management.spec.md
@@ -1,0 +1,414 @@
+---
+id: SPEC-002
+status: DRAFT
+feature: folio-management
+created: 2026-04-21
+updated: 2026-04-21
+author: spec-generator
+version: "1.0"
+related-specs: ["SPEC-001"]
+---
+
+# Spec: Creación de Folio con Idempotencia
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+`Insurance-Quoter-Back` expone `POST /v1/folios` para crear un nuevo folio de cotización. El endpoint valida suscriptor y agente contra el core service, obtiene el número de folio del core service y persiste una entidad `Quote` en estado `CREATED`. Si ya existe un folio activo (mismo `subscriberId` + `agentCode` con `quoteStatus = CREATED`), retorna el existente con HTTP 200 en lugar de crear uno nuevo (idempotencia).
+
+### Requerimiento de Negocio
+
+> `POST /v1/folios` — crea un folio con idempotencia.
+> Si ya existe folio para mismo `subscriberId` + `agentCode` sin cotización iniciada → retornar existente (HTTP 200).
+> Número de folio se obtiene llamando `GET /v1/folios` al core service.
+> Validar que `subscriberId` y `agentCode` existan en catálogos del core service.
+> Entidad JPA: `QuoteJpa` (tabla `quotes`). Domain model: `Quote` (sin anotaciones JPA).
+> Campos mínimos: `folioNumber`, `quoteStatus`, `subscriberId`, `agentCode`, `version`, `createdAt`, `updatedAt`.
+
+### Historias de Usuario
+
+#### HU-01: Crear folio nuevo
+
+```
+Como:        agente de seguros
+Quiero:      llamar POST /v1/folios con mi código y el suscriptor
+Para:        obtener un número de folio único que inicia el proceso de cotización
+
+Prioridad:   Alta
+Estimación:  M
+Dependencias: SPEC-001 (core service GET /v1/folios operativo)
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path — folio nuevo**
+```gherkin
+CRITERIO-1.1: Creación exitosa de folio nuevo
+  Dado que:  subscriberId "SUB-001" y agentCode "AGT-123" existen en el core service
+             Y no existe ningún folio con quoteStatus CREATED para esa combinación
+  Cuando:    se realiza POST /v1/folios con body {"subscriberId": "SUB-001", "agentCode": "AGT-123"}
+  Entonces:  la respuesta tiene HTTP 201
+             Y el cuerpo contiene "folioNumber" con formato "FOL-<año>-<5dígitos>"
+             Y "quoteStatus" es "CREATED"
+             Y "underwritingData.subscriberId" es "SUB-001"
+             Y "underwritingData.agentCode" es "AGT-123"
+             Y "version" es 1
+             Y "createdAt" es un timestamp ISO-8601 UTC
+             Y el folio queda persistido en la tabla quotes
+```
+
+**Idempotencia — folio existente**
+```gherkin
+CRITERIO-1.2: Retorno de folio existente sin cotización iniciada
+  Dado que:  subscriberId "SUB-001" y agentCode "AGT-123" existen en el core service
+             Y ya existe un folio "FOL-2026-00042" con quoteStatus CREATED para esa combinación
+  Cuando:    se realiza POST /v1/folios con body {"subscriberId": "SUB-001", "agentCode": "AGT-123"}
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene "folioNumber" "FOL-2026-00042"
+             Y NO se genera un nuevo número de folio en el core service
+             Y NO se crea un nuevo registro en la tabla quotes
+```
+
+**Error — suscriptor o agente inválido**
+```gherkin
+CRITERIO-1.3: Rechazo por referencia inválida
+  Dado que:  subscriberId "SUB-999" NO existe en el core service
+  Cuando:    se realiza POST /v1/folios con body {"subscriberId": "SUB-999", "agentCode": "AGT-123"}
+  Entonces:  la respuesta tiene HTTP 400
+             Y el cuerpo es {"error": "Invalid subscriber or agent", "code": "INVALID_REFERENCE"}
+```
+
+**Error — campos faltantes**
+```gherkin
+CRITERIO-1.4: Rechazo por validación de campos
+  Dado que:  se envía un body sin el campo "agentCode"
+  Cuando:    se realiza POST /v1/folios con body {"subscriberId": "SUB-001"}
+  Entonces:  la respuesta tiene HTTP 422
+             Y el cuerpo contiene "code": "VALIDATION_ERROR"
+             Y "fields" incluye "agentCode"
+```
+
+**Edge Case — folio existente con cotización iniciada**
+```gherkin
+CRITERIO-1.5: Creación de folio nuevo aunque exista otro en progreso
+  Dado que:  subscriberId "SUB-001" y agentCode "AGT-123" tienen un folio con quoteStatus IN_PROGRESS
+  Cuando:    se realiza POST /v1/folios con body {"subscriberId": "SUB-001", "agentCode": "AGT-123"}
+  Entonces:  la respuesta tiene HTTP 201
+             Y se genera un nuevo folio distinto al existente
+```
+
+### Reglas de Negocio
+
+1. **Idempotencia:** si existe Quote con `subscriberId = X` AND `agentCode = Y` AND `quoteStatus = CREATED`, retornar ese Quote con HTTP 200 sin llamar al core service.
+2. **Orden de validación:** primero buscar folio existente (idempotencia); si no existe, validar referencias en el core service; si son válidas, obtener número de folio del core y persistir.
+3. **Validación de referencias:** `subscriberId` y `agentCode` deben existir en los catálogos del core service (GET /v1/subscribers y GET /v1/agents respectivamente). Si alguno no existe → HTTP 400 `INVALID_REFERENCE`.
+4. **Número de folio:** obtenido llamando `GET /v1/folios` al core service (puerto 8081). Nunca se genera localmente.
+5. **Estado inicial:** todo folio nuevo inicia con `quoteStatus = CREATED`.
+6. **Versión:** inicia en 1 al crear; se incrementa con cada modificación posterior (optimistic locking con `@Version` JPA).
+7. **Timestamps:** `createdAt` y `updatedAt` en UTC; se generan automáticamente al persistir.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Almacén | Cambios | Descripción |
+|---------|---------|---------|-------------|
+| `QuoteJpa` | tabla `quotes` en `insurance_quoter_db` (:5432) | nueva | Registro de cotización persistida con JPA |
+| `Quote` | — (domain model, no persiste directamente) | nueva | Aggregate raíz con lógica de negocio |
+
+#### Campos de la tabla `quotes`
+
+| Columna | Tipo SQL | Obligatorio | Constraint | Descripción |
+|---------|----------|-------------|------------|-------------|
+| `id` | `BIGSERIAL` | sí | PK | Identificador interno |
+| `folio_number` | `VARCHAR(20)` | sí | UNIQUE, NOT NULL | Número de folio (ej. `FOL-2026-00042`) |
+| `quote_status` | `VARCHAR(20)` | sí | NOT NULL | Estado: CREATED, IN_PROGRESS, CALCULATED, ISSUED |
+| `subscriber_id` | `VARCHAR(50)` | sí | NOT NULL | ID del suscriptor |
+| `agent_code` | `VARCHAR(50)` | sí | NOT NULL | Código del agente |
+| `version` | `BIGINT` | sí | NOT NULL, DEFAULT 1 | Versión para optimistic locking |
+| `created_at` | `TIMESTAMP WITH TIME ZONE` | sí | NOT NULL | Timestamp creación UTC |
+| `updated_at` | `TIMESTAMP WITH TIME ZONE` | sí | NOT NULL | Timestamp última actualización UTC |
+
+#### Índices / Constraints
+
+- `UNIQUE (folio_number)` — garantiza unicidad del número de folio
+- `INDEX (subscriber_id, agent_code, quote_status)` — soporta la consulta de idempotencia (búsqueda frecuente en el happy path y en el path idempotente)
+
+#### Migración Flyway
+
+```sql
+-- V1__create_quotes_table.sql
+CREATE TABLE IF NOT EXISTS quotes (
+    id              BIGSERIAL PRIMARY KEY,
+    folio_number    VARCHAR(20)                 NOT NULL UNIQUE,
+    quote_status    VARCHAR(20)                 NOT NULL,
+    subscriber_id   VARCHAR(50)                 NOT NULL,
+    agent_code      VARCHAR(50)                 NOT NULL,
+    version         BIGINT                      NOT NULL DEFAULT 1,
+    created_at      TIMESTAMP WITH TIME ZONE    NOT NULL,
+    updated_at      TIMESTAMP WITH TIME ZONE    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_quotes_idempotency
+    ON quotes (subscriber_id, agent_code, quote_status);
+```
+
+#### Domain Model: `Quote`
+
+```java
+// domain/model/Quote.java  — POJO, sin anotaciones Spring ni JPA
+public record Quote(
+    String folioNumber,
+    QuoteStatus quoteStatus,
+    String subscriberId,
+    String agentCode,
+    Long version,
+    Instant createdAt,
+    Instant updatedAt
+) {}
+```
+
+```java
+// domain/model/QuoteStatus.java
+public enum QuoteStatus {
+    CREATED, IN_PROGRESS, CALCULATED, ISSUED
+}
+```
+
+#### Application Layer: `FolioCreationResult`
+
+```java
+// application/usecase/FolioCreationResult.java
+public record FolioCreationResult(Quote quote, boolean created) {}
+```
+
+> `created = true` → controller retorna HTTP 201. `created = false` → HTTP 200 (idempotencia).
+
+### API Endpoints
+
+#### POST /v1/folios
+
+- **Descripción:** Crea folio nuevo o retorna existente (idempotencia)
+- **Auth requerida:** no
+- **Request Body:**
+  ```json
+  {
+    "subscriberId": "SUB-001",
+    "agentCode": "AGT-123"
+  }
+  ```
+- **Response 201 — Created:**
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "quoteStatus": "CREATED",
+    "underwritingData": {
+      "subscriberId": "SUB-001",
+      "agentCode": "AGT-123"
+    },
+    "createdAt": "2026-04-20T14:30:00Z",
+    "version": 1
+  }
+  ```
+- **Response 200 — Already exists (idempotent):** misma estructura, datos del folio existente
+- **Response 400:** `{"error": "Invalid subscriber or agent", "code": "INVALID_REFERENCE"}`
+- **Response 422:** `{"error": "Validation failed", "code": "VALIDATION_ERROR", "fields": ["agentCode"]}`
+
+### Arquitectura Hexagonal — Descomposición de Componentes
+
+#### Contexto: `folio`
+
+```
+com.sofka.insurancequoter.back.folio/
+├── domain/
+│   ├── model/
+│   │   ├── Quote.java                              ← Record (folioNumber, quoteStatus, subscriberId, agentCode, version, createdAt, updatedAt)
+│   │   └── QuoteStatus.java                        ← Enum: CREATED | IN_PROGRESS | CALCULATED | ISSUED
+│   └── port/
+│       ├── in/
+│       │   └── CreateFolioUseCase.java             ← Input Port: FolioCreationResult createFolio(CreateFolioCommand)
+│       └── out/
+│           ├── QuoteRepository.java                ← Output Port: findActiveBySubscriberAndAgent / save
+│           └── CoreServiceClient.java              ← Output Port: validateSubscriber / validateAgent / nextFolioNumber
+├── application/
+│   └── usecase/
+│       ├── CreateFolioCommand.java                 ← Record: subscriberId, agentCode
+│       ├── FolioCreationResult.java                ← Record: quote, created (boolean)
+│       └── CreateFolioUseCaseImpl.java             ← Orquesta: idempotencia → validación → core call → persist
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/
+    │   │   └── rest/
+    │   │       ├── FolioController.java            ← POST /v1/folios → CreateFolioUseCase
+    │   │       ├── swaggerdocs/
+    │   │       │   └── FolioApi.java               ← @Tag, @Operation, @ApiResponse(201), @ApiResponse(200)
+    │   │       ├── dto/
+    │   │       │   ├── CreateFolioRequest.java     ← { subscriberId, agentCode } con @NotBlank
+    │   │       │   ├── FolioResponse.java          ← { folioNumber, quoteStatus, underwritingData, createdAt, version }
+    │   │       │   └── UnderwritingDataDto.java    ← { subscriberId, agentCode }
+    │   │       └── mapper/
+    │   │           └── FolioRestMapper.java        ← Quote → FolioResponse
+    │   └── out/
+    │       ├── persistence/
+    │       │   ├── adapter/
+    │       │   │   └── QuoteJpaAdapter.java        ← implementa QuoteRepository; inyecta QuoteJpaRepository
+    │       │   ├── repositories/
+    │       │   │   └── QuoteJpaRepository.java     ← extiende JpaRepository<QuoteJpa, Long>
+    │       │   ├── entities/
+    │       │   │   └── QuoteJpa.java               ← @Entity tabla quotes; @Version en campo version
+    │       │   └── mappers/
+    │       │       └── QuotePersistenceMapper.java ← Quote ↔ QuoteJpa
+    │       └── http/
+    │           ├── adapter/
+    │           │   └── CoreServiceClientAdapter.java ← implementa CoreServiceClient; usa RestClient
+    │           └── dto/
+    │               ├── SubscribersResponse.java    ← { subscribers: [...] }
+    │               ├── AgentsResponse.java         ← { agents: [...] }
+    │               └── CoreFolioResponse.java      ← { folioNumber, generatedAt }
+    └── config/
+        └── FolioConfig.java                        ← @Bean wiring CreateFolioUseCaseImpl + RestClient (core)
+```
+
+#### Contratos de interfaces clave
+
+```java
+// domain/port/in/CreateFolioUseCase.java
+public interface CreateFolioUseCase {
+    FolioCreationResult createFolio(CreateFolioCommand command);
+}
+
+// domain/port/out/QuoteRepository.java
+public interface QuoteRepository {
+    Optional<Quote> findActiveBySubscriberAndAgent(String subscriberId, String agentCode);
+    Quote save(Quote quote);
+}
+
+// domain/port/out/CoreServiceClient.java
+public interface CoreServiceClient {
+    boolean existsSubscriber(String subscriberId);
+    boolean existsAgent(String agentCode);
+    String nextFolioNumber();
+}
+```
+
+#### Flujo de llamada
+
+```
+FolioController.createFolio(request)
+  → CreateFolioUseCase.createFolio(command)
+      1. QuoteRepository.findActiveBySubscriberAndAgent(subscriberId, agentCode)
+         → si encontrado: return FolioCreationResult(existingQuote, false)   ← HTTP 200
+      2. CoreServiceClient.existsSubscriber(subscriberId)  → false → throw InvalidReferenceException
+      3. CoreServiceClient.existsAgent(agentCode)          → false → throw InvalidReferenceException
+      4. CoreServiceClient.nextFolioNumber()               ← "FOL-2026-00042"
+      5. QuoteRepository.save(newQuote)
+         ← Quote persisted
+      6. return FolioCreationResult(newQuote, true)         ← HTTP 201
+  ← ResponseEntity(FolioResponse, 201 | 200)
+```
+
+#### Manejo de excepciones
+
+| Excepción de dominio | HTTP | Código |
+|---------------------|------|--------|
+| `InvalidReferenceException` | 400 | `INVALID_REFERENCE` |
+| `jakarta.validation.ConstraintViolationException` / `MethodArgumentNotValidException` | 422 | `VALIDATION_ERROR` |
+
+Manejar con `@RestControllerAdvice` en `infrastructure/adapter/in/rest/`.
+
+### Notas de Implementación
+
+- `QuoteJpaRepository.findBySubscriberIdAndAgentCodeAndQuoteStatus(subscriberId, agentCode, "CREATED")` — Spring Data deriva la query automáticamente con el nombre del método.
+- `@Version` en `QuoteJpa.version` activa optimistic locking de JPA; el valor inicial es `null` antes del primer `save` y JPA lo asigna a `1`.
+- `CoreServiceClientAdapter` usa `RestClient` (Spring 6 / Spring Boot 3+) — no `RestTemplate`. URL base configurable via `application.properties` (`core.service.base-url=http://localhost:8081`).
+- `createdAt` y `updatedAt` se gestionan con `@CreationTimestamp` y `@UpdateTimestamp` de Hibernate en `QuoteJpa`.
+- `CreateFolioCommand` y `FolioCreationResult` viven en `application/usecase/` — no son DTOs REST ni domain objects, son objetos de coordinación de aplicación.
+- La validación de request (`@NotBlank`) se declara en `CreateFolioRequest` con Bean Validation; `@Valid` en el controller activa la validación automática.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable. Marcar cada ítem (`[x]`) al completarlo.
+
+### Backend
+
+#### Base de Datos
+- [ ] Crear migración Flyway `V1__create_quotes_table.sql` — tabla `quotes` con todos los campos definidos en el diseño
+- [ ] Crear índice `idx_quotes_idempotency` en `(subscriber_id, agent_code, quote_status)`
+- [ ] Configurar Flyway en `application.properties` apuntando a `insurance_quoter_db` (:5432)
+
+#### Dominio
+- [ ] Crear enum `QuoteStatus` en `folio/domain/model/QuoteStatus.java` — valores: CREATED, IN_PROGRESS, CALCULATED, ISSUED
+- [ ] Crear record `Quote` en `folio/domain/model/Quote.java` — campos: folioNumber, quoteStatus, subscriberId, agentCode, version, createdAt, updatedAt
+- [ ] Crear Input Port `CreateFolioUseCase` en `folio/domain/port/in/` — método `FolioCreationResult createFolio(CreateFolioCommand)`
+- [ ] Crear Output Port `QuoteRepository` en `folio/domain/port/out/` — métodos: `findActiveBySubscriberAndAgent`, `save`
+- [ ] Crear Output Port `CoreServiceClient` en `folio/domain/port/out/` — métodos: `existsSubscriber`, `existsAgent`, `nextFolioNumber`
+
+#### Aplicación
+- [ ] Crear record `CreateFolioCommand` en `folio/application/usecase/` — campos: subscriberId, agentCode
+- [ ] Crear record `FolioCreationResult` en `folio/application/usecase/` — campos: quote (Quote), created (boolean)
+- [ ] Crear excepción `InvalidReferenceException` en `folio/application/` (o `folio/domain/`)
+- [ ] Crear `CreateFolioUseCaseImpl` en `folio/application/usecase/` — implementa lógica: idempotencia → validación referencias → nextFolioNumber → save
+
+#### Infraestructura — Persistencia
+- [ ] Crear `QuoteJpa` en `folio/infrastructure/adapter/out/persistence/entities/` — `@Entity @Table(name = "quotes")`, `@Version`, `@CreationTimestamp`, `@UpdateTimestamp`
+- [ ] Crear `QuoteJpaRepository` en `folio/infrastructure/adapter/out/persistence/repositories/` — extiende `JpaRepository<QuoteJpa, Long>`; método `findBySubscriberIdAndAgentCodeAndQuoteStatus`
+- [ ] Crear `QuotePersistenceMapper` en `folio/infrastructure/adapter/out/persistence/mappers/` — convierte `Quote ↔ QuoteJpa`
+- [ ] Crear `QuoteJpaAdapter` en `folio/infrastructure/adapter/out/persistence/adapter/` — implementa `QuoteRepository`; inyecta `QuoteJpaRepository` y `QuotePersistenceMapper`
+
+#### Infraestructura — HTTP Client
+- [ ] Crear DTOs de respuesta del core: `SubscribersResponse`, `AgentsResponse`, `CoreFolioResponse` en `folio/infrastructure/adapter/out/http/dto/`
+- [ ] Crear `CoreServiceClientAdapter` en `folio/infrastructure/adapter/out/http/adapter/` — implementa `CoreServiceClient`; usa `RestClient` con base URL configurable; llama GET /v1/subscribers, GET /v1/agents, GET /v1/folios
+
+#### Infraestructura — REST
+- [ ] Crear DTO `CreateFolioRequest` en `folio/infrastructure/adapter/in/rest/dto/` — campos con `@NotBlank`: subscriberId, agentCode
+- [ ] Crear DTO `UnderwritingDataDto` en `folio/infrastructure/adapter/in/rest/dto/` — campos: subscriberId, agentCode
+- [ ] Crear DTO `FolioResponse` en `folio/infrastructure/adapter/in/rest/dto/` — campos: folioNumber, quoteStatus, underwritingData, createdAt, version
+- [ ] Crear `FolioRestMapper` en `folio/infrastructure/adapter/in/rest/mapper/` — método `FolioResponse toResponse(Quote quote)`
+- [ ] Crear Swagger interface `FolioApi` en `folio/infrastructure/adapter/in/rest/swaggerdocs/` — `@PostMapping("/v1/folios")`, `@Tag`, `@Operation`, `@ApiResponse(201)`, `@ApiResponse(200)`, `@ApiResponse(400)`, `@ApiResponse(422)`
+- [ ] Crear `FolioController` en `folio/infrastructure/adapter/in/rest/` — implementa `FolioApi`; inyecta `CreateFolioUseCase` y `FolioRestMapper`; retorna `ResponseEntity` con 201 o 200 según `FolioCreationResult.created`
+- [ ] Crear `GlobalExceptionHandler` en `folio/infrastructure/adapter/in/rest/` — `@RestControllerAdvice`; maneja `InvalidReferenceException` → 400, `MethodArgumentNotValidException` → 422
+
+#### Configuración
+- [ ] Crear `FolioConfig` en `folio/infrastructure/config/` — `@Bean` para `CreateFolioUseCaseImpl`, `RestClient` configurado con `core.service.base-url`
+- [ ] Añadir en `application.properties`: `core.service.base-url=http://localhost:8081`
+
+#### Tests Backend (TDD — escribir el test ANTES de la implementación)
+- [ ] `CreateFolioUseCaseImplTest` — idempotencia: folio existente en CREATED → retorna FolioCreationResult(quote, created=false) sin llamar core
+- [ ] `CreateFolioUseCaseImplTest` — folio nuevo: referencias válidas → llama nextFolioNumber, persiste, retorna FolioCreationResult(quote, created=true)
+- [ ] `CreateFolioUseCaseImplTest` — subscriberId inválido → lanza InvalidReferenceException
+- [ ] `CreateFolioUseCaseImplTest` — agentCode inválido → lanza InvalidReferenceException
+- [ ] `CreateFolioUseCaseImplTest` — folio existente en IN_PROGRESS → crea folio nuevo (HTTP 201)
+- [ ] `QuoteJpaAdapterTest` — findActiveBySubscriberAndAgent devuelve Optional.empty cuando no hay folio CREATED
+- [ ] `QuoteJpaAdapterTest` — save persiste correctamente y retorna Quote con version=1
+- [ ] `QuotePersistenceMapperTest` — Quote → QuoteJpa y QuoteJpa → Quote mapean todos los campos correctamente
+- [ ] `CoreServiceClientAdapterTest` — existsSubscriber true cuando core retorna el id en la lista
+- [ ] `CoreServiceClientAdapterTest` — existsSubscriber false cuando core no retorna el id
+- [ ] `CoreServiceClientAdapterTest` — nextFolioNumber retorna el folioNumber del core response
+- [ ] `FolioRestMapperTest` — toResponse mapea folioNumber, quoteStatus, subscriberId, agentCode, createdAt, version
+- [ ] `FolioControllerTest` — POST /v1/folios con creación nueva → HTTP 201 con body correcto
+- [ ] `FolioControllerTest` — POST /v1/folios idempotente → HTTP 200 con body correcto
+- [ ] `FolioControllerTest` — POST /v1/folios sin agentCode → HTTP 422 con VALIDATION_ERROR
+- [ ] `FolioControllerTest` — POST /v1/folios con referencia inválida → HTTP 400 con INVALID_REFERENCE
+- [ ] `CreateFolioIntegrationTest` — `@SpringBootTest` + Testcontainers PostgreSQL + WireMock para core: flujo completo 201
+- [ ] `CreateFolioIntegrationTest` — flujo idempotente: segunda llamada retorna 200 con mismo folioNumber
+
+### QA
+- [ ] Ejecutar skill `/gherkin-case-generator` → escenarios para CRITERIO-1.1, 1.2, 1.3, 1.4, 1.5
+- [ ] Ejecutar skill `/risk-identifier` → clasificación ASD de riesgos (core unavailable, concurrencia en idempotencia, versión conflict)
+- [ ] Validar manualmente con Bruno/Postman: `POST http://localhost:8080/v1/folios`
+- [ ] Verificar idempotencia: dos llamadas iguales → segunda retorna 200 con mismo folioNumber
+- [ ] Verificar que folio en IN_PROGRESS no bloquea creación de nuevo folio
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,7 @@ Notas y recomendaciones
 - Adaptaciones del proyecto: en este repositorio sustituiremos nombres de paquetes, endpoints y puertos por los que correspondan (p. ej. `/api/v1/folios` versus `/v1/folios`). Este archivo es una guía conceptual, no un mapeo literal.
 
 Si quieres, hago commit y push del archivo ahora, y/o lo adapto a nombres concretos del proyecto.
+
+## Agentes
+
+Los agentes custom del proyecto viven en `.claude/agents/`. Siempre usar estos agentes — **nunca** los de `.github/`, que son para GitHub Copilot.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,37 +1,45 @@
 plugins {
-	java
-	id("org.springframework.boot") version "4.0.5"
-	id("io.spring.dependency-management") version "1.1.7"
+    java
+    id("org.springframework.boot") version "4.0.5"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 group = "com.sofka.insurancequoter"
 version = "0.0.1-SNAPSHOT"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-webmvc")
-	compileOnly("org.projectlombok:lombok")
-	developmentOnly("org.springframework.boot:spring-boot-docker-compose")
-	runtimeOnly("org.postgresql:postgresql")
-	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-	annotationProcessor("org.projectlombok:lombok")
-	testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
-	testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
-	testCompileOnly("org.projectlombok:lombok")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	testAnnotationProcessor("org.projectlombok:lombok")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+    compileOnly("org.projectlombok:lombok")
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
+    runtimeOnly("org.postgresql:postgresql")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    annotationProcessor("org.projectlombok:lombok")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:testcontainers-junit-jupiter")
+    testImplementation("org.testcontainers:testcontainers-postgresql")
+    testImplementation("org.wiremock:wiremock-standalone:3.13.0")
+    testCompileOnly("org.projectlombok:lombok")
+    testAnnotationProcessor("org.projectlombok:lombok")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,9 @@
 services:
   postgres:
-    image: 'postgres:latest'
+    image: 'postgres:16'
     environment:
-      - 'POSTGRES_DB=mydatabase'
+      - 'POSTGRES_DB=insurance_quoter_db'
       - 'POSTGRES_PASSWORD=secret'
       - 'POSTGRES_USER=myuser'
     ports:
-      - '5432'
+      - '5432:5432'

--- a/src/main/java/com/sofka/insurancequoter/InsuranceQuoterApplication.java
+++ b/src/main/java/com/sofka/insurancequoter/InsuranceQuoterApplication.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class InsuranceQuoterApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(InsuranceQuoterApplication.class, args);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/Insurance_Quoter/InsuranceQuoterApplication.java
+++ b/src/main/java/com/sofka/insurancequoter/Insurance_Quoter/InsuranceQuoterApplication.java
@@ -1,13 +1,5 @@
 package com.sofka.insurancequoter.Insurance_Quoter;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-@SpringBootApplication
+// Main class moved to com.sofka.insurancequoter.InsuranceQuoterApplication
 public class InsuranceQuoterApplication {
-
-	public static void main(String[] args) {
-		SpringApplication.run(InsuranceQuoterApplication.class, args);
-	}
-
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CoreServiceException.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CoreServiceException.java
@@ -1,0 +1,7 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+public class CoreServiceException extends RuntimeException {
+    public CoreServiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioCommand.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioCommand.java
@@ -1,0 +1,7 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+// Application-layer command object — carries the intent to create a folio
+public record CreateFolioCommand(
+        String subscriberId,
+        String agentCode
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImpl.java
@@ -1,0 +1,60 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
+import java.util.Optional;
+
+// Orchestrates idempotency check → reference validation → folio generation → persistence
+@RequiredArgsConstructor
+public class CreateFolioUseCaseImpl implements CreateFolioUseCase {
+
+    private final QuoteRepository quoteRepository;
+    private final CoreServiceClient coreServiceClient;
+
+    @Override
+    public FolioCreationResult createFolio(CreateFolioCommand command) {
+        // Step 1: idempotency — return existing CREATED folio if found
+        Optional<Quote> existing =
+                quoteRepository.findActiveBySubscriberAndAgent(command.subscriberId(), command.agentCode());
+        if (existing.isPresent()) {
+            return new FolioCreationResult(existing.get(), false);
+        }
+
+        // Step 2: validate subscriber reference
+        if (!coreServiceClient.existsSubscriber(command.subscriberId())) {
+            throw new InvalidReferenceException(
+                    "Subscriber not found: " + command.subscriberId());
+        }
+
+        // Step 3: validate agent reference
+        if (!coreServiceClient.existsAgent(command.agentCode())) {
+            throw new InvalidReferenceException(
+                    "Agent not found: " + command.agentCode());
+        }
+
+        // Step 4: obtain folio number from core service
+        String folioNumber = coreServiceClient.nextFolioNumber();
+
+        // Step 5: build new Quote and persist it
+        Instant now = Instant.now();
+        Quote newQuote = new Quote(
+                folioNumber,
+                QuoteStatus.CREATED,
+                command.subscriberId(),
+                command.agentCode(),
+                null,   // version assigned by JPA on first save
+                now,
+                now
+        );
+        Quote saved = quoteRepository.save(newQuote);
+
+        // Step 6: return result flagged as newly created
+        return new FolioCreationResult(saved, true);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/FolioCreationResult.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/FolioCreationResult.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+
+// Application-layer result — wraps the quote and a flag indicating if it was newly created
+public record FolioCreationResult(
+        Quote quote,
+        boolean created
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/InvalidReferenceException.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/InvalidReferenceException.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+// Thrown when a subscriber or agent reference does not exist in the core service
+public class InvalidReferenceException extends RuntimeException {
+
+    public InvalidReferenceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/Quote.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/Quote.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+import java.time.Instant;
+
+// Domain aggregate root — no JPA or Spring annotations allowed here
+public record Quote(
+        String folioNumber,
+        QuoteStatus quoteStatus,
+        String subscriberId,
+        String agentCode,
+        Long version,
+        Instant createdAt,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteStatus.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteStatus.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+public enum QuoteStatus {
+    CREATED,
+    IN_PROGRESS,
+    CALCULATED,
+    ISSUED
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/CreateFolioUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/CreateFolioUseCase.java
@@ -2,8 +2,10 @@ package com.sofka.insurancequoter.back.folio.domain.port.in;
 
 import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioCommand;
 import com.sofka.insurancequoter.back.folio.application.usecase.FolioCreationResult;
+import org.springframework.transaction.annotation.Transactional;
 
 // Input port — defines the use case contract for folio creation
 public interface CreateFolioUseCase {
+    @Transactional
     FolioCreationResult createFolio(CreateFolioCommand command);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/CreateFolioUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/CreateFolioUseCase.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.domain.port.in;
+
+import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioCommand;
+import com.sofka.insurancequoter.back.folio.application.usecase.FolioCreationResult;
+
+// Input port — defines the use case contract for folio creation
+public interface CreateFolioUseCase {
+    FolioCreationResult createFolio(CreateFolioCommand command);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/CoreServiceClient.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/CoreServiceClient.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.folio.domain.port.out;
+
+// Output port — contract for calling the core service (Insurance-Quoter-Core)
+public interface CoreServiceClient {
+    boolean existsSubscriber(String subscriberId);
+    boolean existsAgent(String agentCode);
+    String nextFolioNumber();
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/QuoteRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/QuoteRepository.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.folio.domain.port.out;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+
+import java.util.Optional;
+
+// Output port — persistence contract for Quote aggregate
+public interface QuoteRepository {
+    Optional<Quote> findActiveBySubscriberAndAgent(String subscriberId, String agentCode);
+    Quote save(Quote quote);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioController.java
@@ -1,0 +1,35 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioCommand;
+import com.sofka.insurancequoter.back.folio.application.usecase.FolioCreationResult;
+import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.CreateFolioRequest;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.swaggerdocs.FolioApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+// Parses HTTP, delegates to the use case, maps the result — no business logic here
+@RestController
+@RequiredArgsConstructor
+public class FolioController implements FolioApi {
+
+    private final CreateFolioUseCase createFolioUseCase;
+    private final FolioRestMapper folioRestMapper;
+
+    @Override
+    public ResponseEntity<FolioResponse> createFolio(CreateFolioRequest request) {
+        CreateFolioCommand command = new CreateFolioCommand(
+                request.subscriberId(),
+                request.agentCode()
+        );
+        FolioCreationResult result = createFolioUseCase.createFolio(command);
+        FolioResponse response = folioRestMapper.toResponse(result.quote());
+        return result.created()
+                ? ResponseEntity.status(HttpStatus.CREATED).body(response)
+                : ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
 
+import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
 import com.sofka.insurancequoter.back.folio.application.usecase.InvalidReferenceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +15,8 @@ import java.util.Map;
 // Translates domain and validation exceptions into standardised HTTP error responses
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(InvalidReferenceException.class)
     public ResponseEntity<Map<String, String>> handleInvalidReference(InvalidReferenceException ex) {
@@ -32,6 +37,26 @@ public class GlobalExceptionHandler {
                         "error", "Validation failed",
                         "code", "VALIDATION_ERROR",
                         "fields", fields
+                ));
+    }
+
+    @ExceptionHandler(CoreServiceException.class)
+    public ResponseEntity<Map<String, String>> handleCoreServiceError(CoreServiceException ex) {
+        log.error("Core service unavailable: {}", ex.getMessage());
+        return ResponseEntity.status(502)
+                .body(Map.of(
+                        "error", "Core service unavailable",
+                        "code", "CORE_SERVICE_ERROR"
+                ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleUnexpected(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(500)
+                .body(Map.of(
+                        "error", "Internal server error",
+                        "code", "INTERNAL_ERROR"
                 ));
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.application.usecase.InvalidReferenceException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.Map;
+
+// Translates domain and validation exceptions into standardised HTTP error responses
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidReferenceException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidReference(InvalidReferenceException ex) {
+        return ResponseEntity.status(400)
+                .body(Map.of(
+                        "error", "Invalid subscriber or agent",
+                        "code", "INVALID_REFERENCE"
+                ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationError(MethodArgumentNotValidException ex) {
+        List<String> fields = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField())
+                .toList();
+        return ResponseEntity.status(422)
+                .body(Map.of(
+                        "error", "Validation failed",
+                        "code", "VALIDATION_ERROR",
+                        "fields", fields
+                ));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/CreateFolioRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/CreateFolioRequest.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+// Request body for POST /v1/folios
+public record CreateFolioRequest(
+        @NotBlank String subscriberId,
+        @NotBlank String agentCode
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/FolioResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/FolioResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto;
+
+import java.time.Instant;
+
+// Response body for POST /v1/folios — matches the api-contracts.md contract exactly
+public record FolioResponse(
+        String folioNumber,
+        String quoteStatus,
+        UnderwritingDataDto underwritingData,
+        Instant createdAt,
+        Long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/UnderwritingDataDto.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/UnderwritingDataDto.java
@@ -1,0 +1,4 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto;
+
+// Nested DTO carrying subscriber and agent identifiers within a folio response
+public record UnderwritingDataDto(String subscriberId, String agentCode) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/FolioRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/FolioRestMapper.java
@@ -1,0 +1,19 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.UnderwritingDataDto;
+
+// Maps domain Quote to the REST FolioResponse DTO
+public class FolioRestMapper {
+
+    public FolioResponse toResponse(Quote quote) {
+        return new FolioResponse(
+                quote.folioNumber(),
+                quote.quoteStatus().name(),
+                new UnderwritingDataDto(quote.subscriberId(), quote.agentCode()),
+                quote.createdAt(),
+                quote.version()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/FolioRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/FolioRestMapper.java
@@ -3,8 +3,10 @@ package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapp
 import com.sofka.insurancequoter.back.folio.domain.model.Quote;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.UnderwritingDataDto;
+import org.springframework.stereotype.Component;
 
 // Maps domain Quote to the REST FolioResponse DTO
+@Component
 public class FolioRestMapper {
 
     public FolioResponse toResponse(Quote quote) {

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/FolioApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/FolioApi.java
@@ -1,0 +1,31 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.CreateFolioRequest;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+// Swagger annotations live here — FolioController stays clean
+@Tag(name = "Folios", description = "Gestión de folios de cotización")
+@RequestMapping("/v1/folios")
+public interface FolioApi {
+
+    @Operation(summary = "Crear o recuperar folio de cotización",
+               description = "Crea un nuevo folio si no existe uno activo para el mismo suscriptor y agente (CREATED). "
+                             + "Si ya existe, lo retorna con HTTP 200 (idempotencia).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Folio creado exitosamente"),
+            @ApiResponse(responseCode = "200", description = "Folio existente recuperado (idempotencia)"),
+            @ApiResponse(responseCode = "400", description = "Suscriptor o agente no encontrado en el core service"),
+            @ApiResponse(responseCode = "422", description = "Datos de entrada inválidos")
+    })
+    @PostMapping
+    ResponseEntity<FolioResponse> createFolio(@Valid @RequestBody CreateFolioRequest request);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/adapter/CoreServiceClientAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/adapter/CoreServiceClientAdapter.java
@@ -1,10 +1,12 @@
 package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.adapter;
 
+import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
 import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto.AgentsResponse;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto.CoreFolioResponse;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto.SubscribersResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.web.client.RestClient;
 
 // Adapter: implements CoreServiceClient output port using Spring RestClient
@@ -18,6 +20,10 @@ public class CoreServiceClientAdapter implements CoreServiceClient {
         SubscribersResponse response = restClient.get()
                 .uri("/v1/subscribers")
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    throw new CoreServiceException(
+                            "Core service error fetching subscribers: HTTP " + res.getStatusCode().value());
+                })
                 .body(SubscribersResponse.class);
         if (response == null || response.subscribers() == null) {
             return false;
@@ -31,6 +37,10 @@ public class CoreServiceClientAdapter implements CoreServiceClient {
         AgentsResponse response = restClient.get()
                 .uri("/v1/agents")
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    throw new CoreServiceException(
+                            "Core service error fetching agents: HTTP " + res.getStatusCode().value());
+                })
                 .body(AgentsResponse.class);
         if (response == null || response.agents() == null) {
             return false;
@@ -44,9 +54,13 @@ public class CoreServiceClientAdapter implements CoreServiceClient {
         CoreFolioResponse response = restClient.get()
                 .uri("/v1/folios")
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    throw new CoreServiceException(
+                            "Core service error fetching folio number: HTTP " + res.getStatusCode().value());
+                })
                 .body(CoreFolioResponse.class);
         if (response == null) {
-            throw new IllegalStateException("Core service returned null folio response");
+            throw new CoreServiceException("Core service returned empty folio response");
         }
         return response.folioNumber();
     }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/adapter/CoreServiceClientAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/adapter/CoreServiceClientAdapter.java
@@ -1,0 +1,53 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.adapter;
+
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto.AgentsResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto.CoreFolioResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto.SubscribersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.client.RestClient;
+
+// Adapter: implements CoreServiceClient output port using Spring RestClient
+@RequiredArgsConstructor
+public class CoreServiceClientAdapter implements CoreServiceClient {
+
+    private final RestClient restClient;
+
+    @Override
+    public boolean existsSubscriber(String subscriberId) {
+        SubscribersResponse response = restClient.get()
+                .uri("/v1/subscribers")
+                .retrieve()
+                .body(SubscribersResponse.class);
+        if (response == null || response.subscribers() == null) {
+            return false;
+        }
+        return response.subscribers().stream()
+                .anyMatch(s -> subscriberId.equals(s.id()));
+    }
+
+    @Override
+    public boolean existsAgent(String agentCode) {
+        AgentsResponse response = restClient.get()
+                .uri("/v1/agents")
+                .retrieve()
+                .body(AgentsResponse.class);
+        if (response == null || response.agents() == null) {
+            return false;
+        }
+        return response.agents().stream()
+                .anyMatch(a -> agentCode.equals(a.code()));
+    }
+
+    @Override
+    public String nextFolioNumber() {
+        CoreFolioResponse response = restClient.get()
+                .uri("/v1/folios")
+                .retrieve()
+                .body(CoreFolioResponse.class);
+        if (response == null) {
+            throw new IllegalStateException("Core service returned null folio response");
+        }
+        return response.folioNumber();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/dto/AgentsResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/dto/AgentsResponse.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto;
+
+import java.util.List;
+
+// Response DTO for GET /v1/agents from the core service
+public record AgentsResponse(List<AgentItem> agents) {
+
+    public record AgentItem(String code, String name, String subscriberId) {}
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/dto/CoreFolioResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/dto/CoreFolioResponse.java
@@ -1,0 +1,6 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto;
+
+import java.time.Instant;
+
+// Response DTO for GET /v1/folios from the core service
+public record CoreFolioResponse(String folioNumber, Instant generatedAt) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/dto/SubscribersResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/dto/SubscribersResponse.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.dto;
+
+import java.util.List;
+
+// Response DTO for GET /v1/subscribers from the core service
+public record SubscribersResponse(List<SubscriberItem> subscribers) {
+
+    public record SubscriberItem(String id, String name) {}
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteJpaAdapter.java
@@ -1,0 +1,37 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.mappers.QuotePersistenceMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+// Adapter: implements the QuoteRepository output port using Spring Data JPA
+@RequiredArgsConstructor
+public class QuoteJpaAdapter implements QuoteRepository {
+
+    private final QuoteJpaRepository jpaRepository;
+    private final QuotePersistenceMapper mapper;
+
+    @Override
+    public Optional<Quote> findActiveBySubscriberAndAgent(String subscriberId, String agentCode) {
+        // Only CREATED status is considered "active" for idempotency purposes
+        return jpaRepository
+                .findBySubscriberIdAndAgentCodeAndQuoteStatus(
+                        subscriberId,
+                        agentCode,
+                        QuoteStatus.CREATED.name())
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public Quote save(Quote quote) {
+        QuoteJpa jpa = mapper.toJpa(quote);
+        QuoteJpa saved = jpaRepository.save(jpa);
+        return mapper.toDomain(saved);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteJpaAdapter.java
@@ -7,10 +7,12 @@ import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persisten
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.mappers.QuotePersistenceMapper;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 // Adapter: implements the QuoteRepository output port using Spring Data JPA
+@Component
 @RequiredArgsConstructor
 public class QuoteJpaAdapter implements QuoteRepository {
 

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/entities/QuoteJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/entities/QuoteJpa.java
@@ -1,0 +1,45 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "quotes")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuoteJpa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "folio_number", nullable = false, unique = true, length = 20)
+    private String folioNumber;
+
+    @Column(name = "quote_status", nullable = false, length = 20)
+    private String quoteStatus;
+
+    @Column(name = "subscriber_id", nullable = false, length = 50)
+    private String subscriberId;
+
+    @Column(name = "agent_code", nullable = false, length = 50)
+    private String agentCode;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/mappers/QuotePersistenceMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/mappers/QuotePersistenceMapper.java
@@ -1,0 +1,31 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.mappers;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+
+// Converts between the domain model (Quote) and the JPA entity (QuoteJpa)
+public class QuotePersistenceMapper {
+
+    public QuoteJpa toJpa(Quote quote) {
+        QuoteJpa jpa = new QuoteJpa();
+        jpa.setFolioNumber(quote.folioNumber());
+        jpa.setQuoteStatus(quote.quoteStatus().name());
+        jpa.setSubscriberId(quote.subscriberId());
+        jpa.setAgentCode(quote.agentCode());
+        // id, version, createdAt, updatedAt are managed by JPA/Hibernate
+        return jpa;
+    }
+
+    public Quote toDomain(QuoteJpa jpa) {
+        return new Quote(
+                jpa.getFolioNumber(),
+                QuoteStatus.valueOf(jpa.getQuoteStatus()),
+                jpa.getSubscriberId(),
+                jpa.getAgentCode(),
+                jpa.getVersion(),
+                jpa.getCreatedAt(),
+                jpa.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/mappers/QuotePersistenceMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/mappers/QuotePersistenceMapper.java
@@ -4,7 +4,10 @@ import com.sofka.insurancequoter.back.folio.domain.model.Quote;
 import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
 
+import org.springframework.stereotype.Component;
+
 // Converts between the domain model (Quote) and the JPA entity (QuoteJpa)
+@Component
 public class QuotePersistenceMapper {
 
     public QuoteJpa toJpa(Quote quote) {

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/repositories/QuoteJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/repositories/QuoteJpaRepository.java
@@ -1,0 +1,16 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+// Spring Data derives the idempotency query from the method name
+public interface QuoteJpaRepository extends JpaRepository<QuoteJpa, Long> {
+
+    Optional<QuoteJpa> findBySubscriberIdAndAgentCodeAndQuoteStatus(
+            String subscriberId,
+            String agentCode,
+            String quoteStatus
+    );
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
@@ -1,0 +1,33 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.config;
+
+import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioUseCaseImpl;
+import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.adapter.CoreServiceClientAdapter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class FolioConfig {
+
+    @Bean
+    public RestClient coreRestClient(@Value("${core.service.base-url}") String baseUrl) {
+        return RestClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
+
+    @Bean
+    public CoreServiceClient coreServiceClient(RestClient coreRestClient) {
+        return new CoreServiceClientAdapter(coreRestClient);
+    }
+
+    @Bean
+    public CreateFolioUseCase createFolioUseCase(QuoteRepository quoteRepository,
+                                                  CoreServiceClient coreServiceClient) {
+        return new CreateFolioUseCaseImpl(quoteRepository, coreServiceClient);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,25 @@
 spring.application.name=Insurance-Quoter
+server.port=8080
+
+# Datasource — PostgreSQL insurance_quoter_db (:5432)
+spring.datasource.url=jdbc:postgresql://localhost:5432/insurance_quoter_db
+spring.datasource.username=myuser
+spring.datasource.password=secret
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA / Hibernate
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.open-in-view=false
+
+# Flyway
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+
+# Core service base URL
+core.service.base-url=http://localhost:8081
+
+# OpenAPI / Swagger UI
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui/index.html

--- a/src/main/resources/db/migration/V1__create_quotes_table.sql
+++ b/src/main/resources/db/migration/V1__create_quotes_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS quotes (
+    id              BIGSERIAL PRIMARY KEY,
+    folio_number    VARCHAR(20)                 NOT NULL UNIQUE,
+    quote_status    VARCHAR(20)                 NOT NULL,
+    subscriber_id   VARCHAR(50)                 NOT NULL,
+    agent_code      VARCHAR(50)                 NOT NULL,
+    version         BIGINT                      NOT NULL DEFAULT 1,
+    created_at      TIMESTAMP WITH TIME ZONE    NOT NULL,
+    updated_at      TIMESTAMP WITH TIME ZONE    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_quotes_idempotency
+    ON quotes (subscriber_id, agent_code, quote_status);

--- a/src/main/resources/db/migration/V2__add_unique_active_folio_constraint.sql
+++ b/src/main/resources/db/migration/V2__add_unique_active_folio_constraint.sql
@@ -1,0 +1,5 @@
+-- Prevents two CREATED folios for the same subscriber+agent combination.
+-- Partial index: only one row per (subscriber_id, agent_code) when status is CREATED.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_quotes_active_folio
+    ON quotes (subscriber_id, agent_code)
+    WHERE quote_status = 'CREATED';

--- a/src/test/java/com/sofka/insurancequoter/InsuranceQuoterApplicationTests.java
+++ b/src/test/java/com/sofka/insurancequoter/InsuranceQuoterApplicationTests.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class InsuranceQuoterApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImplTest.java
@@ -1,0 +1,147 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateFolioUseCaseImplTest {
+
+    @Mock
+    private QuoteRepository quoteRepository;
+
+    @Mock
+    private CoreServiceClient coreServiceClient;
+
+    @InjectMocks
+    private CreateFolioUseCaseImpl useCase;
+
+    // --- CRITERIO-1.2: Idempotencia — folio existente en CREATED ---
+
+    @Test
+    void shouldReturnExistingQuote_whenActiveCreatedFolioAlreadyExists() {
+        // GIVEN
+        var existingQuote = buildQuote("FOL-2026-00042", QuoteStatus.CREATED);
+        var command = new CreateFolioCommand("SUB-001", "AGT-123");
+        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-123"))
+                .thenReturn(Optional.of(existingQuote));
+
+        // WHEN
+        FolioCreationResult result = useCase.createFolio(command);
+
+        // THEN
+        assertThat(result.created()).isFalse();
+        assertThat(result.quote().folioNumber()).isEqualTo("FOL-2026-00042");
+        // Core service must NOT be called when idempotency applies
+        verifyNoInteractions(coreServiceClient);
+        verify(quoteRepository, never()).save(any());
+    }
+
+    // --- CRITERIO-1.1: Creación exitosa de folio nuevo ---
+
+    @Test
+    void shouldCreateNewFolio_whenNoActiveFolioExistsAndReferencesAreValid() {
+        // GIVEN
+        var command = new CreateFolioCommand("SUB-001", "AGT-123");
+        var savedQuote = buildQuote("FOL-2026-00042", QuoteStatus.CREATED);
+        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-123"))
+                .thenReturn(Optional.empty());
+        when(coreServiceClient.existsSubscriber("SUB-001")).thenReturn(true);
+        when(coreServiceClient.existsAgent("AGT-123")).thenReturn(true);
+        when(coreServiceClient.nextFolioNumber()).thenReturn("FOL-2026-00042");
+        when(quoteRepository.save(any())).thenReturn(savedQuote);
+
+        // WHEN
+        FolioCreationResult result = useCase.createFolio(command);
+
+        // THEN
+        assertThat(result.created()).isTrue();
+        assertThat(result.quote().folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(result.quote().quoteStatus()).isEqualTo(QuoteStatus.CREATED);
+        verify(quoteRepository).save(any(Quote.class));
+    }
+
+    // --- CRITERIO-1.3: subscriberId inválido ---
+
+    @Test
+    void shouldThrowInvalidReferenceException_whenSubscriberDoesNotExist() {
+        // GIVEN
+        var command = new CreateFolioCommand("SUB-999", "AGT-123");
+        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-999", "AGT-123"))
+                .thenReturn(Optional.empty());
+        when(coreServiceClient.existsSubscriber("SUB-999")).thenReturn(false);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.createFolio(command))
+                .isInstanceOf(InvalidReferenceException.class);
+        verify(coreServiceClient, never()).existsAgent(any());
+        verify(quoteRepository, never()).save(any());
+    }
+
+    // --- CRITERIO-1.3: agentCode inválido ---
+
+    @Test
+    void shouldThrowInvalidReferenceException_whenAgentDoesNotExist() {
+        // GIVEN
+        var command = new CreateFolioCommand("SUB-001", "AGT-999");
+        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-999"))
+                .thenReturn(Optional.empty());
+        when(coreServiceClient.existsSubscriber("SUB-001")).thenReturn(true);
+        when(coreServiceClient.existsAgent("AGT-999")).thenReturn(false);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.createFolio(command))
+                .isInstanceOf(InvalidReferenceException.class);
+        verify(quoteRepository, never()).save(any());
+    }
+
+    // --- CRITERIO-1.5: folio existente en IN_PROGRESS no bloquea nuevo folio ---
+
+    @Test
+    void shouldCreateNewFolio_whenExistingFolioIsInProgress() {
+        // GIVEN — repository returns empty (only CREATED status is considered active for idempotency)
+        var command = new CreateFolioCommand("SUB-001", "AGT-123");
+        var savedQuote = buildQuote("FOL-2026-00099", QuoteStatus.CREATED);
+        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-123"))
+                .thenReturn(Optional.empty());
+        when(coreServiceClient.existsSubscriber("SUB-001")).thenReturn(true);
+        when(coreServiceClient.existsAgent("AGT-123")).thenReturn(true);
+        when(coreServiceClient.nextFolioNumber()).thenReturn("FOL-2026-00099");
+        when(quoteRepository.save(any())).thenReturn(savedQuote);
+
+        // WHEN
+        FolioCreationResult result = useCase.createFolio(command);
+
+        // THEN
+        assertThat(result.created()).isTrue();
+        assertThat(result.quote().quoteStatus()).isEqualTo(QuoteStatus.CREATED);
+    }
+
+    // --- Helper ---
+
+    private Quote buildQuote(String folioNumber, QuoteStatus status) {
+        return new Quote(
+                folioNumber,
+                status,
+                "SUB-001",
+                "AGT-123",
+                1L,
+                Instant.parse("2026-04-20T14:30:00Z"),
+                Instant.parse("2026-04-20T14:30:00Z")
+        );
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioControllerTest.java
@@ -1,0 +1,118 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.application.usecase.FolioCreationResult;
+import com.sofka.insurancequoter.back.folio.application.usecase.InvalidReferenceException;
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class FolioControllerTest {
+
+    @Mock
+    private CreateFolioUseCase createFolioUseCase;
+
+    private MockMvc mockMvc;
+
+    private static final Instant FIXED = Instant.parse("2026-04-20T14:30:00Z");
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new FolioController(createFolioUseCase, new FolioRestMapper()))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    private Quote quote(String folio) {
+        return new Quote(folio, QuoteStatus.CREATED, "SUB-001", "AGT-123", 1L, FIXED, FIXED);
+    }
+
+    // --- CRITERIO-1.1: creación nueva → HTTP 201 ---
+
+    @Test
+    void shouldReturn201_whenFolioIsCreatedSuccessfully() throws Exception {
+        when(createFolioUseCase.createFolio(any()))
+                .thenReturn(new FolioCreationResult(quote("FOL-2026-00042"), true));
+
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-001","agentCode":"AGT-123"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00042"))
+                .andExpect(jsonPath("$.quoteStatus").value("CREATED"))
+                .andExpect(jsonPath("$.underwritingData.subscriberId").value("SUB-001"))
+                .andExpect(jsonPath("$.underwritingData.agentCode").value("AGT-123"))
+                .andExpect(jsonPath("$.version").value(1));
+    }
+
+    // --- CRITERIO-1.2: idempotencia → HTTP 200 ---
+
+    @Test
+    void shouldReturn200_whenFolioAlreadyExists() throws Exception {
+        when(createFolioUseCase.createFolio(any()))
+                .thenReturn(new FolioCreationResult(quote("FOL-2026-00042"), false));
+
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-001","agentCode":"AGT-123"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00042"));
+    }
+
+    // --- CRITERIO-1.4: campo faltante → HTTP 422 ---
+
+    @Test
+    void shouldReturn422_whenAgentCodeIsMissing() throws Exception {
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-001"}
+                                """))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // --- CRITERIO-1.3: referencia inválida → HTTP 400 ---
+
+    @Test
+    void shouldReturn400_whenSubscriberOrAgentIsInvalid() throws Exception {
+        when(createFolioUseCase.createFolio(any()))
+                .thenThrow(new InvalidReferenceException("Subscriber not found: SUB-999"));
+
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-999","agentCode":"AGT-123"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REFERENCE"))
+                .andExpect(jsonPath("$.error").value("Invalid subscriber or agent"));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioRestMapperTest.java
@@ -1,0 +1,43 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FolioRestMapperTest {
+
+    private final FolioRestMapper mapper = new FolioRestMapper();
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-04-20T14:30:00Z");
+
+    @Test
+    void shouldMapAllFields_whenConvertingQuoteToFolioResponse() {
+        // GIVEN
+        Quote quote = new Quote(
+                "FOL-2026-00042",
+                QuoteStatus.CREATED,
+                "SUB-001",
+                "AGT-123",
+                1L,
+                FIXED_INSTANT,
+                FIXED_INSTANT
+        );
+
+        // WHEN
+        FolioResponse response = mapper.toResponse(quote);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(response.quoteStatus()).isEqualTo("CREATED");
+        assertThat(response.underwritingData().subscriberId()).isEqualTo("SUB-001");
+        assertThat(response.underwritingData().agentCode()).isEqualTo("AGT-123");
+        assertThat(response.createdAt()).isEqualTo(FIXED_INSTANT);
+        assertThat(response.version()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/CoreServiceClientAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/CoreServiceClientAdapterTest.java
@@ -1,0 +1,128 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.adapter.CoreServiceClientAdapter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.client.RestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoreServiceClientAdapterTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    private CoreServiceClientAdapter buildAdapter() {
+        String baseUrl = "http://localhost:" + wireMock.getPort();
+        RestClient restClient = RestClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+        return new CoreServiceClientAdapter(restClient);
+    }
+
+    // --- existsSubscriber ---
+
+    @Test
+    void shouldReturnTrue_whenCoreReturnsSubscriberWithMatchingId() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/subscribers"))
+                .willReturn(okJson("""
+                        {
+                          "subscribers": [
+                            { "id": "SUB-001", "name": "Seguros Sofka" },
+                            { "id": "SUB-002", "name": "Aseguradora Norte" }
+                          ]
+                        }
+                        """)));
+
+        // WHEN
+        boolean result = buildAdapter().existsSubscriber("SUB-001");
+
+        // THEN
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalse_whenCoreDoesNotReturnSubscriberWithMatchingId() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/subscribers"))
+                .willReturn(okJson("""
+                        {
+                          "subscribers": [
+                            { "id": "SUB-001", "name": "Seguros Sofka" }
+                          ]
+                        }
+                        """)));
+
+        // WHEN
+        boolean result = buildAdapter().existsSubscriber("SUB-999");
+
+        // THEN
+        assertThat(result).isFalse();
+    }
+
+    // --- existsAgent ---
+
+    @Test
+    void shouldReturnTrue_whenCoreReturnsAgentWithMatchingCode() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/agents"))
+                .willReturn(okJson("""
+                        {
+                          "agents": [
+                            { "code": "AGT-123", "name": "Juan Pérez", "subscriberId": "SUB-001" }
+                          ]
+                        }
+                        """)));
+
+        // WHEN
+        boolean result = buildAdapter().existsAgent("AGT-123");
+
+        // THEN
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalse_whenCoreDoesNotReturnAgentWithMatchingCode() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/agents"))
+                .willReturn(okJson("""
+                        {
+                          "agents": [
+                            { "code": "AGT-123", "name": "Juan Pérez", "subscriberId": "SUB-001" }
+                          ]
+                        }
+                        """)));
+
+        // WHEN
+        boolean result = buildAdapter().existsAgent("AGT-999");
+
+        // THEN
+        assertThat(result).isFalse();
+    }
+
+    // --- nextFolioNumber ---
+
+    @Test
+    void shouldReturnFolioNumber_whenCoreRespondsWithFolioData() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/folios"))
+                .willReturn(okJson("""
+                        {
+                          "folioNumber": "FOL-2026-00042",
+                          "generatedAt": "2026-04-20T14:30:00Z"
+                        }
+                        """)));
+
+        // WHEN
+        String folioNumber = buildAdapter().nextFolioNumber();
+
+        // THEN
+        assertThat(folioNumber).isEqualTo("FOL-2026-00042");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/QuoteJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/QuoteJpaAdapterTest.java
@@ -1,0 +1,92 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter.QuoteJpaAdapter;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.mappers.QuotePersistenceMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QuoteJpaAdapterTest {
+
+    @Mock
+    private QuoteJpaRepository jpaRepository;
+
+    @Spy
+    private QuotePersistenceMapper mapper = new QuotePersistenceMapper();
+
+    @InjectMocks
+    private QuoteJpaAdapter adapter;
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-04-20T14:30:00Z");
+
+    // --- findActiveBySubscriberAndAgent ---
+
+    @Test
+    void shouldReturnEmpty_whenNoCreatedFolioExistsForSubscriberAndAgent() {
+        // GIVEN
+        when(jpaRepository.findBySubscriberIdAndAgentCodeAndQuoteStatus(
+                "SUB-001", "AGT-123", "CREATED"))
+                .thenReturn(Optional.empty());
+
+        // WHEN
+        Optional<Quote> result = adapter.findActiveBySubscriberAndAgent("SUB-001", "AGT-123");
+
+        // THEN
+        assertThat(result).isEmpty();
+        verify(jpaRepository).findBySubscriberIdAndAgentCodeAndQuoteStatus(
+                eq("SUB-001"), eq("AGT-123"), eq("CREATED"));
+    }
+
+    // --- save ---
+
+    @Test
+    void shouldPersistQuoteAndReturnDomainWithVersion_whenSaving() {
+        // GIVEN
+        Quote quoteToSave = new Quote(
+                "FOL-2026-00042",
+                QuoteStatus.CREATED,
+                "SUB-001",
+                "AGT-123",
+                null,
+                FIXED_INSTANT,
+                FIXED_INSTANT
+        );
+        QuoteJpa savedJpa = QuoteJpa.builder()
+                .id(1L)
+                .folioNumber("FOL-2026-00042")
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .version(1L)
+                .createdAt(FIXED_INSTANT)
+                .updatedAt(FIXED_INSTANT)
+                .build();
+        when(jpaRepository.save(any(QuoteJpa.class))).thenReturn(savedJpa);
+
+        // WHEN
+        Quote saved = adapter.save(quoteToSave);
+
+        // THEN
+        assertThat(saved.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(saved.quoteStatus()).isEqualTo(QuoteStatus.CREATED);
+        assertThat(saved.version()).isEqualTo(1L);
+        verify(jpaRepository).save(any(QuoteJpa.class));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/QuotePersistenceMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/QuotePersistenceMapperTest.java
@@ -1,0 +1,71 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.mappers.QuotePersistenceMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuotePersistenceMapperTest {
+
+    private final QuotePersistenceMapper mapper = new QuotePersistenceMapper();
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-04-20T14:30:00Z");
+
+    // --- toJpa ---
+
+    @Test
+    void shouldMapAllFields_whenConvertingQuoteToJpa() {
+        // GIVEN
+        Quote quote = new Quote(
+                "FOL-2026-00042",
+                QuoteStatus.CREATED,
+                "SUB-001",
+                "AGT-123",
+                1L,
+                FIXED_INSTANT,
+                FIXED_INSTANT
+        );
+
+        // WHEN
+        QuoteJpa jpa = mapper.toJpa(quote);
+
+        // THEN
+        assertThat(jpa.getFolioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(jpa.getQuoteStatus()).isEqualTo("CREATED");
+        assertThat(jpa.getSubscriberId()).isEqualTo("SUB-001");
+        assertThat(jpa.getAgentCode()).isEqualTo("AGT-123");
+    }
+
+    // --- toDomain ---
+
+    @Test
+    void shouldMapAllFields_whenConvertingJpaToDomain() {
+        // GIVEN
+        QuoteJpa jpa = QuoteJpa.builder()
+                .folioNumber("FOL-2026-00042")
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .version(1L)
+                .createdAt(FIXED_INSTANT)
+                .updatedAt(FIXED_INSTANT)
+                .build();
+
+        // WHEN
+        Quote quote = mapper.toDomain(jpa);
+
+        // THEN
+        assertThat(quote.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(quote.quoteStatus()).isEqualTo(QuoteStatus.CREATED);
+        assertThat(quote.subscriberId()).isEqualTo("SUB-001");
+        assertThat(quote.agentCode()).isEqualTo("AGT-123");
+        assertThat(quote.version()).isEqualTo(1L);
+        assertThat(quote.createdAt()).isEqualTo(FIXED_INSTANT);
+        assertThat(quote.updatedAt()).isEqualTo(FIXED_INSTANT);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/integration/CreateFolioIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/integration/CreateFolioIntegrationTest.java
@@ -1,0 +1,162 @@
+package com.sofka.insurancequoter.back.folio.integration;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.sofka.insurancequoter.InsuranceQuoterApplication;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = InsuranceQuoterApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Testcontainers
+@Transactional
+class CreateFolioIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:16-alpine");
+
+    static WireMockServer wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMock.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMock.stop();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("core.service.base-url", () -> "http://localhost:" + wireMock.port());
+    }
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        wireMock.resetAll();
+    }
+
+    private void stubCoreHappyPath(String folioNumber) {
+        wireMock.stubFor(get(urlEqualTo("/v1/subscribers"))
+                .willReturn(okJson("""
+                        {"subscribers":[{"id":"SUB-001","name":"Test Subscriber"}]}
+                        """)));
+        wireMock.stubFor(get(urlEqualTo("/v1/agents"))
+                .willReturn(okJson("""
+                        {"agents":[{"code":"AGT-123","name":"Test Agent"}]}
+                        """)));
+        wireMock.stubFor(get(urlEqualTo("/v1/folios"))
+                .willReturn(okJson("""
+                        {"folioNumber":"%s"}
+                        """.formatted(folioNumber))));
+    }
+
+    // --- CRITERIO-1.1: nuevo folio → 201 con folioNumber y status CREATED ---
+
+    @Test
+    void shouldReturn201_whenNewFolioCreated() throws Exception {
+        // GIVEN
+        stubCoreHappyPath("FOL-2026-IT-001");
+
+        // WHEN / THEN
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-001","agentCode":"AGT-123"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-IT-001"))
+                .andExpect(jsonPath("$.quoteStatus").value("CREATED"))
+                .andExpect(jsonPath("$.underwritingData.subscriberId").value("SUB-001"))
+                .andExpect(jsonPath("$.underwritingData.agentCode").value("AGT-123"));
+    }
+
+    // --- CRITERIO-1.2: segunda llamada misma combinación → 200 idempotente ---
+
+    @Test
+    void shouldReturn200_whenFolioAlreadyExistsForSameSubscriberAndAgent() throws Exception {
+        // GIVEN — first call creates the folio
+        stubCoreHappyPath("FOL-2026-IT-002");
+        mockMvc.perform(post("/v1/folios")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"subscriberId":"SUB-001","agentCode":"AGT-123"}
+                        """));
+
+        // WHEN — second call with same subscriber+agent
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-001","agentCode":"AGT-123"}
+                                """))
+                // THEN — idempotent: existing folio returned with 200
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-IT-002"))
+                .andExpect(jsonPath("$.quoteStatus").value("CREATED"));
+    }
+
+    // --- CRITERIO-1.3: subscriber inválido → 400 ---
+
+    @Test
+    void shouldReturn400_whenSubscriberDoesNotExistInCore() throws Exception {
+        // GIVEN — core returns empty subscriber list
+        wireMock.stubFor(get(urlEqualTo("/v1/subscribers"))
+                .willReturn(okJson("""
+                        {"subscribers":[]}
+                        """)));
+
+        // WHEN / THEN
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-UNKNOWN","agentCode":"AGT-123"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REFERENCE"));
+    }
+
+    // --- Error: core retorna 503 → 502 Bad Gateway ---
+
+    @Test
+    void shouldReturn502_whenCoreServiceIsUnavailable() throws Exception {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/subscribers"))
+                .willReturn(serviceUnavailable()));
+
+        // WHEN / THEN
+        mockMvc.perform(post("/v1/folios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"subscriberId":"SUB-001","agentCode":"AGT-123"}
+                                """))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.code").value("CORE_SERVICE_ERROR"));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:tc:postgresql:16-alpine:///insurance_quoter_db
+spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.flyway.enabled=false
+core.service.base-url=http://localhost:9999


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa la creación de folios con idempotencia (SPEC-002) siguiendo arquitectura hexagonal y TDD.

## Cambios principales

### Feature
- **POST /v1/folios** — crea folio nuevo (201) o retorna existente (200) para misma combinación subscriber+agent
- Validación de referencias contra core service (subscriber, agent)
- Generación de folio number vía core service

### QA fixes (post code review)
-  en  + índice único parcial `uq_quotes_active_folio` — previene race condition en idempotencia
- `CoreServiceClientAdapter` maneja 4xx/5xx del core con `CoreServiceException` controlada
- `GlobalExceptionHandler` con handler 502 para core errors y 500 fallback
- `@Component` añadido a adapters y mappers faltantes
- Clase main movida a paquete raíz `com.sofka.insurancequoter` (fix crítico de component scan)

### Tests
- 21 tests unitarios (TDD)
- 4 tests de integración con Testcontainers + WireMock

## Criterios de aceptación cubiertos
- [x] CRITERIO-1.1: folio nuevo → 201
- [x] CRITERIO-1.2: misma combinación → 200 idempotente
- [x] CRITERIO-1.3: subscriber/agent inválido → 400
- [x] CRITERIO-1.4: campos faltantes → 422
- [x] CRITERIO-1.5: folio IN_PROGRESS no bloquea nueva creación

## Issues cerrados
Closes #39 #40 #41 #42 #43 #44