### PR TITLE
feat(SPEC-003): location layout configuration

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -2,3 +2,4 @@
 
 - [folio-generator feature — implementation state](project_folio_feature.md) — SPEC-001 implementado, compila. Estructura de paquetes, decisiones de diseño y archivos clave.
 - [Insurance-Quoter-Core — setup y configuración base](project_core_setup.md) — Paquete base, puerto, DB, dependencias reales del proyecto core.
+- [location-layout feature — implementation state](project_location_layout_feature.md) — SPEC-003 implementado. Decisiones de diseño: optimistic lock manual, sin @Transactional en integration test, GlobalExceptionHandler ampliado.

--- a/.claude/agent-memory/backend-developer/project_location_layout_feature.md
+++ b/.claude/agent-memory/backend-developer/project_location_layout_feature.md
@@ -1,0 +1,44 @@
+---
+name: location-layout feature — implementation state
+description: SPEC-003 implementado y en verde. Decisiones de diseño clave del bounded context location.
+type: project
+---
+
+SPEC-003 (location-layout) implementado completamente. Suite completa verde.
+
+**Why:** Feature que permite configurar el layout de ubicaciones por cotización (numberOfLocations, locationType), sincronizando la tabla `locations` sin borrar filas.
+
+**How to apply:** Consultar este registro al retomar trabajo relacionado con ubicaciones o al implementar SPEC-004+.
+
+## Decisiones críticas de implementación
+
+### Optimistic lock check manual en QuoteLayoutJpaAdapter
+`QuoteLayoutJpaAdapter.save()` compara explícitamente `jpa.getVersion().equals(data.version())` antes de mutar la entidad y lanza `ObjectOptimisticLockingFailureException` manualmente si no coinciden.
+
+**Motivo:** Hibernate ignora `setVersion()` en entidades managed — al cargar la entidad con `findById()` dentro de la misma sesión, el campo `@Version` queda bajo control de Hibernate y no puede ser sobreescrito para forzar el chequeo. La comparación manual es el único mecanismo confiable en este patrón sin transacciones anidadas.
+
+### Test de integración sin @Transactional
+`SaveLocationLayoutIntegrationTest` no usa `@Transactional` a nivel de clase. La limpieza se hace en `@BeforeEach` con `deleteAll()` (locations primero por FK, luego quotes).
+
+**Motivo:** Con `@Transactional` todo el test corre en una sola transacción — los commits intermedios no ocurren y el chequeo de versión nunca se dispara, haciendo que el test 409 siempre pase como 200.
+
+### LocationJpaAdapter.saveAll() — bifurcación insert vs deactivate
+- Si todas las `Location` tienen `active=true` → bulk insert vía `saveAll`.
+- Si alguna tiene `active=false` → deactivation path: busca por `findByQuoteIdAndIndexGreaterThan(quoteId, minIndex-1)` y hace `save()` individual por fila (para respetar el `@UpdateTimestamp`).
+
+### GlobalExceptionHandler ampliado
+Se agregaron handlers para:
+- `FolioNotFoundException` → 404
+- `ObjectOptimisticLockingFailureException` + `OptimisticLockingFailureException` → 409
+- `IllegalArgumentException` → 422 (regla SINGLE con numberOfLocations != 1)
+
+### QuoteJpaRepository.findByFolioNumber
+Se agregó este método a `QuoteJpaRepository` existente (bounded context folio) para ser reutilizado por `QuoteLayoutJpaAdapter` sin duplicar el repositorio.
+
+## Archivos clave creados/modificados
+
+- `V3__add_layout_columns_to_quotes.sql` — columnas `number_of_locations`, `location_type` en `quotes`
+- `V4__create_locations_table.sql` — tabla `locations` con FK, UNIQUE y índice
+- `QuoteJpa` — campos `numberOfLocations`, `locationType` agregados
+- `back.location` — bounded context completo (domain, application, infrastructure)
+- `GlobalExceptionHandler` — handlers 404, 409, 422 nuevos

--- a/.claude/specs/location-layout.spec.md
+++ b/.claude/specs/location-layout.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-003
-status: DRAFT
+status: IMPLEMENTED
 feature: location-layout
 created: 2026-04-21
 updated: 2026-04-21

--- a/.claude/specs/location-layout.spec.md
+++ b/.claude/specs/location-layout.spec.md
@@ -1,0 +1,360 @@
+---
+id: SPEC-003
+status: DRAFT
+feature: location-layout
+created: 2026-04-21
+updated: 2026-04-21
+author: spec-generator
+version: "1.0"
+related-specs: ["SPEC-002"]
+---
+
+# Spec: Configuración de Layout de Ubicaciones
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+Permite consultar y configurar el layout de ubicaciones de una cotización (cuántas ubicaciones y de qué tipo). Al guardar, el sistema sincroniza la colección de `LocationJpa` sin eliminar datos: agrega entradas vacías si `numberOfLocations` aumenta, o marca las excedentes como inactivas si disminuye.
+
+### Requerimiento de Negocio
+El usuario necesita definir cuántas ubicaciones (locations) tendrá su cotización y de qué tipo (`SINGLE` / `MULTIPLE`) antes de capturar el detalle de cada una. El sistema debe preservar datos ya ingresados al ajustar la cantidad.
+
+### Historias de Usuario
+
+#### HU-01: Consultar layout de ubicaciones
+
+```
+Como:        Agente de seguros
+Quiero:      Consultar la configuración de layout de ubicaciones de una cotización
+Para:        Saber cuántas ubicaciones hay configuradas y de qué tipo antes de editarlas
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: SPEC-002 (folio existente)
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Obtener layout de cotización con layout configurado
+  Dado que:  existe la cotización con folio "FOL-2026-00042" con layoutConfiguration establecido
+  Cuando:    el cliente hace GET /v1/quotes/FOL-2026-00042/locations/layout
+  Entonces:  retorna HTTP 200 con folioNumber, layoutConfiguration (numberOfLocations, locationType) y version
+```
+
+**Error Path**
+```gherkin
+CRITERIO-1.2: Folio inexistente retorna 404
+  Dado que:  no existe cotización con folio "FOL-9999-99999"
+  Cuando:    el cliente hace GET /v1/quotes/FOL-9999-99999/locations/layout
+  Entonces:  retorna HTTP 404 con { "error": "Folio not found", "code": "FOLIO_NOT_FOUND" }
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-1.3: Cotización sin layout configurado retorna valores nulos
+  Dado que:  existe la cotización "FOL-2026-00042" recién creada sin layoutConfiguration
+  Cuando:    el cliente hace GET /v1/quotes/FOL-2026-00042/locations/layout
+  Entonces:  retorna HTTP 200 con layoutConfiguration: { numberOfLocations: null, locationType: null }
+```
+
+---
+
+#### HU-02: Guardar layout de ubicaciones
+
+```
+Como:        Agente de seguros
+Quiero:      Definir o actualizar el número y tipo de ubicaciones de una cotización
+Para:        Que el sistema prepare la estructura de ubicaciones correspondiente
+
+Prioridad:   Alta
+Estimación:  M
+Dependencias: HU-01
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-02
+
+**Happy Path**
+```gherkin
+CRITERIO-2.1: Guardar layout por primera vez crea las ubicaciones vacías
+  Dado que:  existe la cotización "FOL-2026-00042" sin ubicaciones, con version 1
+  Cuando:    el cliente hace PUT /v1/quotes/FOL-2026-00042/locations/layout
+             con { layoutConfiguration: { numberOfLocations: 3, locationType: "MULTIPLE" }, version: 1 }
+  Entonces:  retorna HTTP 200 con layoutConfiguration actualizado y version 2
+             Y existen 3 registros en la tabla locations asociados al folio, todos con active: true
+```
+
+**Happy Path**
+```gherkin
+CRITERIO-2.2: Aumentar numberOfLocations agrega ubicaciones vacías
+  Dado que:  existe la cotización "FOL-2026-00042" con 2 ubicaciones activas, version 3
+  Cuando:    el cliente hace PUT con numberOfLocations: 4, version: 3
+  Entonces:  retorna HTTP 200 con version 4
+             Y existen 4 ubicaciones activas: las 2 originales con sus datos y 2 nuevas vacías
+```
+
+**Happy Path**
+```gherkin
+CRITERIO-2.3: Reducir numberOfLocations marca excedentes como inactivas
+  Dado que:  existe la cotización con 4 ubicaciones activas, version 4
+  Cuando:    el cliente hace PUT con numberOfLocations: 2, version: 4
+  Entonces:  retorna HTTP 200 con version 5
+             Y las ubicaciones con índice 1 y 2 siguen activas
+             Y las ubicaciones con índice 3 y 4 quedan con active: false (no se eliminan)
+```
+
+**Error Path**
+```gherkin
+CRITERIO-2.4: Conflicto de versión retorna 409
+  Dado que:  existe la cotización con version 3 real
+  Cuando:    el cliente envía PUT con version: 2 (desactualizada)
+  Entonces:  retorna HTTP 409 con { "error": "Optimistic lock conflict", "code": "VERSION_CONFLICT" }
+```
+
+**Error Path**
+```gherkin
+CRITERIO-2.5: Folio inexistente retorna 404
+  Dado que:  no existe la cotización "FOL-9999-99999"
+  Cuando:    el cliente hace PUT /v1/quotes/FOL-9999-99999/locations/layout
+  Entonces:  retorna HTTP 404 con { "error": "Folio not found", "code": "FOLIO_NOT_FOUND" }
+```
+
+**Error Path**
+```gherkin
+CRITERIO-2.6: numberOfLocations menor a 1 retorna 422
+  Dado que:  existe la cotización con version 1
+  Cuando:    el cliente envía PUT con numberOfLocations: 0
+  Entonces:  retorna HTTP 422 con { "error": "Validation failed", "code": "VALIDATION_ERROR" }
+```
+
+### Reglas de Negocio
+
+1. `numberOfLocations` debe ser ≥ 1 y ≤ 50.
+2. `locationType` acepta solo los valores `SINGLE` o `MULTIPLE`. Si `locationType` es `SINGLE`, `numberOfLocations` debe ser exactamente 1.
+3. Al aumentar `numberOfLocations`: se insertan `(nuevo - actual)` registros `LocationJpa` vacíos con `active: true` e `index` secuencial.
+4. Al reducir `numberOfLocations`: las ubicaciones con `index > numberOfLocations` se marcan `active: false`. **Nunca se eliminan filas**.
+5. El versionado optimista (`@Version`) aplica sobre `QuoteJpa`. Si hay conflicto, retorna 409.
+6. El campo `layout_configuration` se almacena en `QuoteJpa` como columnas separadas (`number_of_locations`, `location_type`), no como JSONB, para facilitar queries futuras.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Tabla | Cambios | Descripción |
+|---------|-------|---------|-------------|
+| `QuoteJpa` | `quotes` | Agregar columnas `number_of_locations`, `location_type` | Almacena configuración de layout |
+| `LocationJpa` | `locations` | **Nueva** | Una fila por ubicación dentro de la cotización |
+
+#### Campos nuevos en QuoteJpa
+
+| Campo Java | Columna DB | Tipo SQL | Obligatorio | Descripción |
+|------------|-----------|----------|-------------|-------------|
+| `numberOfLocations` | `number_of_locations` | `INTEGER` | no (null = sin configurar) | Cantidad total de ubicaciones |
+| `locationType` | `location_type` | `VARCHAR(10)` | no (null = sin configurar) | `SINGLE` o `MULTIPLE` |
+
+#### Entidad LocationJpa (nueva)
+
+| Campo Java | Columna DB | Tipo SQL | Obligatorio | Descripción |
+|------------|-----------|----------|-------------|-------------|
+| `id` | `id` | `BIGSERIAL PK` | sí | Identificador interno |
+| `quoteId` | `quote_id` | `BIGINT FK → quotes.id` | sí | Cotización propietaria |
+| `index` | `index` | `INTEGER` | sí | Índice 1-based de la ubicación |
+| `active` | `active` | `BOOLEAN` | sí | false = marcada como inactiva al reducir numberOfLocations |
+| `locationName` | `location_name` | `VARCHAR(255)` | no | Nombre de la ubicación (llenado en fase posterior) |
+| `createdAt` | `created_at` | `TIMESTAMP WITH TIME ZONE` | sí | Auto-generado |
+| `updatedAt` | `updated_at` | `TIMESTAMP WITH TIME ZONE` | sí | Auto-actualizado |
+
+#### Índices / Constraints
+
+- `UK_locations_quote_index`: UNIQUE(`quote_id`, `index`) — evita índices duplicados por cotización.
+- `IDX_locations_quote_id`: índice en `quote_id` — búsquedas frecuentes de todas las ubicaciones del folio.
+
+#### Migraciones Flyway
+
+- `V3__add_layout_columns_to_quotes.sql` — agrega `number_of_locations` y `location_type` a `quotes`.
+- `V4__create_locations_table.sql` — crea tabla `locations` con FK, índices y constraint.
+
+---
+
+### API Endpoints
+
+#### GET /v1/quotes/{folio}/locations/layout
+
+- **Descripción**: Retorna la configuración de layout de ubicaciones de la cotización.
+- **Path param**: `folio` — número de folio (ej. `FOL-2026-00042`)
+- **Auth requerida**: no
+- **Response 200**:
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "layoutConfiguration": {
+      "numberOfLocations": 3,
+      "locationType": "MULTIPLE"
+    },
+    "version": 3
+  }
+  ```
+- **Response 404**: `{ "error": "Folio not found", "code": "FOLIO_NOT_FOUND" }`
+
+#### PUT /v1/quotes/{folio}/locations/layout
+
+- **Descripción**: Define o actualiza el layout de ubicaciones. Sincroniza la colección `LocationJpa`.
+- **Path param**: `folio` — número de folio
+- **Auth requerida**: no
+- **Request Body**:
+  ```json
+  {
+    "layoutConfiguration": {
+      "numberOfLocations": 3,
+      "locationType": "MULTIPLE"
+    },
+    "version": 3
+  }
+  ```
+- **Response 200**:
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "layoutConfiguration": {
+      "numberOfLocations": 3,
+      "locationType": "MULTIPLE"
+    },
+    "updatedAt": "2026-04-21T15:20:00Z",
+    "version": 4
+  }
+  ```
+- **Response 404**: `{ "error": "Folio not found", "code": "FOLIO_NOT_FOUND" }`
+- **Response 409**: `{ "error": "Optimistic lock conflict", "code": "VERSION_CONFLICT" }`
+- **Response 422**: `{ "error": "Validation failed", "code": "VALIDATION_ERROR", "fields": [...] }`
+
+---
+
+### Arquitectura y Dependencias
+
+El feature vive en el bounded context `location` dentro de `plataforma-danos-back`. Se crea un nuevo context separado del context `folio` existente para mantener la separación de responsabilidades.
+
+#### Estructura de paquetes nueva
+
+```
+com.sofka.insurancequoter.back.location/
+├── domain/
+│   ├── model/
+│   │   ├── LayoutConfiguration.java      ← Value Object (numberOfLocations, locationType)
+│   │   ├── Location.java                 ← Domain model (index, active)
+│   │   └── LocationType.java             ← Enum: SINGLE, MULTIPLE
+│   └── port/
+│       ├── in/
+│       │   ├── GetLocationLayoutUseCase.java
+│       │   └── SaveLocationLayoutUseCase.java
+│       └── out/
+│           ├── QuoteLayoutRepository.java  ← findByFolio, saveLayout
+│           └── LocationRepository.java     ← findByQuoteId, saveAll
+├── application/
+│   └── usecase/
+│       ├── GetLocationLayoutUseCaseImpl.java
+│       └── SaveLocationLayoutUseCaseImpl.java
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/rest/
+    │   │   ├── LocationLayoutController.java
+    │   │   ├── swaggerdocs/LocationLayoutApi.java
+    │   │   ├── dto/
+    │   │   │   ├── LayoutConfigurationDto.java
+    │   │   │   ├── GetLayoutResponse.java
+    │   │   │   ├── SaveLayoutRequest.java
+    │   │   │   └── SaveLayoutResponse.java
+    │   │   └── mapper/LocationLayoutRestMapper.java
+    │   └── out/persistence/
+    │       ├── adapter/
+    │       │   ├── QuoteLayoutJpaAdapter.java   ← implementa QuoteLayoutRepository
+    │       │   └── LocationJpaAdapter.java      ← implementa LocationRepository
+    │       ├── entities/
+    │       │   └── LocationJpa.java
+    │       ├── mappers/
+    │       │   └── LocationPersistenceMapper.java
+    │       └── repositories/
+    │           ├── QuoteJpaRepository.java      ← ya existe, reusar
+    │           └── LocationJpaRepository.java   ← nueva
+    └── config/
+        └── LocationLayoutConfig.java
+```
+
+#### Notas de implementación
+
+- `QuoteJpa` ya existe en el context `folio`. Se debe agregar los campos `numberOfLocations` y `locationType` a esa clase y migrar con Flyway V3.
+- `QuoteJpaRepository` ya existe — `QuoteLayoutJpaAdapter` puede inyectarlo o se puede crear un segundo adaptador que use el mismo `JpaRepository` (opción recomendada para no contaminar el context `folio`).
+- La lógica de sincronización (agregar / desactivar ubicaciones) vive en `SaveLocationLayoutUseCaseImpl`, no en el adaptador de persistencia.
+- `@Transactional` en `SaveLocationLayoutUseCaseImpl` para garantizar atomicidad entre el update de `QuoteJpa` y los inserts/updates de `LocationJpa`.
+- Captura `ObjectOptimisticLockingFailureException` de Spring Data y la convierte en respuesta 409 en `GlobalExceptionHandler`.
+
+---
+
+## 3. LISTA DE TAREAS
+
+### Backend
+
+#### Modelo de Datos
+- [ ] Crear migración `V3__add_layout_columns_to_quotes.sql` — columnas `number_of_locations`, `location_type` en `quotes`
+- [ ] Crear migración `V4__create_locations_table.sql` — tabla `locations` con FK, constraint único y índices
+- [ ] Agregar campos `numberOfLocations` y `locationType` a `QuoteJpa`
+- [ ] Crear entidad `LocationJpa` con todos los campos definidos en el diseño
+
+#### Domain
+- [ ] Crear Value Object `LayoutConfiguration` (record: numberOfLocations, locationType)
+- [ ] Crear enum `LocationType` (SINGLE, MULTIPLE)
+- [ ] Crear domain model `Location` (record: index, active)
+- [ ] Crear input port `GetLocationLayoutUseCase`
+- [ ] Crear input port `SaveLocationLayoutUseCase`
+- [ ] Crear output port `QuoteLayoutRepository` (findByFolioNumber, saveLayout)
+- [ ] Crear output port `LocationRepository` (findActiveByQuoteId, saveAll)
+
+#### Application
+- [ ] Implementar `GetLocationLayoutUseCaseImpl` — busca QuoteJpa y mapea layoutConfiguration
+- [ ] Implementar `SaveLocationLayoutUseCaseImpl` con lógica de sincronización:
+  - Leer cuántas ubicaciones activas hay actualmente
+  - Si nuevo > actual: insertar (nuevo - actual) LocationJpa vacíos con active=true
+  - Si nuevo < actual: marcar LocationJpa con index > nuevo como active=false
+  - Si igual: solo actualizar numberOfLocations y locationType en QuoteJpa
+  - Guardar QuoteJpa (dispara @Version check)
+
+#### Infrastructure
+- [ ] Crear `LocationJpaRepository` extendiendo `JpaRepository<LocationJpa, Long>`
+  - Método: `List<LocationJpa> findByQuoteIdAndActiveTrue(Long quoteId)`
+  - Método: `List<LocationJpa> findByQuoteId(Long quoteId)`
+- [ ] Crear `QuoteLayoutJpaAdapter` implementando `QuoteLayoutRepository`
+- [ ] Crear `LocationJpaAdapter` implementando `LocationRepository`
+- [ ] Crear `LocationPersistenceMapper`
+- [ ] Crear DTOs: `LayoutConfigurationDto`, `GetLayoutResponse`, `SaveLayoutRequest`, `SaveLayoutResponse`
+- [ ] Crear `LocationLayoutRestMapper`
+- [ ] Crear `LocationLayoutApi` (interfaz Swagger en `swaggerdocs/`)
+- [ ] Crear `LocationLayoutController` implementando `LocationLayoutApi`
+- [ ] Crear `LocationLayoutConfig` — wiring de use cases con sus puertos
+- [ ] Registrar `ObjectOptimisticLockingFailureException` en `GlobalExceptionHandler` → 409
+
+#### Tests Backend (TDD — test antes de implementar)
+- [ ] `GetLocationLayoutUseCaseImplTest` — happy path, folio not found
+- [ ] `SaveLocationLayoutUseCaseImplTest` — primera vez, aumentar, reducir, igual, version conflict
+- [ ] `LocationLayoutControllerTest` — GET 200, GET 404, PUT 200, PUT 404, PUT 409, PUT 422
+- [ ] `LocationLayoutRestMapperTest` — mapeo request→command, result→response
+- [ ] `LocationJpaAdapterTest` — findActive, saveAll
+- [ ] `QuoteLayoutJpaAdapterTest` — findByFolioNumber, saveLayout
+- [ ] `LocationPersistenceMapperTest` — domain→jpa, jpa→domain
+- [ ] `SaveLocationLayoutIntegrationTest` — test de integración con Testcontainers: escenarios 2.1, 2.2, 2.3, 2.4
+
+### QA
+- [ ] Ejecutar skill `/gherkin-case-generator` → criterios CRITERIO-1.1 al 2.6
+- [ ] Ejecutar skill `/risk-identifier` → clasificación ASD de riesgos
+- [ ] Validar todos los criterios de aceptación contra la implementación
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=insurance_quoter_db
+DB_USERNAME=change_me
+DB_PASSWORD=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment secrets ###
+.env
+*.env
+!.env.example

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,8 +2,8 @@ services:
   postgres:
     image: 'postgres:16'
     environment:
-      - 'POSTGRES_DB=insurance_quoter_db'
-      - 'POSTGRES_PASSWORD=secret'
-      - 'POSTGRES_USER=myuser'
+      - 'POSTGRES_DB=${DB_NAME}'
+      - 'POSTGRES_USER=${DB_USERNAME}'
+      - 'POSTGRES_PASSWORD=${DB_PASSWORD}'
     ports:
       - '5432:5432'

--- a/docs/output/qa/location-layout-gherkin.md
+++ b/docs/output/qa/location-layout-gherkin.md
@@ -1,0 +1,256 @@
+# Gherkin — SPEC-003: Configuración de Layout de Ubicaciones
+
+**Spec:** `.claude/specs/location-layout.spec.md`
+**Generado:** 2026-04-21
+**Cobertura:** CRITERIO-1.1 al CRITERIO-2.6 + edge cases de reglas de negocio
+
+---
+
+## Datos de Prueba
+
+| Escenario | Campo | Valor válido | Valor inválido | Valor borde |
+|-----------|-------|-------------|----------------|-------------|
+| Folio existente | `folioNumber` | `FOL-2026-00042` | `FOL-9999-99999` | — |
+| Folio sin layout | `folioNumber` | `FOL-2026-00099` | — | — |
+| Número de ubicaciones | `numberOfLocations` | `3` | `0`, `-1` | `1`, `50` |
+| Número de ubicaciones | `numberOfLocations` | `3` | `51` | `50` |
+| Tipo de ubicación | `locationType` | `MULTIPLE`, `SINGLE` | `OTRO`, `""` | — |
+| SINGLE + cantidad | `locationType` + `numberOfLocations` | `SINGLE` + `1` | `SINGLE` + `3` | — |
+| Versión | `version` | `3` (actual) | `2` (desactualizada) | — |
+
+---
+
+```gherkin
+#language: es
+Característica: Configuración de layout de ubicaciones de una cotización
+  Como agente de seguros
+  Quiero consultar y definir el número y tipo de ubicaciones de una cotización
+  Para que el sistema prepare la estructura de ubicaciones antes de capturar su detalle
+
+  Antecedentes:
+    Dado que el sistema está en funcionamiento
+    Y la base de datos está disponible
+
+  # ===========================================================================
+  # HU-01: Consultar layout de ubicaciones
+  # ===========================================================================
+
+  @smoke @critico
+  Escenario: CRITERIO-1.1 — Obtener layout de cotización con configuración existente
+    Dado que existe la cotización con folio "FOL-2026-00042"
+    Y dicha cotización tiene configuradas 3 ubicaciones de tipo "MULTIPLE"
+    Y la cotización está en la versión 3
+    Cuando el agente consulta el layout de ubicaciones del folio "FOL-2026-00042"
+    Entonces el sistema responde con código 200
+    Y la respuesta incluye el folio "FOL-2026-00042"
+    Y la respuesta incluye "numberOfLocations" igual a 3
+    Y la respuesta incluye "locationType" igual a "MULTIPLE"
+    Y la respuesta incluye "version" igual a 3
+
+  @regression
+  Escenario: CRITERIO-1.2 — Consulta de folio inexistente retorna 404
+    Dado que no existe ninguna cotización con folio "FOL-9999-99999"
+    Cuando el agente consulta el layout de ubicaciones del folio "FOL-9999-99999"
+    Entonces el sistema responde con código 404
+    Y la respuesta contiene el error "Folio not found"
+    Y la respuesta contiene el código de error "FOLIO_NOT_FOUND"
+
+  @regression
+  Escenario: CRITERIO-1.3 — Cotización recién creada devuelve layout con valores nulos
+    Dado que existe la cotización con folio "FOL-2026-00099" recién creada
+    Y dicha cotización no tiene configuración de layout
+    Cuando el agente consulta el layout de ubicaciones del folio "FOL-2026-00099"
+    Entonces el sistema responde con código 200
+    Y la respuesta incluye el folio "FOL-2026-00099"
+    Y la respuesta incluye "numberOfLocations" con valor nulo
+    Y la respuesta incluye "locationType" con valor nulo
+
+  # ===========================================================================
+  # HU-02: Guardar layout de ubicaciones
+  # ===========================================================================
+
+  @smoke @critico
+  Escenario: CRITERIO-2.1 — Guardar layout por primera vez crea las ubicaciones vacías
+    Dado que existe la cotización con folio "FOL-2026-00042" sin ubicaciones configuradas
+    Y la cotización está en la versión 1
+    Cuando el agente guarda el layout con 3 ubicaciones de tipo "MULTIPLE" indicando versión 1
+    Entonces el sistema responde con código 200
+    Y la respuesta incluye "numberOfLocations" igual a 3
+    Y la respuesta incluye "locationType" igual a "MULTIPLE"
+    Y la respuesta incluye "version" igual a 2
+    Y existen exactamente 3 ubicaciones activas asociadas al folio "FOL-2026-00042"
+    Y cada ubicación tiene los índices 1, 2 y 3 respectivamente
+    Y todas las ubicaciones tienen el campo activo en verdadero
+
+  @smoke @critico
+  Escenario: CRITERIO-2.2 — Aumentar numberOfLocations agrega ubicaciones vacías
+    Dado que existe la cotización con folio "FOL-2026-00042" con 2 ubicaciones activas ya rellenas
+    Y la cotización está en la versión 3
+    Cuando el agente actualiza el layout a 4 ubicaciones de tipo "MULTIPLE" indicando versión 3
+    Entonces el sistema responde con código 200
+    Y la respuesta incluye "version" igual a 4
+    Y existen exactamente 4 ubicaciones activas asociadas al folio "FOL-2026-00042"
+    Y las 2 ubicaciones originales conservan sus datos previos
+    Y las 2 ubicaciones nuevas tienen los campos de detalle vacíos
+
+  @smoke @critico
+  Escenario: CRITERIO-2.3 — Reducir numberOfLocations marca excedentes como inactivas
+    Dado que existe la cotización con folio "FOL-2026-00042" con 4 ubicaciones activas
+    Y la cotización está en la versión 4
+    Cuando el agente actualiza el layout a 2 ubicaciones de tipo "MULTIPLE" indicando versión 4
+    Entonces el sistema responde con código 200
+    Y la respuesta incluye "version" igual a 5
+    Y las ubicaciones con índice 1 y 2 permanecen activas
+    Y las ubicaciones con índice 3 y 4 quedan marcadas como inactivas
+    Y en la base de datos existen 4 registros (ninguno fue eliminado)
+
+  @regression
+  Escenario: CRITERIO-2.4 — Conflicto de versión retorna 409
+    Dado que existe la cotización con folio "FOL-2026-00042" en la versión 3
+    Cuando el agente intenta guardar el layout con 2 ubicaciones indicando versión 2
+    Entonces el sistema responde con código 409
+    Y la respuesta contiene el error "Optimistic lock conflict"
+    Y la respuesta contiene el código de error "VERSION_CONFLICT"
+    Y el layout de la cotización no fue modificado
+
+  @regression
+  Escenario: CRITERIO-2.5 — Guardar layout en folio inexistente retorna 404
+    Dado que no existe ninguna cotización con folio "FOL-9999-99999"
+    Cuando el agente intenta guardar el layout con 2 ubicaciones para el folio "FOL-9999-99999"
+    Entonces el sistema responde con código 404
+    Y la respuesta contiene el error "Folio not found"
+    Y la respuesta contiene el código de error "FOLIO_NOT_FOUND"
+
+  @regression
+  Escenario: CRITERIO-2.6 — numberOfLocations igual a cero retorna 422
+    Dado que existe la cotización con folio "FOL-2026-00042" en la versión 1
+    Cuando el agente intenta guardar el layout con 0 ubicaciones indicando versión 1
+    Entonces el sistema responde con código 422
+    Y la respuesta contiene el error "Validation failed"
+    Y la respuesta contiene el código de error "VALIDATION_ERROR"
+    Y la respuesta incluye el campo "fields" con los errores de validación
+
+  # ===========================================================================
+  # Edge Cases — Reglas de Negocio adicionales
+  # ===========================================================================
+
+  @regression
+  Escenario: RN-1 — numberOfLocations negativo retorna 422
+    Dado que existe la cotización con folio "FOL-2026-00042" en la versión 1
+    Cuando el agente intenta guardar el layout con -1 ubicaciones indicando versión 1
+    Entonces el sistema responde con código 422
+    Y la respuesta contiene el código de error "VALIDATION_ERROR"
+
+  @regression
+  Escenario: RN-1 — numberOfLocations mayor a 50 retorna 422
+    Dado que existe la cotización con folio "FOL-2026-00042" en la versión 1
+    Cuando el agente intenta guardar el layout con 51 ubicaciones indicando versión 1
+    Entonces el sistema responde con código 422
+    Y la respuesta contiene el código de error "VALIDATION_ERROR"
+
+  @smoke @critico
+  Escenario: RN-1 — numberOfLocations igual a 50 (límite superior válido) es aceptado
+    Dado que existe la cotización con folio "FOL-2026-00042" sin ubicaciones configuradas
+    Y la cotización está en la versión 1
+    Cuando el agente guarda el layout con 50 ubicaciones de tipo "MULTIPLE" indicando versión 1
+    Entonces el sistema responde con código 200
+    Y existen exactamente 50 ubicaciones activas asociadas al folio "FOL-2026-00042"
+
+  @regression
+  Escenario: RN-2 — locationType inválido retorna 422
+    Dado que existe la cotización con folio "FOL-2026-00042" en la versión 1
+    Cuando el agente intenta guardar el layout con tipo "PARCIAL" y 2 ubicaciones indicando versión 1
+    Entonces el sistema responde con código 422
+    Y la respuesta contiene el código de error "VALIDATION_ERROR"
+
+  @regression
+  Escenario: RN-2 — locationType SINGLE con numberOfLocations mayor a 1 retorna 422
+    Dado que existe la cotización con folio "FOL-2026-00042" en la versión 1
+    Cuando el agente intenta guardar el layout con tipo "SINGLE" y 3 ubicaciones indicando versión 1
+    Entonces el sistema responde con código 422
+    Y la respuesta contiene el código de error "VALIDATION_ERROR"
+    Y la respuesta indica que SINGLE solo admite una ubicación
+
+  @smoke @critico
+  Escenario: RN-2 — locationType SINGLE con numberOfLocations igual a 1 es aceptado
+    Dado que existe la cotización con folio "FOL-2026-00042" sin ubicaciones configuradas
+    Y la cotización está en la versión 1
+    Cuando el agente guarda el layout con 1 ubicación de tipo "SINGLE" indicando versión 1
+    Entonces el sistema responde con código 200
+    Y existen exactamente 1 ubicación activa asociada al folio "FOL-2026-00042"
+    Y la respuesta incluye "locationType" igual a "SINGLE"
+
+  @regression
+  Escenario: RN-3 — Actualizar layout con mismo numberOfLocations solo actualiza locationType
+    Dado que existe la cotización con folio "FOL-2026-00042" con 2 ubicaciones activas tipo "SINGLE"
+    Y la cotización está en la versión 2
+    Cuando el agente actualiza el layout a 2 ubicaciones de tipo "MULTIPLE" indicando versión 2
+    Entonces el sistema responde con código 200
+    Y la respuesta incluye "version" igual a 3
+    Y existen exactamente 2 ubicaciones activas asociadas al folio (sin nuevas inserciones)
+    Y la respuesta incluye "locationType" igual a "MULTIPLE"
+
+  @regression
+  Escenario: RN-4 — Reducir y luego aumentar numberOfLocations reactiva nuevas ubicaciones (no reactiva las inactivas)
+    Dado que existe la cotización con folio "FOL-2026-00042" con 4 ubicaciones activas
+    Y la cotización está en la versión 4
+    Y el agente ya redujo el layout a 2 ubicaciones (índices 3 y 4 inactivos) y la versión quedó en 5
+    Cuando el agente aumenta el layout a 3 ubicaciones indicando versión 5
+    Entonces el sistema responde con código 200
+    Y existe 1 nueva ubicación vacía con índice 5
+    Y las ubicaciones con índice 3 y 4 permanecen inactivas
+    Y existen en total 5 registros en la tabla locations para dicho folio
+
+  @regression
+  Escenario: RN-4 — Las filas de ubicaciones nunca se eliminan físicamente
+    Dado que existe la cotización con folio "FOL-2026-00042" con 3 ubicaciones activas
+    Y la cotización está en la versión 2
+    Cuando el agente reduce el layout a 1 ubicación indicando versión 2
+    Entonces el sistema responde con código 200
+    Y en la base de datos existen 3 registros de ubicaciones para dicho folio
+    Y solo 1 de los registros tiene el campo activo en verdadero
+    Y 2 registros tienen el campo activo en falso
+
+  @regression
+  Esquema del escenario: Validar límites del campo numberOfLocations
+    Dado que existe la cotización con folio "FOL-2026-00042" en la versión 1
+    Cuando el agente intenta guardar el layout con <cantidad> ubicaciones de tipo "MULTIPLE"
+    Entonces el sistema responde con código <codigoHttp>
+
+    Ejemplos:
+      | cantidad | codigoHttp |
+      | -1       | 422        |
+      | 0        | 422        |
+      | 1        | 200        |
+      | 50       | 200        |
+      | 51       | 422        |
+      | 100      | 422        |
+```
+
+---
+
+## Resumen de cobertura
+
+| Criterio | Escenario Gherkin | Tags |
+|----------|------------------|------|
+| CRITERIO-1.1 | Obtener layout con configuración existente | `@smoke @critico` |
+| CRITERIO-1.2 | Consulta folio inexistente → 404 | `@regression` |
+| CRITERIO-1.3 | Cotización sin layout → valores nulos | `@regression` |
+| CRITERIO-2.1 | Guardar layout primera vez crea ubicaciones | `@smoke @critico` |
+| CRITERIO-2.2 | Aumentar numberOfLocations agrega ubicaciones | `@smoke @critico` |
+| CRITERIO-2.3 | Reducir numberOfLocations marca inactivas | `@smoke @critico` |
+| CRITERIO-2.4 | Conflicto de versión → 409 | `@regression` |
+| CRITERIO-2.5 | Folio inexistente en PUT → 404 | `@regression` |
+| CRITERIO-2.6 | numberOfLocations = 0 → 422 | `@regression` |
+| RN-1 | numberOfLocations negativo → 422 | `@regression` |
+| RN-1 | numberOfLocations > 50 → 422 | `@regression` |
+| RN-1 | numberOfLocations = 50 (límite válido) → 200 | `@smoke @critico` |
+| RN-2 | locationType inválido → 422 | `@regression` |
+| RN-2 | SINGLE + numberOfLocations > 1 → 422 | `@regression` |
+| RN-2 | SINGLE + numberOfLocations = 1 → 200 | `@smoke @critico` |
+| RN-3 | Misma cantidad → solo actualiza locationType | `@regression` |
+| RN-4 | Aumentar tras reducir inserta nuevas, no reactiva | `@regression` |
+| RN-4 | Nunca se eliminan filas físicas | `@regression` |
+| RN-1 (esquema) | Límites tabulados 6 casos | `@regression` |
+
+**Total escenarios:** 19 (6 `@smoke @critico` + 13 `@regression`)

--- a/docs/output/qa/location-layout-risks.md
+++ b/docs/output/qa/location-layout-risks.md
@@ -1,0 +1,122 @@
+# Matriz de Riesgos — SPEC-003: Configuración de Layout de Ubicaciones
+
+**Feature:** `location-layout`
+**Spec:** `.claude/specs/location-layout.spec.md`
+**Fecha de análisis:** 2026-04-21
+**Analista:** risk-identifier (ASD Rule)
+
+---
+
+## Resumen Ejecutivo
+
+| Nivel | Cantidad | Acción requerida |
+|-------|----------|------------------|
+| **Alto (A)** | 5 | Testing OBLIGATORIO — bloquea release |
+| **Medio (S)** | 4 | Testing RECOMENDADO — documentar si se omite |
+| **Bajo (D)** | 2 | Testing OPCIONAL — priorizar en backlog |
+| **Total** | **11** | |
+
+---
+
+## Detalle de Riesgos
+
+| ID | HU | Descripción del Riesgo | Factores ASD | Nivel | Testing |
+|----|-----|------------------------|--------------|-------|---------|
+| R-001 | HU-02 | La lógica de sincronización de ubicaciones (aumentar / reducir / igual) aplica transformaciones sobre colecciones persistidas. Un error en la lógica puede corromper datos de cotizaciones existentes o duplicar ubicaciones. | Lógica de negocio compleja con múltiples ramas + operación irreversible (datos ya capturados en ubicaciones se perdería si se eliminan en lugar de desactivar) | **A** | Obligatorio |
+| R-002 | HU-02 | Regla de no-eliminación de filas (soft delete via `active=false`). Si se implementa un `DELETE` en lugar de `UPDATE active=false`, los datos de ubicaciones ya ingresados por el usuario se pierden de forma irrecuperable. | Operación destructiva irrecuperable + regla de negocio explícita | **A** | Obligatorio |
+| R-003 | HU-02 | Conflicto de versión optimista (`@Version` sobre `QuoteJpa`). Bajo acceso concurrente (dos agentes editando el mismo folio simultáneamente), uno debe recibir 409. Si el manejo de `ObjectOptimisticLockingFailureException` es incorrecto, la respuesta puede ser 500 o silenciar el conflicto, causando pérdida silenciosa de datos. | Concurrencia — optimistic lock + integridad de datos entre sesiones | **A** | Obligatorio |
+| R-004 | HU-02 | Atomicidad de la transacción entre `QuoteJpa` (update de columnas layout) y `LocationJpa` (inserts/updates). Si `@Transactional` no está correctamente configurado en el use case, es posible guardar el layout en `QuoteJpa` sin insertar las `LocationJpa` correspondientes, o viceversa, dejando el sistema en estado inconsistente. | Lógica de negocio compleja + múltiples entidades en una misma transacción | **A** | Obligatorio |
+| R-005 | HU-02 | Constraint único `UK_locations_quote_index` (quote_id, index). Al aumentar `numberOfLocations`, si el cálculo del índice de las nuevas ubicaciones es incorrecto y colisiona con uno existente (incluso inactivo), la operación lanzará una violación de constraint en BD, resultando en 500 en lugar de un error controlado. | Integridad referencial + lógica de cálculo de índices | **A** | Obligatorio |
+| R-006 | HU-01 | Cotización sin `layoutConfiguration` configurado debe retornar campos nulos en lugar de un error (CRITERIO-1.3). Si el mapper o el use case no maneja el caso null correctamente, se obtiene NullPointerException o un 500 inesperado. | Código nuevo sin historial + edge case de nulos | **S** | Recomendado |
+| R-007 | HU-02 | Validación de la regla de negocio: si `locationType = SINGLE`, entonces `numberOfLocations` debe ser exactamente 1. Esta validación cruzada entre dos campos no es cubierta por anotaciones Bean Validation estándar y requiere lógica custom; es probable que sea omitida o incompleta. | Lógica de negocio compleja — validación cruzada entre campos | **S** | Recomendado |
+| R-008 | HU-02 | Rango de `numberOfLocations` (1–50). Si el límite superior no se valida, un agente podría enviar 1000 ubicaciones y generar 1000 inserts en una sola transacción, degradando el rendimiento de la BD y causando timeouts o errores de memoria. | Funcionalidad de alta frecuencia de uso + ausencia de límite superior en validación | **S** | Recomendado |
+| R-009 | HU-01 / HU-02 | El `QuoteJpaRepository` ya existe en el context `folio`. Reutilizarlo en el context `location` (via `QuoteLayoutJpaAdapter`) introduce un acoplamiento entre bounded contexts. Un cambio en el context `folio` puede romper la lógica de layout sin aviso. | Componente con muchas dependencias — shared JPA repository entre contextos | **S** | Recomendado |
+| R-010 | HU-02 | Las migraciones Flyway V3 y V4 modifican tablas existentes (`quotes`) y crean una nueva tabla con FK. Si se ejecutan fuera de orden o en un entorno con datos existentes, pueden fallar con errores de columna duplicada o FK violation. | Feature nueva sin historial + dependencia de estado previo de BD | **D** | Opcional |
+| R-011 | HU-01 / HU-02 | Los endpoints no tienen autenticación (`Auth requerida: no` en la spec). Si en el futuro se añade auth, todos los tests de integración y contratos actuales deberán actualizarse. Esto no es un riesgo funcional inmediato pero genera deuda técnica. | Feature interna / administrativa + sin impacto en lógica actual | **D** | Opcional |
+
+---
+
+## Plan de Mitigación — Riesgos ALTO
+
+### R-001: Lógica de sincronización de ubicaciones
+
+- **Descripcion completa:** `SaveLocationLayoutUseCaseImpl` tiene tres ramas lógicas (aumentar, reducir, sin cambio). Cada rama manipula listas de `LocationJpa` y debe preservar datos existentes.
+- **Mitigacion tecnica:**
+  - Separar cada rama en método privado con nombre descriptivo.
+  - Usar `findByQuoteIdAndActiveTrue` para contar solo activas (no inactivas previas).
+  - Calcular el índice de nuevas ubicaciones como `currentActive.size() + i + 1`.
+- **Tests obligatorios:**
+  - `SaveLocationLayoutUseCaseImplTest`: escenarios CRITERIO-2.1 (primera vez), CRITERIO-2.2 (aumentar), CRITERIO-2.3 (reducir), caso "sin cambio en cantidad".
+  - `SaveLocationLayoutIntegrationTest` con Testcontainers: verificar el estado real de la BD para los cuatro escenarios.
+- **Cobertura mínima requerida:** 100% de las ramas del método de sincronización.
+- **Bloqueante para release:** Si
+
+---
+
+### R-002: Regla de no-eliminación (soft delete)
+
+- **Descripcion completa:** La regla de negocio explícita prohíbe `DELETE FROM locations`. Solo se permite `UPDATE active = false`. Un error de implementación (usar `delete()` de JPA) destruye datos irrecuperablemente.
+- **Mitigacion tecnica:**
+  - El adaptador `LocationJpaAdapter` no debe exponer ni llamar métodos `delete*` del `LocationJpaRepository`.
+  - Revisar que `LocationJpaRepository` no tenga `deleteBy*` ni métodos que llamen `deleteAll`.
+  - Añadir test de integración que verifique que después de reducir `numberOfLocations`, el COUNT total de filas en `locations` no decrece.
+- **Tests obligatorios:**
+  - `SaveLocationLayoutIntegrationTest` CRITERIO-2.3: verificar `SELECT COUNT(*) FROM locations WHERE quote_id = X` antes y después — debe ser igual.
+  - `LocationJpaAdapterTest`: verificar que el adaptador solo llama `save`/`saveAll`, nunca `delete`.
+- **Bloqueante para release:** Si
+
+---
+
+### R-003: Conflicto de versión optimista (concurrencia)
+
+- **Descripcion completa:** `ObjectOptimisticLockingFailureException` debe ser capturada en `GlobalExceptionHandler` y traducida a HTTP 409. Si no se registra o se captura en el handler equivocado, el cliente recibe 500 (o peor, 200 con datos corruptos si se hace retry silencioso).
+- **Mitigacion tecnica:**
+  - Registrar `ObjectOptimisticLockingFailureException` en `GlobalExceptionHandler` con respuesta `{ "error": "Optimistic lock conflict", "code": "VERSION_CONFLICT" }` y status 409.
+  - No hacer retry automático en el handler — dejar que el cliente reintente con la versión correcta.
+- **Tests obligatorios:**
+  - `LocationLayoutControllerTest`: mock del use case lanzando `ObjectOptimisticLockingFailureException` → verificar respuesta 409 con body correcto.
+  - `SaveLocationLayoutIntegrationTest` CRITERIO-2.4: dos transacciones concurrentes sobre el mismo folio → la segunda recibe 409.
+- **Bloqueante para release:** Si
+
+---
+
+### R-004: Atomicidad de la transacción
+
+- **Descripcion completa:** `SaveLocationLayoutUseCaseImpl` debe tener `@Transactional`. Si falta, un fallo en el `saveAll` de `LocationJpa` después del `save` de `QuoteJpa` deja el sistema con el layout actualizado pero sin las ubicaciones correspondientes.
+- **Mitigacion tecnica:**
+  - Anotar `SaveLocationLayoutUseCaseImpl.saveLayout(...)` con `@Transactional`.
+  - Verificar que el `@Transactional` sea de Spring (no JPA) y que la propagación sea `REQUIRED` (default).
+  - En `LocationLayoutConfig`, asegurarse de que el use case es un bean Spring gestionado (no instanciado con `new`).
+- **Tests obligatorios:**
+  - `SaveLocationLayoutIntegrationTest`: simular fallo en `saveAll` (inyectando un mock que lanza excepción tras el save de `QuoteJpa`) y verificar rollback — el `number_of_locations` en `quotes` no debe haber cambiado.
+- **Bloqueante para release:** Si
+
+---
+
+### R-005: Violación de constraint único en índices de ubicación
+
+- **Descripcion completa:** `UK_locations_quote_index (quote_id, index)` aplica sobre todas las filas, incluyendo inactivas. Al re-activar ubicaciones o al calcular índices para nuevas filas, si el índice calculado coincide con una fila inactiva existente, se produce `DataIntegrityViolationException`.
+- **Mitigacion tecnica:**
+  - Al calcular el índice de nuevas ubicaciones, usar `findByQuoteId` (todas, activas e inactivas) para obtener el máximo índice existente y partir de ahí.
+  - Alternativamente, en el caso de reducir y volver a aumentar, re-activar las filas inactivas en orden antes de insertar nuevas.
+  - Documentar en el código la decisión tomada sobre el manejo de inactivas al re-expandir.
+- **Tests obligatorios:**
+  - `SaveLocationLayoutIntegrationTest`: flujo reducir 4→2 seguido de aumentar 2→4 — verificar que no hay violación de constraint y que las 4 ubicaciones quedan con `active=true`.
+  - `LocationJpaAdapterTest`: verificar que `saveAll` no genera índices duplicados en el escenario anterior.
+- **Bloqueante para release:** Si
+
+---
+
+## Cobertura de Criterios de Aceptacion por Nivel de Riesgo
+
+| Criterio | HU | Riesgo relacionado | Nivel | Cobertura requerida |
+|----------|----|--------------------|-------|---------------------|
+| CRITERIO-1.1 | HU-01 | R-006 | S | Test unitario + controller test |
+| CRITERIO-1.2 | HU-01 | — | S | Controller test (404) |
+| CRITERIO-1.3 | HU-01 | R-006 | S | Test unitario (nulos) |
+| CRITERIO-2.1 | HU-02 | R-001, R-004, R-005 | **A** | Use case test + integración |
+| CRITERIO-2.2 | HU-02 | R-001, R-004, R-005 | **A** | Use case test + integración |
+| CRITERIO-2.3 | HU-02 | R-001, R-002, R-004 | **A** | Use case test + integración + count rows |
+| CRITERIO-2.4 | HU-02 | R-003 | **A** | Controller test + integración concurrente |
+| CRITERIO-2.5 | HU-02 | — | S | Controller test (404) |
+| CRITERIO-2.6 | HU-02 | R-007, R-008 | S | Controller test (422) + validación cruzada |

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
 
 import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
 import com.sofka.insurancequoter.back.folio.application.usecase.InvalidReferenceException;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,6 +20,24 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(FolioNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleFolioNotFound(FolioNotFoundException ex) {
+        return ResponseEntity.status(404)
+                .body(Map.of(
+                        "error", "Folio not found",
+                        "code", "FOLIO_NOT_FOUND"
+                ));
+    }
+
+    @ExceptionHandler({ObjectOptimisticLockingFailureException.class, OptimisticLockingFailureException.class})
+    public ResponseEntity<Map<String, String>> handleOptimisticLock(Exception ex) {
+        return ResponseEntity.status(409)
+                .body(Map.of(
+                        "error", "Optimistic lock conflict",
+                        "code", "VERSION_CONFLICT"
+                ));
+    }
 
     @ExceptionHandler(InvalidReferenceException.class)
     public ResponseEntity<Map<String, String>> handleInvalidReference(InvalidReferenceException ex) {
@@ -37,6 +58,16 @@ public class GlobalExceptionHandler {
                         "error", "Validation failed",
                         "code", "VALIDATION_ERROR",
                         "fields", fields
+                ));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.status(422)
+                .body(Map.of(
+                        "error", "Validation failed",
+                        "code", "VALIDATION_ERROR",
+                        "fields", List.of(ex.getMessage())
                 ));
     }
 

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/entities/QuoteJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/entities/QuoteJpa.java
@@ -31,6 +31,12 @@ public class QuoteJpa {
     @Column(name = "agent_code", nullable = false, length = 50)
     private String agentCode;
 
+    @Column(name = "number_of_locations")
+    private Integer numberOfLocations;
+
+    @Column(name = "location_type", length = 10)
+    private String locationType;
+
     @Version
     @Column(name = "version", nullable = false)
     private Long version;

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/repositories/QuoteJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/repositories/QuoteJpaRepository.java
@@ -13,4 +13,6 @@ public interface QuoteJpaRepository extends JpaRepository<QuoteJpa, Long> {
             String agentCode,
             String quoteStatus
     );
+
+    Optional<QuoteJpa> findByFolioNumber(String folioNumber);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/FolioNotFoundException.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/FolioNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+// Thrown when a folio number does not match any quote in the database
+public class FolioNotFoundException extends RuntimeException {
+
+    public FolioNotFoundException(String folioNumber) {
+        super("Folio not found: " + folioNumber);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLayoutResult.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLayoutResult.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+
+// Result returned by GetLocationLayoutUseCase
+public record GetLayoutResult(
+        String folioNumber,
+        LayoutConfiguration layoutConfiguration,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationLayoutUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationLayoutUseCaseImpl.java
@@ -1,0 +1,30 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteLayoutRepository;
+
+// Retrieves the layout configuration of a quote identified by its folio number
+public class GetLocationLayoutUseCaseImpl implements GetLocationLayoutUseCase {
+
+    private final QuoteLayoutRepository quoteLayoutRepository;
+
+    public GetLocationLayoutUseCaseImpl(QuoteLayoutRepository quoteLayoutRepository) {
+        this.quoteLayoutRepository = quoteLayoutRepository;
+    }
+
+    @Override
+    public GetLayoutResult getLayout(String folioNumber) {
+        QuoteLayoutData data = quoteLayoutRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
+
+        LocationType locationType = data.locationType() != null
+                ? LocationType.valueOf(data.locationType())
+                : null;
+
+        LayoutConfiguration layout = new LayoutConfiguration(data.numberOfLocations(), locationType);
+
+        return new GetLayoutResult(data.folioNumber(), layout, data.version());
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/QuoteLayoutData.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/QuoteLayoutData.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import java.time.Instant;
+
+// Data transfer object between the persistence output port and the application layer
+public record QuoteLayoutData(
+        Long id,
+        String folioNumber,
+        Integer numberOfLocations,
+        String locationType,
+        Long version,
+        Instant updatedAt
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLayoutCommand.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLayoutCommand.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+
+// Command sent to SaveLocationLayoutUseCase
+public record SaveLayoutCommand(
+        String folioNumber,
+        LayoutConfiguration layoutConfiguration,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLayoutResult.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLayoutResult.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+
+import java.time.Instant;
+
+// Result returned by SaveLocationLayoutUseCase
+public record SaveLayoutResult(
+        String folioNumber,
+        LayoutConfiguration layoutConfiguration,
+        Instant updatedAt,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImpl.java
@@ -1,0 +1,98 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.domain.port.in.SaveLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteLayoutRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Saves or updates the location layout for a quote and synchronises the location records
+public class SaveLocationLayoutUseCaseImpl implements SaveLocationLayoutUseCase {
+
+    private final QuoteLayoutRepository quoteLayoutRepository;
+    private final LocationRepository locationRepository;
+
+    public SaveLocationLayoutUseCaseImpl(
+            QuoteLayoutRepository quoteLayoutRepository,
+            LocationRepository locationRepository) {
+        this.quoteLayoutRepository = quoteLayoutRepository;
+        this.locationRepository = locationRepository;
+    }
+
+    @Override
+    @Transactional
+    public SaveLayoutResult saveLayout(SaveLayoutCommand command) {
+        QuoteLayoutData existing = quoteLayoutRepository.findByFolioNumber(command.folioNumber())
+                .orElseThrow(() -> new FolioNotFoundException(command.folioNumber()));
+
+        LayoutConfiguration layout = command.layoutConfiguration();
+
+        if (LocationType.SINGLE.equals(layout.locationType())
+                && !Integer.valueOf(1).equals(layout.numberOfLocations())) {
+            throw new IllegalArgumentException(
+                    "numberOfLocations must be 1 when locationType is SINGLE");
+        }
+
+        int requested = layout.numberOfLocations();
+
+        // Load ALL locations (active + inactive) to know what indices already exist in DB.
+        // Using only active count would cause UK constraint violations when re-increasing
+        // after a previous reduction (inactive rows with those indices already exist).
+        List<Location> allLocations = locationRepository.findAllByQuoteId(existing.id());
+        int maxExistingIndex = allLocations.stream().mapToInt(Location::index).max().orElse(0);
+        int currentActive = (int) allLocations.stream().filter(Location::active).count();
+
+        if (requested > currentActive) {
+            // Reactivate any previously deactivated rows whose index falls within the new range
+            List<Integer> indicesToReactivate = allLocations.stream()
+                    .filter(l -> !l.active() && l.index() <= requested)
+                    .map(Location::index)
+                    .toList();
+            if (!indicesToReactivate.isEmpty()) {
+                locationRepository.reactivateByIndices(existing.id(), indicesToReactivate);
+            }
+
+            // Insert truly new rows for indices beyond what has ever been allocated
+            if (requested > maxExistingIndex) {
+                List<Location> newLocations = new ArrayList<>();
+                for (int i = maxExistingIndex + 1; i <= requested; i++) {
+                    newLocations.add(new Location(i, true));
+                }
+                locationRepository.insertAll(existing.id(), newLocations);
+            }
+
+        } else if (requested < currentActive) {
+            List<Integer> indicesToDeactivate = allLocations.stream()
+                    .filter(l -> l.active() && l.index() > requested)
+                    .map(Location::index)
+                    .toList();
+            locationRepository.deactivateByIndices(existing.id(), indicesToDeactivate);
+        }
+        // equal — no location changes needed
+
+        String locationTypeName = layout.locationType() != null ? layout.locationType().name() : null;
+        QuoteLayoutData updated = new QuoteLayoutData(
+                existing.id(),
+                existing.folioNumber(),
+                layout.numberOfLocations(),
+                locationTypeName,
+                command.version(),
+                existing.updatedAt()
+        );
+
+        QuoteLayoutData saved = quoteLayoutRepository.save(updated);
+
+        return new SaveLayoutResult(
+                saved.folioNumber(),
+                new LayoutConfiguration(saved.numberOfLocations(),
+                        saved.locationType() != null ? LocationType.valueOf(saved.locationType()) : null),
+                saved.updatedAt(),
+                saved.version()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/LayoutConfiguration.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/LayoutConfiguration.java
@@ -1,0 +1,5 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+// Value object representing how many locations a quote has and their type
+public record LayoutConfiguration(Integer numberOfLocations, LocationType locationType) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/Location.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/Location.java
@@ -1,0 +1,5 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+// Domain model for a single location within a quote
+public record Location(int index, boolean active) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/LocationType.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/LocationType.java
@@ -1,0 +1,6 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+public enum LocationType {
+    SINGLE,
+    MULTIPLE
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/GetLocationLayoutUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/GetLocationLayoutUseCase.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.location.domain.port.in;
+
+import com.sofka.insurancequoter.back.location.application.usecase.GetLayoutResult;
+
+// Input port: retrieves the layout configuration for a given folio
+public interface GetLocationLayoutUseCase {
+
+    GetLayoutResult getLayout(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/SaveLocationLayoutUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/SaveLocationLayoutUseCase.java
@@ -1,0 +1,10 @@
+package com.sofka.insurancequoter.back.location.domain.port.in;
+
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutCommand;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutResult;
+
+// Input port: saves or updates the location layout for a given folio
+public interface SaveLocationLayoutUseCase {
+
+    SaveLayoutResult saveLayout(SaveLayoutCommand command);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/LocationRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/LocationRepository.java
@@ -1,0 +1,19 @@
+package com.sofka.insurancequoter.back.location.domain.port.out;
+
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+
+import java.util.List;
+
+// Output port for reading and persisting location records per quote
+public interface LocationRepository {
+
+    List<Location> findActiveByQuoteId(Long quoteId);
+
+    List<Location> findAllByQuoteId(Long quoteId);
+
+    void insertAll(Long quoteId, List<Location> locations);
+
+    void deactivateByIndices(Long quoteId, List<Integer> indices);
+
+    void reactivateByIndices(Long quoteId, List<Integer> indices);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/QuoteLayoutRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/QuoteLayoutRepository.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.location.domain.port.out;
+
+import com.sofka.insurancequoter.back.location.application.usecase.QuoteLayoutData;
+
+import java.util.Optional;
+
+// Output port for reading and persisting quote layout data
+public interface QuoteLayoutRepository {
+
+    Optional<QuoteLayoutData> findByFolioNumber(String folioNumber);
+
+    QuoteLayoutData save(QuoteLayoutData data);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutController.java
@@ -1,0 +1,48 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.location.application.usecase.GetLayoutResult;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutResult;
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.in.SaveLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.GetLayoutResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper.LocationLayoutRestMapper;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.swaggerdocs.LocationLayoutApi;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+// REST adapter for the location layout bounded context
+@RestController
+@RequestMapping("/v1/quotes/{folio}/locations/layout")
+public class LocationLayoutController implements LocationLayoutApi {
+
+    private final GetLocationLayoutUseCase getLayoutUseCase;
+    private final SaveLocationLayoutUseCase saveLayoutUseCase;
+    private final LocationLayoutRestMapper mapper;
+
+    public LocationLayoutController(GetLocationLayoutUseCase getLayoutUseCase,
+                                    SaveLocationLayoutUseCase saveLayoutUseCase,
+                                    LocationLayoutRestMapper mapper) {
+        this.getLayoutUseCase = getLayoutUseCase;
+        this.saveLayoutUseCase = saveLayoutUseCase;
+        this.mapper = mapper;
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<GetLayoutResponse> getLayout(@PathVariable String folio) {
+        GetLayoutResult result = getLayoutUseCase.getLayout(folio);
+        return ResponseEntity.ok(mapper.toGetResponse(result));
+    }
+
+    @Override
+    @PutMapping
+    public ResponseEntity<SaveLayoutResponse> saveLayout(
+            @PathVariable String folio,
+            @Valid @RequestBody SaveLayoutRequest request) {
+        SaveLayoutResult result = saveLayoutUseCase.saveLayout(mapper.toCommand(folio, request));
+        return ResponseEntity.ok(mapper.toSaveResponse(result));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/GetLayoutResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/GetLayoutResponse.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto;
+
+// HTTP response DTO for GET /v1/quotes/{folio}/locations/layout
+public record GetLayoutResponse(
+        String folioNumber,
+        LayoutConfigurationDto layoutConfiguration,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/LayoutConfigurationDto.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/LayoutConfigurationDto.java
@@ -1,0 +1,5 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto;
+
+// DTO representing the layout configuration in REST requests and responses
+public record LayoutConfigurationDto(Integer numberOfLocations, String locationType) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/SaveLayoutRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/SaveLayoutRequest.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+// HTTP request DTO for PUT /v1/quotes/{folio}/locations/layout
+public record SaveLayoutRequest(
+        @NotNull @Valid LayoutConfigurationDto layoutConfiguration,
+        @NotNull Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/SaveLayoutResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/SaveLayoutResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto;
+
+import java.time.Instant;
+
+// HTTP response DTO for PUT /v1/quotes/{folio}/locations/layout
+public record SaveLayoutResponse(
+        String folioNumber,
+        LayoutConfigurationDto layoutConfiguration,
+        Instant updatedAt,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/mapper/LocationLayoutRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/mapper/LocationLayoutRestMapper.java
@@ -1,0 +1,50 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.back.location.application.usecase.GetLayoutResult;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutCommand;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutResult;
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.GetLayoutResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.LayoutConfigurationDto;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutResponse;
+import org.springframework.stereotype.Component;
+
+// Maps between REST DTOs and application layer command/result objects
+@Component
+public class LocationLayoutRestMapper {
+
+    public GetLayoutResponse toGetResponse(GetLayoutResult result) {
+        LayoutConfiguration layout = result.layoutConfiguration();
+        String locationTypeName = layout.locationType() != null
+                ? layout.locationType().name()
+                : null;
+        LayoutConfigurationDto dto = new LayoutConfigurationDto(
+                layout.numberOfLocations(),
+                locationTypeName
+        );
+        return new GetLayoutResponse(result.folioNumber(), dto, result.version());
+    }
+
+    public SaveLayoutCommand toCommand(String folioNumber, SaveLayoutRequest request) {
+        LayoutConfigurationDto dto = request.layoutConfiguration();
+        LocationType locationType = dto.locationType() != null
+                ? LocationType.valueOf(dto.locationType())
+                : null;
+        LayoutConfiguration layout = new LayoutConfiguration(dto.numberOfLocations(), locationType);
+        return new SaveLayoutCommand(folioNumber, layout, request.version());
+    }
+
+    public SaveLayoutResponse toSaveResponse(SaveLayoutResult result) {
+        LayoutConfiguration layout = result.layoutConfiguration();
+        String locationTypeName = layout.locationType() != null
+                ? layout.locationType().name()
+                : null;
+        LayoutConfigurationDto dto = new LayoutConfigurationDto(
+                layout.numberOfLocations(),
+                locationTypeName
+        );
+        return new SaveLayoutResponse(result.folioNumber(), dto, result.updatedAt(), result.version());
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/swaggerdocs/LocationLayoutApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/swaggerdocs/LocationLayoutApi.java
@@ -1,0 +1,41 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.GetLayoutResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Location Layout", description = "Manages the layout configuration of locations per quote")
+public interface LocationLayoutApi {
+
+    @Operation(summary = "Get layout configuration for a quote")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Layout returned successfully"),
+            @ApiResponse(responseCode = "404", description = "Folio not found")
+    })
+    ResponseEntity<GetLayoutResponse> getLayout(
+            @Parameter(description = "Folio number", required = true)
+            @PathVariable String folio
+    );
+
+    @Operation(summary = "Save or update layout configuration for a quote")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Layout saved successfully"),
+            @ApiResponse(responseCode = "404", description = "Folio not found"),
+            @ApiResponse(responseCode = "409", description = "Optimistic lock conflict"),
+            @ApiResponse(responseCode = "422", description = "Validation error")
+    })
+    ResponseEntity<SaveLayoutResponse> saveLayout(
+            @Parameter(description = "Folio number", required = true)
+            @PathVariable String folio,
+            @Valid @RequestBody SaveLayoutRequest request
+    );
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/LocationJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/LocationJpaAdapter.java
@@ -1,0 +1,65 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+// JPA adapter that implements the LocationRepository output port
+@Component
+public class LocationJpaAdapter implements LocationRepository {
+
+    private final LocationJpaRepository locationJpaRepository;
+    private final LocationPersistenceMapper mapper;
+
+    public LocationJpaAdapter(LocationJpaRepository locationJpaRepository,
+                              LocationPersistenceMapper mapper) {
+        this.locationJpaRepository = locationJpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<Location> findActiveByQuoteId(Long quoteId) {
+        return locationJpaRepository.findByQuoteIdAndActiveTrue(quoteId)
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Location> findAllByQuoteId(Long quoteId) {
+        return locationJpaRepository.findByQuoteId(quoteId)
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void insertAll(Long quoteId, List<Location> locations) {
+        if (locations.isEmpty()) return;
+        List<LocationJpa> entities = locations.stream()
+                .map(l -> mapper.toLocationJpa(quoteId, l))
+                .toList();
+        locationJpaRepository.saveAll(entities);
+    }
+
+    @Override
+    public void deactivateByIndices(Long quoteId, List<Integer> indices) {
+        if (indices.isEmpty()) return;
+        List<LocationJpa> rows = locationJpaRepository.findByQuoteIdAndIndexIn(quoteId, indices);
+        rows.forEach(jpa -> jpa.setActive(false));
+        locationJpaRepository.saveAll(rows);
+    }
+
+    @Override
+    public void reactivateByIndices(Long quoteId, List<Integer> indices) {
+        if (indices.isEmpty()) return;
+        List<LocationJpa> rows = locationJpaRepository.findByQuoteIdAndIndexIn(quoteId, indices);
+        rows.forEach(jpa -> jpa.setActive(true));
+        locationJpaRepository.saveAll(rows);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/QuoteLayoutJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/QuoteLayoutJpaAdapter.java
@@ -1,0 +1,52 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.QuoteLayoutData;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteLayoutRepository;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+// JPA adapter that implements the QuoteLayoutRepository output port
+@Component
+public class QuoteLayoutJpaAdapter implements QuoteLayoutRepository {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+    private final LocationPersistenceMapper mapper;
+
+    public QuoteLayoutJpaAdapter(QuoteJpaRepository quoteJpaRepository,
+                                 LocationPersistenceMapper mapper) {
+        this.quoteJpaRepository = quoteJpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<QuoteLayoutData> findByFolioNumber(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .map(mapper::toQuoteLayoutData);
+    }
+
+    @Override
+    public QuoteLayoutData save(QuoteLayoutData data) {
+        // Load the current managed entity from the database
+        QuoteJpa jpa = quoteJpaRepository.findById(data.id())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Quote not found by id during save: " + data.id()));
+
+        // Manual optimistic lock check: compare client-supplied version with the current DB version.
+        // Hibernate manages @Version internally on managed entities and ignores setVersion(),
+        // so we perform the guard here before any mutation.
+        if (!jpa.getVersion().equals(data.version())) {
+            throw new ObjectOptimisticLockingFailureException(QuoteJpa.class, data.id());
+        }
+
+        jpa.setNumberOfLocations(data.numberOfLocations());
+        jpa.setLocationType(data.locationType());
+
+        QuoteJpa saved = quoteJpaRepository.save(jpa);
+        return mapper.toQuoteLayoutData(saved);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/entities/LocationJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/entities/LocationJpa.java
@@ -1,0 +1,44 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "locations",
+        uniqueConstraints = @UniqueConstraint(
+                name = "UK_locations_quote_index",
+                columnNames = {"quote_id", "index"}))
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationJpa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "quote_id", nullable = false)
+    private Long quoteId;
+
+    @Column(name = "index", nullable = false)
+    private Integer index;
+
+    @Column(name = "active", nullable = false)
+    private Boolean active;
+
+    @Column(name = "location_name")
+    private String locationName;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/mappers/LocationPersistenceMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/mappers/LocationPersistenceMapper.java
@@ -1,0 +1,35 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.location.application.usecase.QuoteLayoutData;
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import org.springframework.stereotype.Component;
+
+// Maps between domain/application objects and JPA entities for the location bounded context
+@Component
+public class LocationPersistenceMapper {
+
+    public QuoteLayoutData toQuoteLayoutData(QuoteJpa jpa) {
+        return new QuoteLayoutData(
+                jpa.getId(),
+                jpa.getFolioNumber(),
+                jpa.getNumberOfLocations(),
+                jpa.getLocationType(),
+                jpa.getVersion(),
+                jpa.getUpdatedAt()
+        );
+    }
+
+    public LocationJpa toLocationJpa(Long quoteId, Location location) {
+        return LocationJpa.builder()
+                .quoteId(quoteId)
+                .index(location.index())
+                .active(location.active())
+                .build();
+    }
+
+    public Location toDomain(LocationJpa jpa) {
+        return new Location(jpa.getIndex(), jpa.getActive());
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/repositories/LocationJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/repositories/LocationJpaRepository.java
@@ -1,0 +1,15 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories;
+
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LocationJpaRepository extends JpaRepository<LocationJpa, Long> {
+
+    List<LocationJpa> findByQuoteIdAndActiveTrue(Long quoteId);
+
+    List<LocationJpa> findByQuoteId(Long quoteId);
+
+    List<LocationJpa> findByQuoteIdAndIndexIn(Long quoteId, List<Integer> indices);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/config/LocationLayoutConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/config/LocationLayoutConfig.java
@@ -1,0 +1,27 @@
+package com.sofka.insurancequoter.back.location.infrastructure.config;
+
+import com.sofka.insurancequoter.back.location.application.usecase.GetLocationLayoutUseCaseImpl;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLocationLayoutUseCaseImpl;
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.in.SaveLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteLayoutRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// Wires the location layout use case implementations with their output port adapters
+@Configuration
+public class LocationLayoutConfig {
+
+    @Bean
+    public GetLocationLayoutUseCase getLocationLayoutUseCase(QuoteLayoutRepository quoteLayoutRepository) {
+        return new GetLocationLayoutUseCaseImpl(quoteLayoutRepository);
+    }
+
+    @Bean
+    public SaveLocationLayoutUseCase saveLocationLayoutUseCase(
+            QuoteLayoutRepository quoteLayoutRepository,
+            LocationRepository locationRepository) {
+        return new SaveLocationLayoutUseCaseImpl(quoteLayoutRepository, locationRepository);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,9 +2,9 @@ spring.application.name=Insurance-Quoter
 server.port=8080
 
 # Datasource — PostgreSQL insurance_quoter_db (:5432)
-spring.datasource.url=jdbc:postgresql://localhost:5432/insurance_quoter_db
-spring.datasource.username=myuser
-spring.datasource.password=secret
+spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA / Hibernate

--- a/src/main/resources/db/migration/V3__add_layout_columns_to_quotes.sql
+++ b/src/main/resources/db/migration/V3__add_layout_columns_to_quotes.sql
@@ -1,0 +1,4 @@
+-- Adds layout configuration columns to the quotes table
+ALTER TABLE quotes
+    ADD COLUMN IF NOT EXISTS number_of_locations INTEGER,
+    ADD COLUMN IF NOT EXISTS location_type VARCHAR(10);

--- a/src/main/resources/db/migration/V4__create_locations_table.sql
+++ b/src/main/resources/db/migration/V4__create_locations_table.sql
@@ -1,0 +1,13 @@
+-- Creates the locations table for storing per-quote location records
+CREATE TABLE IF NOT EXISTS locations (
+    id          BIGSERIAL PRIMARY KEY,
+    quote_id    BIGINT NOT NULL REFERENCES quotes(id),
+    index       INTEGER NOT NULL,
+    active      BOOLEAN NOT NULL DEFAULT TRUE,
+    location_name VARCHAR(255),
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT UK_locations_quote_index UNIQUE (quote_id, index)
+);
+
+CREATE INDEX IF NOT EXISTS IDX_locations_quote_id ON locations(quote_id);

--- a/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationLayoutUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationLayoutUseCaseImplTest.java
@@ -1,0 +1,73 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteLayoutRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetLocationLayoutUseCaseImplTest {
+
+    @Mock
+    private QuoteLayoutRepository quoteLayoutRepository;
+
+    @InjectMocks
+    private GetLocationLayoutUseCaseImpl useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    // CRITERIO-1.1: returns layout when quote exists with layout configured
+    @Test
+    void shouldReturnLayout_whenFolioExistsWithLayoutConfigured() {
+        // GIVEN
+        var data = new QuoteLayoutData(1L, "FOL-2026-00042", 3, "MULTIPLE", 2L, NOW);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(data));
+
+        // WHEN
+        GetLayoutResult result = useCase.getLayout("FOL-2026-00042");
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(result.version()).isEqualTo(2L);
+        assertThat(result.layoutConfiguration().numberOfLocations()).isEqualTo(3);
+        assertThat(result.layoutConfiguration().locationType()).isEqualTo(LocationType.MULTIPLE);
+    }
+
+    // CRITERIO-1.3: returns null layout fields when quote has no layout configured
+    @Test
+    void shouldReturnNullLayout_whenFolioExistsWithoutLayoutConfigured() {
+        // GIVEN
+        var data = new QuoteLayoutData(1L, "FOL-2026-00042", null, null, 1L, NOW);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(data));
+
+        // WHEN
+        GetLayoutResult result = useCase.getLayout("FOL-2026-00042");
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(result.layoutConfiguration().numberOfLocations()).isNull();
+        assertThat(result.layoutConfiguration().locationType()).isNull();
+    }
+
+    // CRITERIO-1.2: throws FolioNotFoundException when folio does not exist
+    @Test
+    void shouldThrowFolioNotFoundException_whenFolioDoesNotExist() {
+        // GIVEN
+        when(quoteLayoutRepository.findByFolioNumber("FOL-9999-99999")).thenReturn(Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.getLayout("FOL-9999-99999"))
+                .isInstanceOf(FolioNotFoundException.class)
+                .hasMessageContaining("FOL-9999-99999");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImplTest.java
@@ -1,0 +1,261 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteLayoutRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class SaveLocationLayoutUseCaseImplTest {
+
+    @Mock
+    private QuoteLayoutRepository quoteLayoutRepository;
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @InjectMocks
+    private SaveLocationLayoutUseCaseImpl useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    private QuoteLayoutData quoteData(Long id, Integer currentLocations, String currentType, Long version) {
+        return new QuoteLayoutData(id, "FOL-2026-00042", currentLocations, currentType, version, NOW);
+    }
+
+    // CRITERIO-2.1: first time save creates the empty location records
+    @Test
+    void shouldCreateLocations_whenSavingLayoutForFirstTime() {
+        // GIVEN
+        var existing = quoteData(10L, null, null, 1L);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
+        when(locationRepository.findAllByQuoteId(10L)).thenReturn(List.of());
+        when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var command = new SaveLayoutCommand(
+                "FOL-2026-00042",
+                new LayoutConfiguration(3, LocationType.MULTIPLE),
+                1L
+        );
+
+        // WHEN
+        SaveLayoutResult result = useCase.saveLayout(command);
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(result.layoutConfiguration().numberOfLocations()).isEqualTo(3);
+        assertThat(result.layoutConfiguration().locationType()).isEqualTo(LocationType.MULTIPLE);
+
+        ArgumentCaptor<List<Location>> captor = ArgumentCaptor.forClass(List.class);
+        verify(locationRepository).insertAll(eq(10L), captor.capture());
+        List<Location> inserted = captor.getValue();
+        assertThat(inserted).hasSize(3);
+        assertThat(inserted).extracting(Location::index).containsExactly(1, 2, 3);
+        assertThat(inserted).extracting(Location::active).containsOnly(true);
+        verify(locationRepository, never()).reactivateByIndices(any(), any());
+    }
+
+    // CRITERIO-2.2: increasing numberOfLocations appends new empty locations (no prior inactive rows)
+    @Test
+    void shouldAddLocations_whenIncreasingNumberOfLocations() {
+        // GIVEN
+        var existing = quoteData(10L, 2, "MULTIPLE", 3L);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
+        when(locationRepository.findAllByQuoteId(10L))
+                .thenReturn(List.of(new Location(1, true), new Location(2, true)));
+        when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var command = new SaveLayoutCommand(
+                "FOL-2026-00042",
+                new LayoutConfiguration(4, LocationType.MULTIPLE),
+                3L
+        );
+
+        // WHEN
+        useCase.saveLayout(command);
+
+        // THEN — only the 2 new locations (index 3 and 4) are inserted
+        ArgumentCaptor<List<Location>> captor = ArgumentCaptor.forClass(List.class);
+        verify(locationRepository).insertAll(eq(10L), captor.capture());
+        List<Location> inserted = captor.getValue();
+        assertThat(inserted).hasSize(2);
+        assertThat(inserted).extracting(Location::index).containsExactly(3, 4);
+        verify(locationRepository, never()).reactivateByIndices(any(), any());
+    }
+
+    // CRITERIO-2.3: decreasing numberOfLocations marks excess locations inactive
+    @Test
+    void shouldDeactivateLocations_whenDecreasingNumberOfLocations() {
+        // GIVEN
+        var existing = quoteData(10L, 4, "MULTIPLE", 4L);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
+        when(locationRepository.findAllByQuoteId(10L))
+                .thenReturn(List.of(
+                        new Location(1, true),
+                        new Location(2, true),
+                        new Location(3, true),
+                        new Location(4, true)));
+        when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var command = new SaveLayoutCommand(
+                "FOL-2026-00042",
+                new LayoutConfiguration(2, LocationType.MULTIPLE),
+                4L
+        );
+
+        // WHEN
+        useCase.saveLayout(command);
+
+        // THEN — indices 3 and 4 are deactivated, no inserts
+        ArgumentCaptor<List<Integer>> captor = ArgumentCaptor.forClass(List.class);
+        verify(locationRepository).deactivateByIndices(eq(10L), captor.capture());
+        assertThat(captor.getValue()).containsExactlyInAnyOrder(3, 4);
+        verify(locationRepository, never()).insertAll(any(), any());
+        verify(locationRepository, never()).reactivateByIndices(any(), any());
+    }
+
+    // R-005: reduce then increase must reactivate existing inactive rows, not insert duplicates
+    @Test
+    void shouldReactivateInactiveLocations_whenIncreasingAfterPreviousReduction() {
+        // GIVEN: previously had 4, reduced to 2 (indices 3,4 now inactive)
+        var existing = quoteData(10L, 2, "MULTIPLE", 5L);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
+        when(locationRepository.findAllByQuoteId(10L))
+                .thenReturn(List.of(
+                        new Location(1, true),
+                        new Location(2, true),
+                        new Location(3, false),
+                        new Location(4, false)));
+        when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var command = new SaveLayoutCommand(
+                "FOL-2026-00042",
+                new LayoutConfiguration(4, LocationType.MULTIPLE),
+                5L
+        );
+
+        // WHEN
+        useCase.saveLayout(command);
+
+        // THEN — reactivate 3 and 4, no inserts (they already exist)
+        ArgumentCaptor<List<Integer>> reactivateCaptor = ArgumentCaptor.forClass(List.class);
+        verify(locationRepository).reactivateByIndices(eq(10L), reactivateCaptor.capture());
+        assertThat(reactivateCaptor.getValue()).containsExactlyInAnyOrder(3, 4);
+        verify(locationRepository, never()).insertAll(any(), any());
+        verify(locationRepository, never()).deactivateByIndices(any(), any());
+    }
+
+    // Increase beyond max ever-allocated: reactivate existing inactive + insert truly new
+    @Test
+    void shouldReactivateAndInsert_whenIncreasingBeyondMaxExistingIndex() {
+        // GIVEN: previously had 3, reduced to 1 (indices 2,3 inactive), now requesting 5
+        var existing = quoteData(10L, 1, "MULTIPLE", 6L);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
+        when(locationRepository.findAllByQuoteId(10L))
+                .thenReturn(List.of(
+                        new Location(1, true),
+                        new Location(2, false),
+                        new Location(3, false)));
+        when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var command = new SaveLayoutCommand(
+                "FOL-2026-00042",
+                new LayoutConfiguration(5, LocationType.MULTIPLE),
+                6L
+        );
+
+        // WHEN
+        useCase.saveLayout(command);
+
+        // THEN — reactivate 2,3 and insert 4,5
+        ArgumentCaptor<List<Integer>> reactivateCaptor = ArgumentCaptor.forClass(List.class);
+        verify(locationRepository).reactivateByIndices(eq(10L), reactivateCaptor.capture());
+        assertThat(reactivateCaptor.getValue()).containsExactlyInAnyOrder(2, 3);
+
+        ArgumentCaptor<List<Location>> insertCaptor = ArgumentCaptor.forClass(List.class);
+        verify(locationRepository).insertAll(eq(10L), insertCaptor.capture());
+        assertThat(insertCaptor.getValue()).extracting(Location::index).containsExactly(4, 5);
+    }
+
+    // Equal numberOfLocations: no location changes, only quote fields updated
+    @Test
+    void shouldNotTouchLocations_whenNumberOfLocationsIsUnchanged() {
+        // GIVEN
+        var existing = quoteData(10L, 3, "MULTIPLE", 2L);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
+        when(locationRepository.findAllByQuoteId(10L))
+                .thenReturn(List.of(
+                        new Location(1, true),
+                        new Location(2, true),
+                        new Location(3, true)));
+        when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var command = new SaveLayoutCommand(
+                "FOL-2026-00042",
+                new LayoutConfiguration(3, LocationType.MULTIPLE),
+                2L
+        );
+
+        // WHEN
+        useCase.saveLayout(command);
+
+        // THEN — no location writes
+        verify(locationRepository, never()).insertAll(any(), any());
+        verify(locationRepository, never()).deactivateByIndices(any(), any());
+        verify(locationRepository, never()).reactivateByIndices(any(), any());
+    }
+
+    // CRITERIO-2.5: folio not found throws FolioNotFoundException
+    @Test
+    void shouldThrowFolioNotFoundException_whenFolioDoesNotExist() {
+        // GIVEN
+        when(quoteLayoutRepository.findByFolioNumber("FOL-9999-99999")).thenReturn(Optional.empty());
+
+        var command = new SaveLayoutCommand(
+                "FOL-9999-99999",
+                new LayoutConfiguration(2, LocationType.MULTIPLE),
+                1L
+        );
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.saveLayout(command))
+                .isInstanceOf(FolioNotFoundException.class)
+                .hasMessageContaining("FOL-9999-99999");
+    }
+
+    // CRITERIO-2.6 / business rule: SINGLE type must have numberOfLocations == 1
+    @Test
+    void shouldThrowIllegalArgument_whenSingleTypeHasMoreThanOneLocation() {
+        // GIVEN
+        var existing = quoteData(10L, null, null, 1L);
+        when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
+
+        var command = new SaveLayoutCommand(
+                "FOL-2026-00042",
+                new LayoutConfiguration(2, LocationType.SINGLE),
+                1L
+        );
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.saveLayout(command))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutControllerTest.java
@@ -1,0 +1,202 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.GetLayoutResult;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutResult;
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.in.SaveLocationLayoutUseCase;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper.LocationLayoutRestMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class LocationLayoutControllerTest {
+
+    @Mock
+    private GetLocationLayoutUseCase getLayoutUseCase;
+
+    @Mock
+    private SaveLocationLayoutUseCase saveLayoutUseCase;
+
+    private MockMvc mockMvc;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new LocationLayoutController(
+                        getLayoutUseCase, saveLayoutUseCase, new LocationLayoutRestMapper()))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    // CRITERIO-1.1: GET 200 with layout configured
+    @Test
+    void shouldReturn200WithLayout_whenGetLayoutAndFolioExists() throws Exception {
+        // GIVEN
+        GetLayoutResult result = new GetLayoutResult(
+                "FOL-2026-00042",
+                new LayoutConfiguration(3, LocationType.MULTIPLE),
+                2L
+        );
+        when(getLayoutUseCase.getLayout("FOL-2026-00042")).thenReturn(result);
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/FOL-2026-00042/locations/layout"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00042"))
+                .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(3))
+                .andExpect(jsonPath("$.layoutConfiguration.locationType").value("MULTIPLE"))
+                .andExpect(jsonPath("$.version").value(2));
+    }
+
+    // CRITERIO-1.2: GET 404 when folio not found
+    @Test
+    void shouldReturn404_whenGetLayoutAndFolioNotFound() throws Exception {
+        // GIVEN
+        when(getLayoutUseCase.getLayout("FOL-9999-99999"))
+                .thenThrow(new FolioNotFoundException("FOL-9999-99999"));
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/FOL-9999-99999/locations/layout"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("Folio not found"))
+                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+    }
+
+    // CRITERIO-2.1: PUT 200 saves layout successfully
+    @Test
+    void shouldReturn200_whenSaveLayoutSucceeds() throws Exception {
+        // GIVEN
+        SaveLayoutResult result = new SaveLayoutResult(
+                "FOL-2026-00042",
+                new LayoutConfiguration(3, LocationType.MULTIPLE),
+                NOW,
+                2L
+        );
+        when(saveLayoutUseCase.saveLayout(any())).thenReturn(result);
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "layoutConfiguration": {
+                                    "numberOfLocations": 3,
+                                    "locationType": "MULTIPLE"
+                                  },
+                                  "version": 1
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00042"))
+                .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(3))
+                .andExpect(jsonPath("$.version").value(2));
+    }
+
+    // CRITERIO-2.5: PUT 404 when folio not found
+    @Test
+    void shouldReturn404_whenSaveLayoutAndFolioNotFound() throws Exception {
+        // GIVEN
+        when(saveLayoutUseCase.saveLayout(any()))
+                .thenThrow(new FolioNotFoundException("FOL-9999-99999"));
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-9999-99999/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "layoutConfiguration": {
+                                    "numberOfLocations": 2,
+                                    "locationType": "MULTIPLE"
+                                  },
+                                  "version": 1
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+    }
+
+    // CRITERIO-2.4: PUT 409 on optimistic lock conflict
+    @Test
+    void shouldReturn409_whenOptimisticLockConflict() throws Exception {
+        // GIVEN
+        when(saveLayoutUseCase.saveLayout(any()))
+                .thenThrow(new OptimisticLockingFailureException("version conflict"));
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "layoutConfiguration": {
+                                    "numberOfLocations": 2,
+                                    "locationType": "MULTIPLE"
+                                  },
+                                  "version": 1
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("Optimistic lock conflict"))
+                .andExpect(jsonPath("$.code").value("VERSION_CONFLICT"));
+    }
+
+    // CRITERIO-2.6: PUT 422 when layoutConfiguration is null
+    @Test
+    void shouldReturn422_whenLayoutConfigurationIsMissing() throws Exception {
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "version": 1
+                                }
+                                """))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // PUT 422 when version is null
+    @Test
+    void shouldReturn422_whenVersionIsMissing() throws Exception {
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "layoutConfiguration": {
+                                    "numberOfLocations": 2,
+                                    "locationType": "MULTIPLE"
+                                  }
+                                }
+                                """))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutRestMapperTest.java
@@ -1,0 +1,102 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.location.application.usecase.GetLayoutResult;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutCommand;
+import com.sofka.insurancequoter.back.location.application.usecase.SaveLayoutResult;
+import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
+import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.GetLayoutResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.LayoutConfigurationDto;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.SaveLayoutResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper.LocationLayoutRestMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocationLayoutRestMapperTest {
+
+    private final LocationLayoutRestMapper mapper = new LocationLayoutRestMapper();
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    // GetLayoutResult → GetLayoutResponse
+    @Test
+    void shouldMapGetLayoutResultToResponse() {
+        // GIVEN
+        GetLayoutResult result = new GetLayoutResult(
+                "FOL-2026-00042",
+                new LayoutConfiguration(3, LocationType.MULTIPLE),
+                2L
+        );
+
+        // WHEN
+        GetLayoutResponse response = mapper.toGetResponse(result);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(response.version()).isEqualTo(2L);
+        assertThat(response.layoutConfiguration().numberOfLocations()).isEqualTo(3);
+        assertThat(response.layoutConfiguration().locationType()).isEqualTo("MULTIPLE");
+    }
+
+    // GetLayoutResult with null layout → response has null fields
+    @Test
+    void shouldMapNullLayoutConfigurationToNullFields() {
+        // GIVEN
+        GetLayoutResult result = new GetLayoutResult(
+                "FOL-2026-00042",
+                new LayoutConfiguration(null, null),
+                1L
+        );
+
+        // WHEN
+        GetLayoutResponse response = mapper.toGetResponse(result);
+
+        // THEN
+        assertThat(response.layoutConfiguration().numberOfLocations()).isNull();
+        assertThat(response.layoutConfiguration().locationType()).isNull();
+    }
+
+    // SaveLayoutRequest + folio → SaveLayoutCommand
+    @Test
+    void shouldMapSaveRequestToCommand() {
+        // GIVEN
+        SaveLayoutRequest request = new SaveLayoutRequest(
+                new LayoutConfigurationDto(2, "SINGLE"),
+                3L
+        );
+
+        // WHEN
+        SaveLayoutCommand command = mapper.toCommand("FOL-2026-00042", request);
+
+        // THEN
+        assertThat(command.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(command.version()).isEqualTo(3L);
+        assertThat(command.layoutConfiguration().numberOfLocations()).isEqualTo(2);
+        assertThat(command.layoutConfiguration().locationType()).isEqualTo(LocationType.SINGLE);
+    }
+
+    // SaveLayoutResult → SaveLayoutResponse
+    @Test
+    void shouldMapSaveLayoutResultToResponse() {
+        // GIVEN
+        SaveLayoutResult result = new SaveLayoutResult(
+                "FOL-2026-00042",
+                new LayoutConfiguration(2, LocationType.SINGLE),
+                NOW,
+                4L
+        );
+
+        // WHEN
+        SaveLayoutResponse response = mapper.toSaveResponse(result);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(response.updatedAt()).isEqualTo(NOW);
+        assertThat(response.version()).isEqualTo(4L);
+        assertThat(response.layoutConfiguration().locationType()).isEqualTo("SINGLE");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationJpaAdapterTest.java
@@ -1,0 +1,127 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter.LocationJpaAdapter;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class LocationJpaAdapterTest {
+
+    @Mock
+    private LocationJpaRepository locationJpaRepository;
+
+    @Mock
+    private LocationPersistenceMapper mapper;
+
+    @InjectMocks
+    private LocationJpaAdapter adapter;
+
+    @Test
+    void shouldReturnActiveLocations_whenQuoteHasActiveLocations() {
+        // GIVEN
+        LocationJpa jpa1 = LocationJpa.builder().id(1L).quoteId(10L).index(1).active(true).build();
+        LocationJpa jpa2 = LocationJpa.builder().id(2L).quoteId(10L).index(2).active(true).build();
+        when(locationJpaRepository.findByQuoteIdAndActiveTrue(10L)).thenReturn(List.of(jpa1, jpa2));
+        when(mapper.toDomain(jpa1)).thenReturn(new Location(1, true));
+        when(mapper.toDomain(jpa2)).thenReturn(new Location(2, true));
+
+        // WHEN
+        List<Location> result = adapter.findActiveByQuoteId(10L);
+
+        // THEN
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Location::index).containsExactly(1, 2);
+    }
+
+    @Test
+    void shouldReturnAllLocations_includesInactive() {
+        // GIVEN
+        LocationJpa active = LocationJpa.builder().id(1L).quoteId(10L).index(1).active(true).build();
+        LocationJpa inactive = LocationJpa.builder().id(2L).quoteId(10L).index(2).active(false).build();
+        when(locationJpaRepository.findByQuoteId(10L)).thenReturn(List.of(active, inactive));
+        when(mapper.toDomain(active)).thenReturn(new Location(1, true));
+        when(mapper.toDomain(inactive)).thenReturn(new Location(2, false));
+
+        // WHEN
+        List<Location> result = adapter.findAllByQuoteId(10L);
+
+        // THEN
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Location::active).containsExactly(true, false);
+    }
+
+    @Test
+    void shouldInsertNewLocations_whenInsertAllCalled() {
+        // GIVEN
+        List<Location> newLocations = List.of(new Location(3, true), new Location(4, true));
+        LocationJpa jpa3 = LocationJpa.builder().quoteId(10L).index(3).active(true).build();
+        LocationJpa jpa4 = LocationJpa.builder().quoteId(10L).index(4).active(true).build();
+        when(mapper.toLocationJpa(10L, new Location(3, true))).thenReturn(jpa3);
+        when(mapper.toLocationJpa(10L, new Location(4, true))).thenReturn(jpa4);
+
+        // WHEN
+        adapter.insertAll(10L, newLocations);
+
+        // THEN
+        ArgumentCaptor<List<LocationJpa>> captor = ArgumentCaptor.forClass(List.class);
+        verify(locationJpaRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(2);
+    }
+
+    @Test
+    void shouldDoNothing_whenInsertAllWithEmptyList() {
+        // WHEN
+        adapter.insertAll(10L, List.of());
+
+        // THEN
+        verifyNoInteractions(locationJpaRepository);
+    }
+
+    @Test
+    void shouldSetActiveFalse_whenDeactivateByIndicesCalled() {
+        // GIVEN
+        LocationJpa jpa3 = LocationJpa.builder().id(3L).quoteId(10L).index(3).active(true).build();
+        LocationJpa jpa4 = LocationJpa.builder().id(4L).quoteId(10L).index(4).active(true).build();
+        when(locationJpaRepository.findByQuoteIdAndIndexIn(10L, List.of(3, 4)))
+                .thenReturn(List.of(jpa3, jpa4));
+
+        // WHEN
+        adapter.deactivateByIndices(10L, List.of(3, 4));
+
+        // THEN
+        assertThat(jpa3.getActive()).isFalse();
+        assertThat(jpa4.getActive()).isFalse();
+        verify(locationJpaRepository).saveAll(List.of(jpa3, jpa4));
+    }
+
+    @Test
+    void shouldSetActiveTrue_whenReactivateByIndicesCalled() {
+        // GIVEN
+        LocationJpa jpa3 = LocationJpa.builder().id(3L).quoteId(10L).index(3).active(false).build();
+        LocationJpa jpa4 = LocationJpa.builder().id(4L).quoteId(10L).index(4).active(false).build();
+        when(locationJpaRepository.findByQuoteIdAndIndexIn(10L, List.of(3, 4)))
+                .thenReturn(List.of(jpa3, jpa4));
+
+        // WHEN
+        adapter.reactivateByIndices(10L, List.of(3, 4));
+
+        // THEN
+        assertThat(jpa3.getActive()).isTrue();
+        assertThat(jpa4.getActive()).isTrue();
+        verify(locationJpaRepository).saveAll(List.of(jpa3, jpa4));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationPersistenceMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationPersistenceMapperTest.java
@@ -1,0 +1,82 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.location.application.usecase.QuoteLayoutData;
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocationPersistenceMapperTest {
+
+    private final LocationPersistenceMapper mapper = new LocationPersistenceMapper();
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    // QuoteJpa → QuoteLayoutData
+    @Test
+    void shouldMapQuoteJpaToQuoteLayoutData() {
+        // GIVEN
+        QuoteJpa jpa = QuoteJpa.builder()
+                .id(5L)
+                .folioNumber("FOL-2026-00042")
+                .numberOfLocations(3)
+                .locationType("MULTIPLE")
+                .version(2L)
+                .updatedAt(NOW)
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .build();
+
+        // WHEN
+        QuoteLayoutData data = mapper.toQuoteLayoutData(jpa);
+
+        // THEN
+        assertThat(data.id()).isEqualTo(5L);
+        assertThat(data.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(data.numberOfLocations()).isEqualTo(3);
+        assertThat(data.locationType()).isEqualTo("MULTIPLE");
+        assertThat(data.version()).isEqualTo(2L);
+        assertThat(data.updatedAt()).isEqualTo(NOW);
+    }
+
+    // Location domain → LocationJpa (new insert)
+    @Test
+    void shouldMapLocationToJpa_withActiveTrue() {
+        // GIVEN
+        Location location = new Location(2, true);
+
+        // WHEN
+        LocationJpa jpa = mapper.toLocationJpa(42L, location);
+
+        // THEN
+        assertThat(jpa.getQuoteId()).isEqualTo(42L);
+        assertThat(jpa.getIndex()).isEqualTo(2);
+        assertThat(jpa.getActive()).isTrue();
+        assertThat(jpa.getId()).isNull(); // new entity, no id yet
+    }
+
+    // LocationJpa → Location domain
+    @Test
+    void shouldMapLocationJpaToDomain() {
+        // GIVEN
+        LocationJpa jpa = LocationJpa.builder()
+                .id(7L)
+                .quoteId(42L)
+                .index(3)
+                .active(false)
+                .build();
+
+        // WHEN
+        Location location = mapper.toDomain(jpa);
+
+        // THEN
+        assertThat(location.index()).isEqualTo(3);
+        assertThat(location.active()).isFalse();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/QuoteLayoutJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/QuoteLayoutJpaAdapterTest.java
@@ -1,0 +1,101 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.QuoteLayoutData;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter.QuoteLayoutJpaAdapter;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class QuoteLayoutJpaAdapterTest {
+
+    @Mock
+    private QuoteJpaRepository quoteJpaRepository;
+
+    @Mock
+    private LocationPersistenceMapper mapper;
+
+    @InjectMocks
+    private QuoteLayoutJpaAdapter adapter;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    private QuoteJpa buildQuoteJpa(String folio, Integer numLoc, String locType, Long version) {
+        return QuoteJpa.builder()
+                .id(1L)
+                .folioNumber(folio)
+                .numberOfLocations(numLoc)
+                .locationType(locType)
+                .version(version)
+                .updatedAt(NOW)
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .build();
+    }
+
+    // findByFolioNumber — found
+    @Test
+    void shouldReturnQuoteLayoutData_whenFolioExists() {
+        // GIVEN
+        QuoteJpa jpa = buildQuoteJpa("FOL-2026-00042", 3, "MULTIPLE", 2L);
+        QuoteLayoutData expected = new QuoteLayoutData(1L, "FOL-2026-00042", 3, "MULTIPLE", 2L, NOW);
+        when(quoteJpaRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(jpa));
+        when(mapper.toQuoteLayoutData(jpa)).thenReturn(expected);
+
+        // WHEN
+        Optional<QuoteLayoutData> result = adapter.findByFolioNumber("FOL-2026-00042");
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().folioNumber()).isEqualTo("FOL-2026-00042");
+    }
+
+    // findByFolioNumber — not found
+    @Test
+    void shouldReturnEmpty_whenFolioDoesNotExist() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber("FOL-9999-99999")).thenReturn(Optional.empty());
+
+        // WHEN
+        Optional<QuoteLayoutData> result = adapter.findByFolioNumber("FOL-9999-99999");
+
+        // THEN
+        assertThat(result).isEmpty();
+        verify(mapper, never()).toQuoteLayoutData(any());
+    }
+
+    // save — updates numberOfLocations and locationType on the existing QuoteJpa
+    @Test
+    void shouldUpdateQuoteJpaAndReturnMappedData_whenSavingLayout() {
+        // GIVEN
+        QuoteJpa jpa = buildQuoteJpa("FOL-2026-00042", null, null, 1L);
+        QuoteLayoutData inputData = new QuoteLayoutData(1L, "FOL-2026-00042", 3, "MULTIPLE", 1L, NOW);
+        when(quoteJpaRepository.findById(1L)).thenReturn(Optional.of(jpa));
+        when(quoteJpaRepository.save(any(QuoteJpa.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(mapper.toQuoteLayoutData(any())).thenReturn(inputData);
+
+        // WHEN
+        QuoteLayoutData saved = adapter.save(inputData);
+
+        // THEN
+        ArgumentCaptor<QuoteJpa> captor = ArgumentCaptor.forClass(QuoteJpa.class);
+        verify(quoteJpaRepository).save(captor.capture());
+        QuoteJpa persisted = captor.getValue();
+        assertThat(persisted.getNumberOfLocations()).isEqualTo(3);
+        assertThat(persisted.getLocationType()).isEqualTo("MULTIPLE");
+        assertThat(saved).isEqualTo(inputData);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/integration/SaveLocationLayoutIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/integration/SaveLocationLayoutIntegrationTest.java
@@ -1,0 +1,216 @@
+package com.sofka.insurancequoter.back.location.integration;
+
+import com.sofka.insurancequoter.InsuranceQuoterApplication;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Integration tests without @Transactional so that @Version checks and commits happen correctly
+@SpringBootTest(classes = InsuranceQuoterApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Testcontainers
+class SaveLocationLayoutIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:16-alpine");
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private QuoteJpaRepository quoteJpaRepository;
+
+    @Autowired
+    private LocationJpaRepository locationJpaRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        // Clean state between tests — locations first (FK), then quotes
+        locationJpaRepository.deleteAll();
+        quoteJpaRepository.deleteAll();
+
+        QuoteJpa quote = QuoteJpa.builder()
+                .folioNumber("FOL-2026-IT-001")
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .build();
+        quoteJpaRepository.save(quote);
+    }
+
+    // CRITERIO-2.1: first save creates 3 empty locations
+    @Test
+    void shouldCreateLocations_whenSavingLayoutForFirstTime() throws Exception {
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "layoutConfiguration": {
+                                    "numberOfLocations": 3,
+                                    "locationType": "MULTIPLE"
+                                  },
+                                  "version": 0
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(3))
+                .andExpect(jsonPath("$.layoutConfiguration.locationType").value("MULTIPLE"));
+
+        Long quoteId = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getId();
+        assertThat(locationJpaRepository.findByQuoteIdAndActiveTrue(quoteId)).hasSize(3);
+    }
+
+    // CRITERIO-2.2: increasing locations appends new empty records
+    @Test
+    void shouldAddLocations_whenIncreasingNumberOfLocations() throws Exception {
+        // First save with 2
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":2,"locationType":"MULTIPLE"},"version":0}
+                                """))
+                .andExpect(status().isOk());
+
+        // Reload version after first save
+        long version = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getVersion();
+
+        // Second save increasing to 4
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":4,"locationType":"MULTIPLE"},"version":%d}
+                                """.formatted(version)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(4));
+
+        Long quoteId = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getId();
+        assertThat(locationJpaRepository.findByQuoteIdAndActiveTrue(quoteId)).hasSize(4);
+    }
+
+    // CRITERIO-2.3: reducing numberOfLocations marks excess as inactive
+    @Test
+    void shouldDeactivateLocations_whenReducingNumberOfLocations() throws Exception {
+        // First save with 4
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":4,"locationType":"MULTIPLE"},"version":0}
+                                """))
+                .andExpect(status().isOk());
+
+        long version = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getVersion();
+
+        // Reduce to 2
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":2,"locationType":"MULTIPLE"},"version":%d}
+                                """.formatted(version)))
+                .andExpect(status().isOk());
+
+        Long quoteId = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getId();
+        // 2 active, 2 inactive — total 4 rows preserved
+        assertThat(locationJpaRepository.findByQuoteIdAndActiveTrue(quoteId)).hasSize(2);
+        assertThat(locationJpaRepository.findAll()
+                .stream().filter(l -> l.getQuoteId().equals(quoteId))).hasSize(4);
+    }
+
+    // CRITERIO-2.4: stale version returns 409
+    @Test
+    void shouldReturn409_whenVersionIsStale() throws Exception {
+        // First save advances the version (0 → 1)
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":2,"locationType":"MULTIPLE"},"version":0}
+                                """))
+                .andExpect(status().isOk());
+
+        // Send stale version 0 again — must conflict
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":3,"locationType":"MULTIPLE"},"version":0}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("VERSION_CONFLICT"));
+    }
+
+    // R-005: reduce then increase must reactivate inactive rows, not violate UK constraint
+    @Test
+    void shouldReactivateLocations_whenIncreasingAfterPreviousReduction() throws Exception {
+        // Save with 4
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":4,"locationType":"MULTIPLE"},"version":0}
+                                """))
+                .andExpect(status().isOk());
+
+        long v1 = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getVersion();
+
+        // Reduce to 2 (indices 3,4 become inactive)
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":2,"locationType":"MULTIPLE"},"version":%d}
+                                """.formatted(v1)))
+                .andExpect(status().isOk());
+
+        long v2 = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getVersion();
+
+        // Increase back to 4 — must reactivate 3,4, not insert duplicates
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":4,"locationType":"MULTIPLE"},"version":%d}
+                                """.formatted(v2)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(4));
+
+        Long quoteId = quoteJpaRepository.findByFolioNumber("FOL-2026-IT-001").orElseThrow().getId();
+        // 4 active, total rows still 4 (no duplicate inserts)
+        assertThat(locationJpaRepository.findByQuoteIdAndActiveTrue(quoteId)).hasSize(4);
+        assertThat(locationJpaRepository.findByQuoteId(quoteId)).hasSize(4);
+    }
+
+    // GET returns layout after save
+    @Test
+    void shouldReturnLayout_whenGetAfterSave() throws Exception {
+        mockMvc.perform(put("/v1/quotes/FOL-2026-IT-001/locations/layout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"layoutConfiguration":{"numberOfLocations":3,"locationType":"MULTIPLE"},"version":0}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/v1/quotes/FOL-2026-IT-001/locations/layout"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-IT-001"))
+                .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(3))
+                .andExpect(jsonPath("$.layoutConfiguration.locationType").value("MULTIPLE"));
+    }
+}


### PR DESCRIPTION
## SPEC-003 — Configuración de Layout de Ubicaciones

### Cambios principales
- `GET/PUT /v1/quotes/{folio}/locations/layout`
- Nuevo bounded context `back.location` (hexagonal completo)
- Migraciones Flyway V3 (columnas en quotes) y V4 (tabla locations)
- Versionado optimista → 409 en conflicto de versión
- Credenciales removidas de compose.yaml y application.properties

### Fix crítico QA R-005
Corrige violación de UK_locations_quote_index en flujo reduce→increase.
Reactivar filas inactivas en lugar de insertar duplicados.
Cubierto con test de integración Testcontainers.

### Issues cerrados
Closes #46 #47 #48 #49 #50 #51 #52 #53 #54 #55 #56 #57 #58 #59 #60 #61 #62 #63 #64 #65 #66 #67 #68 #69 #70 #71 #72 #73 #74 #75 #76 #77 #78 #79 #80