### PR TITLE
feat(location): gestión de ubicaciones SPEC-004

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -3,3 +3,4 @@
 - [folio-generator feature — implementation state](project_folio_feature.md) — SPEC-001 implementado, compila. Estructura de paquetes, decisiones de diseño y archivos clave.
 - [Insurance-Quoter-Core — setup y configuración base](project_core_setup.md) — Paquete base, puerto, DB, dependencias reales del proyecto core.
 - [location-layout feature — implementation state](project_location_layout_feature.md) — SPEC-003 implementado. Decisiones de diseño: optimistic lock manual, sin @Transactional en integration test, GlobalExceptionHandler ampliado.
+- [location-management feature — implementation state](project_location_management_feature.md) — SPEC-004 implementado, issues #82-#118 cerrados. Input ports con records internos, AttributeConverter para JSONB, @WebMvcTest no existe en Spring Boot 4.

--- a/.claude/agent-memory/backend-developer/project_location_management_feature.md
+++ b/.claude/agent-memory/backend-developer/project_location_management_feature.md
@@ -1,0 +1,38 @@
+---
+name: location-management feature — implementation state
+description: SPEC-004 implementado y todos los issues cerrados (#82-#118). Decisiones de diseño y archivos clave.
+type: project
+---
+
+Feature location-management (SPEC-004) implementado completamente. Todos los issues #82-#118 cerrados (excepto #119-#125 que son QA).
+
+**Why:** Feature de gestión completa de ubicaciones por folio: GET/PUT/PATCH/summary con validación de CP contra core service.
+
+**How to apply:** Referencia de decisiones para features similares.
+
+## Decisiones de diseño relevantes
+
+- Input ports definen sus propios records internos (Command, Result) — no importan del paquete `application`. Esto cumple la regla de dependencia hexagonal (domain no depende de application).
+- `@WebMvcTest` no existe en Spring Boot 4 → usar `MockMvcBuilders.standaloneSetup()` con `@ExtendWith(MockitoExtension.class)`, igual que `FolioControllerTest`.
+- `guarantees` se serializa como TEXT/JSONB con `GuaranteesConverter implements AttributeConverter` + Jackson. Sin Hypersistence.
+- `@ElementCollection` para `blockingAlerts` → tabla `location_blocking_alerts` con FK a `locations.id ON DELETE CASCADE`.
+- `LocationJpaAdapter` ahora recibe `QuoteJpaRepository` por constructor para resolver folio→quoteId.
+- `QuoteVersionJpaAdapter` hace `quoteJpaRepository.save(quote)` para que Hibernate incremente `@Version` automáticamente.
+- El `@GetMapping("/summary")` se declara ANTES de `@GetMapping("/{index}")` en el controller para evitar conflicto de routing.
+- `PatchLocationRequest` usa `Optional<T>` en todos los campos opcionales con normalización en el canonical constructor (null → Optional.empty()).
+- `LocationValidationService` no es un `@Component` — se instancia como `@Bean` en `LocationConfig`.
+- V5 usa `TEXT` en lugar de `JSONB` para `guarantees` en la migración porque JPA no necesita el tipo JSONB nativo (el converter maneja la serialización).
+
+## Archivos clave creados/modificados
+
+- `V5__add_location_detail_columns.sql`, `V6__create_location_blocking_alerts_table.sql`
+- `location/domain/model/`: Location (reemplazado), BusinessLine, Guarantee, BlockingAlert, ValidationStatus, BlockingAlertCode, ZipCodeInfo, LocationSummary
+- `location/domain/service/LocationValidationService`
+- `location/domain/port/in/`: GetLocationsUseCase, ReplaceLocationsUseCase, PatchLocationUseCase, GetLocationsSummaryUseCase
+- `location/domain/port/out/`: LocationRepository (extendido), ZipCodeValidationClient, QuoteVersionRepository
+- `location/application/usecase/`: GetLocationsUseCaseImpl, ReplaceLocationsUseCaseImpl, PatchLocationUseCaseImpl, GetLocationsSummaryUseCaseImpl, VersionConflictException, LocationNotFoundException
+- `location/infrastructure/adapter/out/persistence/`: LocationJpa (extendido), BlockingAlertEmbeddable, GuaranteesConverter, LocationJpaRepository (extendido), LocationPersistenceMapper (extendido), LocationJpaAdapter (extendido), QuoteVersionJpaAdapter
+- `location/infrastructure/adapter/out/http/`: ZipCodeResponse, ZipCodeValidationClientAdapter
+- `location/infrastructure/adapter/in/rest/`: LocationController, LocationApi, LocationRestMapper, todos los DTOs request/response
+- `folio/infrastructure/adapter/in/rest/GlobalExceptionHandler` (extendido: VersionConflictException 409, LocationNotFoundException 404)
+- `location/infrastructure/config/LocationConfig`

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"316cb6a9-76da-4fee-893d-c0aae8cf9dbe","pid":13080,"acquiredAt":1776825542966}

--- a/.claude/specs/location-management.spec.md
+++ b/.claude/specs/location-management.spec.md
@@ -1,12 +1,12 @@
 ---
-id: SPEC-003
+id: SPEC-004
 status: DRAFT
 feature: location-management
 created: 2026-04-21
 updated: 2026-04-21
 author: spec-generator
-version: "1.0"
-related-specs: ["SPEC-002"]
+version: "1.1"
+related-specs: ["SPEC-002", "SPEC-003-location-layout"]
 ---
 
 # Spec: Gestión de Ubicaciones de Cotización
@@ -277,86 +277,89 @@ CRITERIO-4.2: Folio inexistente en summary
 
 ### Modelos de Datos
 
+#### Estado actual del código (post feature/location-layout)
+
+> **IMPORTANTE:** La tabla `locations` y la entidad `LocationJpa` ya existen desde el feature `location-layout` (V4). Esta spec los **extiende**, no los recrea.
+
+| Artefacto | Estado | Acción requerida |
+|-----------|--------|-----------------|
+| `LocationJpa` | existe — solo `id, quote_id, index, active, location_name, created_at, updated_at` | agregar columnas de detalle |
+| `LocationRepository` (port out) | existe — métodos de layout (`findActiveByQuoteId`, `insertAll`, etc.) | agregar métodos de gestión |
+| `Location` (domain model) | existe — solo `record Location(int index, boolean active)` | extender con campos completos |
+| tabla `locations` | existe con 7 columnas básicas (V4) | migración V5 agrega columnas |
+| tabla `location_blocking_alerts` | no existe | migración V6 la crea |
+| `LocationJpaAdapter` | existe — implementa métodos de layout | agregar implementación de nuevos métodos |
+
 #### Entidades afectadas
 
 | Entidad | Almacén | Cambios | Descripción |
 |---------|---------|---------|-------------|
-| `LocationJpa` | tabla `locations` en `insurance_quoter_db` (:5432) | nueva | Ubicación individual de una cotización |
-| `BlockingAlertEmbeddable` | `@ElementCollection` en `locations` → tabla `location_blocking_alerts` | nueva | Alerta bloqueante (code + message) embebida en ubicación |
-| `QuoteJpa` | tabla `quotes` | modificada | Agrega relación `@OneToMany` a `LocationJpa` |
+| `LocationJpa` | tabla `locations` | **modificada** — agregar columnas de detalle | Ubicación con datos completos |
+| `BlockingAlertEmbeddable` | tabla `location_blocking_alerts` | **nueva** — `@ElementCollection` en `LocationJpa` | Alerta bloqueante (code + message) |
+| `Location` | domain model | **modificada** — extender el record existente | Modelo de dominio completo |
 
-#### Campos de la tabla `locations`
+#### Columnas a AGREGAR a `locations` (migración V5 — ALTER TABLE)
 
-| Columna | Tipo SQL | Obligatorio | Constraint | Descripción |
-|---------|----------|-------------|------------|-------------|
-| `id` | `BIGSERIAL` | sí | PK | Identificador interno |
-| `quote_id` | `BIGINT` | sí | FK → quotes.id, NOT NULL | Cotización a la que pertenece |
-| `location_index` | `INT` | sí | NOT NULL | Índice 1-based dentro de la cotización |
-| `location_name` | `VARCHAR(255)` | no | — | Nombre descriptivo de la ubicación |
-| `address` | `VARCHAR(500)` | no | — | Dirección completa |
-| `zip_code` | `VARCHAR(10)` | no | — | Código postal (validado contra core) |
-| `state` | `VARCHAR(100)` | no | — | Estado (enriquecido desde core) |
-| `municipality` | `VARCHAR(100)` | no | — | Municipio (enriquecido desde core) |
-| `neighborhood` | `VARCHAR(100)` | no | — | Colonia seleccionada |
-| `city` | `VARCHAR(100)` | no | — | Ciudad (enriquecido desde core) |
-| `construction_type` | `VARCHAR(50)` | no | — | Tipo constructivo (ej. MASONRY) |
-| `level` | `INT` | no | — | Nivel o piso |
-| `construction_year` | `INT` | no | — | Año de construcción |
-| `business_line_code` | `VARCHAR(50)` | no | — | Código del giro |
-| `business_line_fire_key` | `VARCHAR(50)` | no | — | Clave incendio del giro |
-| `business_line_description` | `VARCHAR(255)` | no | — | Descripción del giro |
-| `guarantees` | `JSONB` | no | — | Array JSON de garantías [{code, insuredValue}] |
-| `catastrophic_zone` | `VARCHAR(50)` | no | — | Zona catastrófica (enriquecido desde core) |
-| `validation_status` | `VARCHAR(20)` | sí | NOT NULL, DEFAULT 'INCOMPLETE' | COMPLETE o INCOMPLETE |
+> Columnas ya existentes: `id, quote_id, index, active, location_name, created_at, updated_at`
 
-#### Campos de la tabla `location_blocking_alerts`
+| Columna nueva | Tipo SQL | Obligatorio | Descripción |
+|---------------|----------|-------------|-------------|
+| `address` | `VARCHAR(500)` | no | Dirección completa |
+| `zip_code` | `VARCHAR(10)` | no | Código postal (validado contra core) |
+| `state` | `VARCHAR(100)` | no | Estado (enriquecido desde core) |
+| `municipality` | `VARCHAR(100)` | no | Municipio (enriquecido desde core) |
+| `neighborhood` | `VARCHAR(100)` | no | Colonia seleccionada |
+| `city` | `VARCHAR(100)` | no | Ciudad (enriquecido desde core) |
+| `construction_type` | `VARCHAR(50)` | no | Tipo constructivo (ej. MASONRY) |
+| `level` | `INT` | no | Nivel o piso |
+| `construction_year` | `INT` | no | Año de construcción |
+| `business_line_code` | `VARCHAR(50)` | no | Código del giro |
+| `business_line_fire_key` | `VARCHAR(50)` | no | Clave incendio del giro |
+| `business_line_description` | `VARCHAR(255)` | no | Descripción del giro |
+| `guarantees` | `JSONB` | no | Array JSON de garantías [{code, insuredValue}] |
+| `catastrophic_zone` | `VARCHAR(50)` | no | Zona catastrófica (enriquecido desde core) |
+| `validation_status` | `VARCHAR(20)` | sí | COMPLETE o INCOMPLETE — DEFAULT 'INCOMPLETE' |
+
+#### Campos de la tabla `location_blocking_alerts` (migración V6 — nueva)
 
 | Columna | Tipo SQL | Obligatorio | Constraint | Descripción |
 |---------|----------|-------------|------------|-------------|
-| `location_id` | `BIGINT` | sí | FK → locations.id | Ubicación propietaria |
+| `location_id` | `BIGINT` | sí | FK → locations.id ON DELETE CASCADE | Ubicación propietaria |
 | `alert_code` | `VARCHAR(50)` | sí | NOT NULL | Código de la alerta |
 | `alert_message` | `VARCHAR(255)` | sí | NOT NULL | Mensaje legible |
 
 #### Índices / Constraints
 
-- `INDEX (quote_id)` — soporta la carga de ubicaciones por cotización (acceso frecuente)
-- `UNIQUE (quote_id, location_index)` — garantiza unicidad del índice dentro de la cotización
-- `FK locations(quote_id) REFERENCES quotes(id) ON DELETE CASCADE`
+- `IDX_locations_quote_id` ya existe (V4)
+- `UK_locations_quote_index` ya existe (V4)
+- `idx_location_alerts_location_id` — nuevo en V6
 
 #### Migraciones Flyway
 
 ```sql
--- V3__create_locations_table.sql
-CREATE TABLE IF NOT EXISTS locations (
-    id                       BIGSERIAL PRIMARY KEY,
-    quote_id                 BIGINT          NOT NULL REFERENCES quotes(id) ON DELETE CASCADE,
-    location_index           INT             NOT NULL,
-    location_name            VARCHAR(255),
-    address                  VARCHAR(500),
-    zip_code                 VARCHAR(10),
-    state                    VARCHAR(100),
-    municipality             VARCHAR(100),
-    neighborhood             VARCHAR(100),
-    city                     VARCHAR(100),
-    construction_type        VARCHAR(50),
-    level                    INT,
-    construction_year        INT,
-    business_line_code       VARCHAR(50),
-    business_line_fire_key   VARCHAR(50),
-    business_line_description VARCHAR(255),
-    guarantees               JSONB,
-    catastrophic_zone        VARCHAR(50),
-    validation_status        VARCHAR(20)     NOT NULL DEFAULT 'INCOMPLETE',
-    CONSTRAINT uq_location_index UNIQUE (quote_id, location_index)
-);
+-- V5__add_location_detail_columns.sql
+ALTER TABLE locations
+    ADD COLUMN IF NOT EXISTS address                  VARCHAR(500),
+    ADD COLUMN IF NOT EXISTS zip_code                 VARCHAR(10),
+    ADD COLUMN IF NOT EXISTS state                    VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS municipality             VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS neighborhood             VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS city                     VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS construction_type        VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS level                    INT,
+    ADD COLUMN IF NOT EXISTS construction_year        INT,
+    ADD COLUMN IF NOT EXISTS business_line_code       VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS business_line_fire_key   VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS business_line_description VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS guarantees               JSONB,
+    ADD COLUMN IF NOT EXISTS catastrophic_zone        VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS validation_status        VARCHAR(20) NOT NULL DEFAULT 'INCOMPLETE';
 
-CREATE INDEX IF NOT EXISTS idx_locations_quote_id ON locations (quote_id);
-
--- V4__create_location_blocking_alerts_table.sql
+-- V6__create_location_blocking_alerts_table.sql
 CREATE TABLE IF NOT EXISTS location_blocking_alerts (
-    location_id     BIGINT          NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
-    alert_code      VARCHAR(50)     NOT NULL,
-    alert_message   VARCHAR(255)    NOT NULL
+    location_id     BIGINT       NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+    alert_code      VARCHAR(50)  NOT NULL,
+    alert_message   VARCHAR(255) NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_location_alerts_location_id ON location_blocking_alerts (location_id);
@@ -364,10 +367,13 @@ CREATE INDEX IF NOT EXISTS idx_location_alerts_location_id ON location_blocking_
 
 #### Domain Models
 
+> `Location.java` ya existe como `record Location(int index, boolean active)`. Se reemplaza por versión extendida.
+
 ```java
-// location/domain/model/Location.java — POJO sin anotaciones JPA/Spring
+// location/domain/model/Location.java — REEMPLAZA el record existente
 public record Location(
     int index,
+    boolean active,
     String locationName,
     String address,
     String zipCode,
@@ -385,19 +391,19 @@ public record Location(
     List<BlockingAlert> blockingAlerts
 ) {}
 
-// location/domain/model/BusinessLine.java
+// location/domain/model/BusinessLine.java — nueva
 public record BusinessLine(String code, String fireKey, String description) {}
 
-// location/domain/model/Guarantee.java
+// location/domain/model/Guarantee.java — nueva
 public record Guarantee(String code, BigDecimal insuredValue) {}
 
-// location/domain/model/BlockingAlert.java
+// location/domain/model/BlockingAlert.java — nueva
 public record BlockingAlert(String code, String message) {}
 
-// location/domain/model/ValidationStatus.java
+// location/domain/model/ValidationStatus.java — nueva
 public enum ValidationStatus { COMPLETE, INCOMPLETE }
 
-// location/domain/model/BlockingAlertCode.java
+// location/domain/model/BlockingAlertCode.java — nueva
 public enum BlockingAlertCode {
     MISSING_ZIP_CODE,
     MISSING_FIRE_KEY,
@@ -732,20 +738,20 @@ LocationController.replaceLocations(folio, request)
 ### Backend
 
 #### Base de Datos
-- [ ] Crear migración `V3__create_locations_table.sql` — tabla `locations` con todos los campos, FK a `quotes`, UNIQUE `(quote_id, location_index)`
-- [ ] Crear migración `V4__create_location_blocking_alerts_table.sql` — tabla `location_blocking_alerts`, FK a `locations` con CASCADE
-- [ ] Crear índices: `idx_locations_quote_id`, `idx_location_alerts_location_id`
+- [ ] Crear migración `V5__add_location_detail_columns.sql` — `ALTER TABLE locations` agrega las 15 columnas de detalle listadas en el diseño
+- [ ] Crear migración `V6__create_location_blocking_alerts_table.sql` — tabla `location_blocking_alerts`, FK `locations.id` ON DELETE CASCADE, índice `idx_location_alerts_location_id`
 
 #### Dominio
-- [ ] Crear records `Location`, `BusinessLine`, `Guarantee`, `BlockingAlert` en `location/domain/model/`
-- [ ] Crear enums `ValidationStatus`, `BlockingAlertCode` en `location/domain/model/`
+- [ ] **Reemplazar** `Location.java` — extender el record existente (`int index, boolean active`) con todos los campos de detalle listados en el diseño
+- [ ] Crear records `BusinessLine`, `Guarantee`, `BlockingAlert` en `location/domain/model/` (nuevos)
+- [ ] Crear enums `ValidationStatus`, `BlockingAlertCode` en `location/domain/model/` (nuevos)
 - [ ] Crear `LocationValidationService` en `location/domain/service/` — método `calculateAlerts(Location, Optional<ZipCodeInfo>)`
 - [ ] Crear Input Port `GetLocationsUseCase` en `location/domain/port/in/`
 - [ ] Crear Input Port `ReplaceLocationsUseCase` en `location/domain/port/in/`
 - [ ] Crear Input Port `PatchLocationUseCase` en `location/domain/port/in/`
 - [ ] Crear Input Port `GetLocationsSummaryUseCase` en `location/domain/port/in/`
-- [ ] Crear Output Port `LocationRepository` en `location/domain/port/out/`
-- [ ] Crear Output Port `ZipCodeValidationClient` en `location/domain/port/out/`
+- [ ] **Extender** `LocationRepository` (port out existente) — agregar métodos: `findByFolioNumber`, `replaceAll`, `patchOne`, `findSummaryByFolioNumber`, `existsByFolioAndIndex`
+- [ ] Crear Output Port `ZipCodeValidationClient` en `location/domain/port/out/` (nuevo)
 
 #### Aplicación
 - [ ] Crear record `ReplaceLocationsCommand` en `location/application/usecase/command/`
@@ -757,11 +763,11 @@ LocationController.replaceLocations(folio, request)
 - [ ] Crear excepciones `FolioNotFoundException`, `LocationNotFoundException`, `VersionConflictException` (si no existen de SPEC-002)
 
 #### Infraestructura — Persistencia
-- [ ] Crear `BlockingAlertEmbeddable` en `location/infrastructure/adapter/out/persistence/entities/` — `@Embeddable`
-- [ ] Crear `LocationJpa` en `location/infrastructure/adapter/out/persistence/entities/` — `@Entity @Table(name = "locations")`, `@ManyToOne QuoteJpa`, `@ElementCollection` para alerts
-- [ ] Crear `LocationJpaRepository` en `location/infrastructure/adapter/out/persistence/repositories/` — extiende `JpaRepository<LocationJpa, Long>`; métodos: `findByQuoteJpa_FolioNumber`, `deleteByQuoteJpa_FolioNumber`
-- [ ] Crear `LocationPersistenceMapper` en `location/infrastructure/adapter/out/persistence/mappers/`
-- [ ] Crear `LocationJpaAdapter` en `location/infrastructure/adapter/out/persistence/adapter/` — implementa `LocationRepository`
+- [ ] Crear `BlockingAlertEmbeddable` en `location/infrastructure/adapter/out/persistence/entities/` — `@Embeddable` (nuevo)
+- [ ] **Extender** `LocationJpa` — agregar los 15 campos de detalle + `@ElementCollection` para `blockingAlerts` usando `BlockingAlertEmbeddable`
+- [ ] **Extender** `LocationJpaRepository` — agregar métodos necesarios para los nuevos casos de uso (ej. `findByQuoteId` con join fetch de alertas)
+- [ ] **Extender** `LocationPersistenceMapper` — mapear los nuevos campos de `Location ↔ LocationJpa`
+- [ ] **Extender** `LocationJpaAdapter` — implementar los nuevos métodos del port: `findByFolioNumber`, `replaceAll`, `patchOne`, `findSummaryByFolioNumber`, `existsByFolioAndIndex`
 
 #### Infraestructura — HTTP Client
 - [ ] Crear `ZipCodeResponse` DTO en `location/infrastructure/adapter/out/http/dto/`

--- a/.claude/specs/location-management.spec.md
+++ b/.claude/specs/location-management.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-004
-status: DRAFT
+status: IMPLEMENTED
 feature: location-management
 created: 2026-04-21
 updated: 2026-04-21

--- a/.claude/specs/location-management.spec.md
+++ b/.claude/specs/location-management.spec.md
@@ -1,0 +1,842 @@
+---
+id: SPEC-003
+status: DRAFT
+feature: location-management
+created: 2026-04-21
+updated: 2026-04-21
+author: spec-generator
+version: "1.0"
+related-specs: ["SPEC-002"]
+---
+
+# Spec: Gestión de Ubicaciones de Cotización
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+`Insurance-Quoter-Back` expone cuatro endpoints para gestionar las ubicaciones dentro de una cotización: listar todas las ubicaciones con su detalle completo, reemplazar la lista completa, actualizar parcialmente una ubicación específica y obtener un resumen de validación. En cada escritura se recalculan las alertas bloqueantes (`blockingAlerts`) y el estado de validación (`validationStatus`) de cada ubicación afectada, consultando el core service para validar el código postal.
+
+### Requerimiento de Negocio
+
+> - `GET /v1/quotes/{folio}/locations` — lista todas las ubicaciones de la cotización con su detalle completo.
+> - `PUT /v1/quotes/{folio}/locations` — reemplaza la lista completa de ubicaciones; recalcula alertas.
+> - `PATCH /v1/quotes/{folio}/locations/{index}` — actualización parcial de una ubicación; solo se aplican campos presentes en el body; recalcula alertas.
+> - `GET /v1/quotes/{folio}/locations/summary` — resumen de validación: solo `index`, `locationName`, `validationStatus` y `blockingAlerts`.
+> - Validar `zipCode` contra el core service (`GET /v1/zip-codes/{zipCode}`). Si inválido o ausente → alerta `MISSING_ZIP_CODE` + `validationStatus = INCOMPLETE`.
+> - Sin `businessLine.fireKey` → alerta `MISSING_FIRE_KEY`.
+> - Sin al menos una guarantee con `tarifable = true` → alerta `NO_TARIFABLE_GUARANTEES`.
+> - `blockingAlerts` se recalcula en cada escritura (PUT y PATCH).
+> - Entidades JPA: `LocationJpa` (tabla `locations`), alertas via `@ElementCollection` en `LocationJpa`.
+
+### Historias de Usuario
+
+#### HU-01: Consultar todas las ubicaciones de una cotización
+
+```
+Como:        agente de seguros
+Quiero:      llamar GET /v1/quotes/{folio}/locations
+Para:        visualizar el detalle completo de todas las ubicaciones registradas
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: SPEC-002 (Quote existe en la tabla quotes)
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Listado exitoso de ubicaciones
+  Dado que:  existe un folio "FOL-2026-00042" con dos ubicaciones registradas
+  Cuando:    se realiza GET /v1/quotes/FOL-2026-00042/locations
+  Entonces:  la respuesta tiene HTTP 200
+             Y el body contiene "folioNumber": "FOL-2026-00042"
+             Y "locations" es un array con los datos completos de ambas ubicaciones
+             Y cada ubicación incluye index, locationName, address, zipCode, state, municipality,
+               neighborhood, city, constructionType, level, constructionYear, businessLine,
+               guarantees, catastrophicZone, validationStatus y blockingAlerts
+             Y "version" refleja la versión actual de la cotización
+```
+
+**Error Path**
+```gherkin
+CRITERIO-1.2: Folio inexistente
+  Dado que:  el folio "FOL-9999-00001" no existe en la base de datos
+  Cuando:    se realiza GET /v1/quotes/FOL-9999-00001/locations
+  Entonces:  la respuesta tiene HTTP 404
+             Y el body es {"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-1.3: Cotización sin ubicaciones registradas
+  Dado que:  existe un folio "FOL-2026-00042" sin ubicaciones registradas
+  Cuando:    se realiza GET /v1/quotes/FOL-2026-00042/locations
+  Entonces:  la respuesta tiene HTTP 200
+             Y "locations" es un array vacío []
+```
+
+---
+
+#### HU-02: Reemplazar la lista completa de ubicaciones
+
+```
+Como:        agente de seguros
+Quiero:      llamar PUT /v1/quotes/{folio}/locations con la lista completa
+Para:        sobreescribir todas las ubicaciones y recalcular alertas bloqueantes
+
+Prioridad:   Alta
+Estimación:  M
+Dependencias: HU-01, SPEC-002
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-02
+
+**Happy Path — todas las ubicaciones completas**
+```gherkin
+CRITERIO-2.1: Reemplazo exitoso sin alertas
+  Dado que:  existe el folio "FOL-2026-00042" con version 4
+             Y cada ubicación enviada tiene zipCode válido, businessLine con fireKey y al menos una guarantee tarifable
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/locations con body válido y version 4
+  Entonces:  la respuesta tiene HTTP 200
+             Y "locations" refleja la nueva lista con validationStatus COMPLETE y blockingAlerts vacíos
+             Y "version" es 5
+             Y "updatedAt" es un timestamp ISO-8601 UTC
+```
+
+**Happy Path — ubicación con zipCode inválido**
+```gherkin
+CRITERIO-2.2: Reemplazo con zipCode inválido genera alerta
+  Dado que:  existe el folio "FOL-2026-00042" con version 4
+             Y una ubicación tiene zipCode "00000" que el core service no reconoce
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/locations con esa ubicación
+  Entonces:  la respuesta tiene HTTP 200
+             Y esa ubicación tiene validationStatus INCOMPLETE
+             Y blockingAlerts contiene {"code": "MISSING_ZIP_CODE", "message": "Código postal requerido"}
+```
+
+**Happy Path — sin fireKey**
+```gherkin
+CRITERIO-2.3: Reemplazo con businessLine sin fireKey genera alerta
+  Dado que:  una ubicación no tiene businessLine.fireKey
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/locations con esa ubicación
+  Entonces:  esa ubicación tiene blockingAlerts con {"code": "MISSING_FIRE_KEY", "message": "Clave incendio requerida"}
+             Y validationStatus INCOMPLETE
+```
+
+**Happy Path — sin guarantees tarifables**
+```gherkin
+CRITERIO-2.4: Reemplazo sin guarantees tarifables genera alerta
+  Dado que:  una ubicación no tiene guarantees o ninguna es tarifable
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/locations con esa ubicación
+  Entonces:  esa ubicación tiene blockingAlerts con {"code": "NO_TARIFABLE_GUARANTEES", "message": "Sin garantías tarifables"}
+             Y validationStatus INCOMPLETE
+```
+
+**Error Path — version conflict**
+```gherkin
+CRITERIO-2.5: Conflicto de versión optimista
+  Dado que:  la version actual del folio es 5
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/locations con version 4
+  Entonces:  la respuesta tiene HTTP 409
+             Y el body es {"error": "Optimistic lock conflict", "code": "VERSION_CONFLICT"}
+```
+
+**Error Path — folio inexistente**
+```gherkin
+CRITERIO-2.6: Folio inexistente en PUT
+  Dado que:  el folio "FOL-9999-00001" no existe
+  Cuando:    se realiza PUT /v1/quotes/FOL-9999-00001/locations con cualquier body
+  Entonces:  la respuesta tiene HTTP 404
+             Y el body contiene "code": "FOLIO_NOT_FOUND"
+```
+
+---
+
+#### HU-03: Actualización parcial de una ubicación
+
+```
+Como:        agente de seguros
+Quiero:      llamar PATCH /v1/quotes/{folio}/locations/{index} con solo los campos que cambian
+Para:        actualizar una ubicación sin sobreescribir los campos no enviados
+
+Prioridad:   Alta
+Estimación:  M
+Dependencias: HU-02, SPEC-002
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-03
+
+**Happy Path — actualización parcial exitosa**
+```gherkin
+CRITERIO-3.1: PATCH aplica solo los campos enviados
+  Dado que:  existe la ubicación con index 1 en el folio "FOL-2026-00042" con version 5
+             Y la ubicación tiene locationName "Bodega Norte", zipCode "06600" y constructionYear 1995
+  Cuando:    se realiza PATCH /v1/quotes/FOL-2026-00042/locations/1 con body {"locationName": "Almacén Central", "version": 5}
+  Entonces:  la respuesta tiene HTTP 200
+             Y "location.locationName" es "Almacén Central"
+             Y "location.zipCode" sigue siendo "06600" (no modificado)
+             Y "location.constructionYear" sigue siendo 1995 (no modificado)
+             Y "version" es 6
+             Y blockingAlerts se recalcula con el nuevo estado
+```
+
+**Happy Path — PATCH que corrige alerta**
+```gherkin
+CRITERIO-3.2: PATCH con zipCode válido elimina alerta MISSING_ZIP_CODE
+  Dado que:  la ubicación index 2 tiene blockingAlerts con MISSING_ZIP_CODE
+  Cuando:    se realiza PATCH /v1/quotes/FOL-2026-00042/locations/2 con {"zipCode": "06600", "version": 5}
+             Y el core service confirma que "06600" es válido
+  Entonces:  la respuesta tiene HTTP 200
+             Y "location.validationStatus" es COMPLETE (si no hay otras alertas)
+             Y blockingAlerts no contiene MISSING_ZIP_CODE
+```
+
+**Error Path — índice inexistente**
+```gherkin
+CRITERIO-3.3: Índice de ubicación no existe
+  Dado que:  la cotización tiene 2 ubicaciones (índices 1 y 2)
+  Cuando:    se realiza PATCH /v1/quotes/FOL-2026-00042/locations/5
+  Entonces:  la respuesta tiene HTTP 404
+             Y el body es {"error": "Location index not found", "code": "LOCATION_NOT_FOUND"}
+```
+
+**Error Path — version conflict en PATCH**
+```gherkin
+CRITERIO-3.4: Conflicto de versión en PATCH
+  Dado que:  la version actual del folio es 6
+  Cuando:    se realiza PATCH /v1/quotes/FOL-2026-00042/locations/1 con version 4
+  Entonces:  la respuesta tiene HTTP 409
+             Y el body contiene "code": "VERSION_CONFLICT"
+```
+
+---
+
+#### HU-04: Resumen de validación de ubicaciones
+
+```
+Como:        agente de seguros
+Quiero:      llamar GET /v1/quotes/{folio}/locations/summary
+Para:        visualizar rápidamente cuáles ubicaciones tienen alertas sin cargar el detalle completo
+
+Prioridad:   Media
+Estimación:  S
+Dependencias: HU-01
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-04
+
+**Happy Path**
+```gherkin
+CRITERIO-4.1: Resumen exitoso con ubicaciones mixtas
+  Dado que:  el folio "FOL-2026-00042" tiene 3 ubicaciones: 2 COMPLETE y 1 INCOMPLETE
+  Cuando:    se realiza GET /v1/quotes/FOL-2026-00042/locations/summary
+  Entonces:  la respuesta tiene HTTP 200
+             Y "totalLocations" es 3
+             Y "completeLocations" es 2
+             Y "incompleteLocations" es 1
+             Y "locations" contiene solo index, locationName, validationStatus y blockingAlerts
+             Y NO contiene campos como address, zipCode, constructionType, etc.
+```
+
+**Error Path**
+```gherkin
+CRITERIO-4.2: Folio inexistente en summary
+  Dado que:  el folio "FOL-9999-00001" no existe
+  Cuando:    se realiza GET /v1/quotes/FOL-9999-00001/locations/summary
+  Entonces:  la respuesta tiene HTTP 404
+             Y el body contiene "code": "FOLIO_NOT_FOUND"
+```
+
+### Reglas de Negocio
+
+1. **PATCH parcial:** solo se actualizan los campos explícitamente presentes en el body JSON. Campos ausentes conservan su valor previo.
+2. **Recálculo de alertas en escritura:** en cada PUT y PATCH se recalculan todas las `blockingAlerts` de la(s) ubicación(es) afectada(s) desde cero antes de persistir.
+3. **Validación de zipCode:** el backend llama `GET /v1/zip-codes/{zipCode}` al core service (puerto 8081). Si la respuesta es 404 o el campo `valid` es `false`, se agrega la alerta `MISSING_ZIP_CODE`.
+4. **Alerta MISSING_FIRE_KEY:** se agrega si `businessLine` está ausente o si `businessLine.fireKey` está vacío o nulo.
+5. **Alerta NO_TARIFABLE_GUARANTEES:** se agrega si la lista `guarantees` está vacía o si ninguna guarantee consultada al core service tiene `tarifable = true`.
+6. **validationStatus:** `COMPLETE` si `blockingAlerts` está vacío; `INCOMPLETE` si contiene al menos una alerta.
+7. **Versionado optimista:** el campo `version` en el request debe coincidir con el valor almacenado; si difiere → HTTP 409 `VERSION_CONFLICT`.
+8. **Enriquecimiento de zipCode:** al validar un zipCode exitosamente, se llenan automáticamente `state`, `municipality`, `city` y `catastrophicZone` con los datos del core service.
+9. **Summary no incluye versión:** `GET /summary` no expone `version` — es una proyección de solo lectura.
+10. **Scope del @Version:** el versionado optimista se mantiene en `QuoteJpa` (aggregate raíz), no en `LocationJpa`. Cada escritura de ubicaciones incrementa la versión de la `Quote`.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Almacén | Cambios | Descripción |
+|---------|---------|---------|-------------|
+| `LocationJpa` | tabla `locations` en `insurance_quoter_db` (:5432) | nueva | Ubicación individual de una cotización |
+| `BlockingAlertEmbeddable` | `@ElementCollection` en `locations` → tabla `location_blocking_alerts` | nueva | Alerta bloqueante (code + message) embebida en ubicación |
+| `QuoteJpa` | tabla `quotes` | modificada | Agrega relación `@OneToMany` a `LocationJpa` |
+
+#### Campos de la tabla `locations`
+
+| Columna | Tipo SQL | Obligatorio | Constraint | Descripción |
+|---------|----------|-------------|------------|-------------|
+| `id` | `BIGSERIAL` | sí | PK | Identificador interno |
+| `quote_id` | `BIGINT` | sí | FK → quotes.id, NOT NULL | Cotización a la que pertenece |
+| `location_index` | `INT` | sí | NOT NULL | Índice 1-based dentro de la cotización |
+| `location_name` | `VARCHAR(255)` | no | — | Nombre descriptivo de la ubicación |
+| `address` | `VARCHAR(500)` | no | — | Dirección completa |
+| `zip_code` | `VARCHAR(10)` | no | — | Código postal (validado contra core) |
+| `state` | `VARCHAR(100)` | no | — | Estado (enriquecido desde core) |
+| `municipality` | `VARCHAR(100)` | no | — | Municipio (enriquecido desde core) |
+| `neighborhood` | `VARCHAR(100)` | no | — | Colonia seleccionada |
+| `city` | `VARCHAR(100)` | no | — | Ciudad (enriquecido desde core) |
+| `construction_type` | `VARCHAR(50)` | no | — | Tipo constructivo (ej. MASONRY) |
+| `level` | `INT` | no | — | Nivel o piso |
+| `construction_year` | `INT` | no | — | Año de construcción |
+| `business_line_code` | `VARCHAR(50)` | no | — | Código del giro |
+| `business_line_fire_key` | `VARCHAR(50)` | no | — | Clave incendio del giro |
+| `business_line_description` | `VARCHAR(255)` | no | — | Descripción del giro |
+| `guarantees` | `JSONB` | no | — | Array JSON de garantías [{code, insuredValue}] |
+| `catastrophic_zone` | `VARCHAR(50)` | no | — | Zona catastrófica (enriquecido desde core) |
+| `validation_status` | `VARCHAR(20)` | sí | NOT NULL, DEFAULT 'INCOMPLETE' | COMPLETE o INCOMPLETE |
+
+#### Campos de la tabla `location_blocking_alerts`
+
+| Columna | Tipo SQL | Obligatorio | Constraint | Descripción |
+|---------|----------|-------------|------------|-------------|
+| `location_id` | `BIGINT` | sí | FK → locations.id | Ubicación propietaria |
+| `alert_code` | `VARCHAR(50)` | sí | NOT NULL | Código de la alerta |
+| `alert_message` | `VARCHAR(255)` | sí | NOT NULL | Mensaje legible |
+
+#### Índices / Constraints
+
+- `INDEX (quote_id)` — soporta la carga de ubicaciones por cotización (acceso frecuente)
+- `UNIQUE (quote_id, location_index)` — garantiza unicidad del índice dentro de la cotización
+- `FK locations(quote_id) REFERENCES quotes(id) ON DELETE CASCADE`
+
+#### Migraciones Flyway
+
+```sql
+-- V3__create_locations_table.sql
+CREATE TABLE IF NOT EXISTS locations (
+    id                       BIGSERIAL PRIMARY KEY,
+    quote_id                 BIGINT          NOT NULL REFERENCES quotes(id) ON DELETE CASCADE,
+    location_index           INT             NOT NULL,
+    location_name            VARCHAR(255),
+    address                  VARCHAR(500),
+    zip_code                 VARCHAR(10),
+    state                    VARCHAR(100),
+    municipality             VARCHAR(100),
+    neighborhood             VARCHAR(100),
+    city                     VARCHAR(100),
+    construction_type        VARCHAR(50),
+    level                    INT,
+    construction_year        INT,
+    business_line_code       VARCHAR(50),
+    business_line_fire_key   VARCHAR(50),
+    business_line_description VARCHAR(255),
+    guarantees               JSONB,
+    catastrophic_zone        VARCHAR(50),
+    validation_status        VARCHAR(20)     NOT NULL DEFAULT 'INCOMPLETE',
+    CONSTRAINT uq_location_index UNIQUE (quote_id, location_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_locations_quote_id ON locations (quote_id);
+
+-- V4__create_location_blocking_alerts_table.sql
+CREATE TABLE IF NOT EXISTS location_blocking_alerts (
+    location_id     BIGINT          NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+    alert_code      VARCHAR(50)     NOT NULL,
+    alert_message   VARCHAR(255)    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_location_alerts_location_id ON location_blocking_alerts (location_id);
+```
+
+#### Domain Models
+
+```java
+// location/domain/model/Location.java — POJO sin anotaciones JPA/Spring
+public record Location(
+    int index,
+    String locationName,
+    String address,
+    String zipCode,
+    String state,
+    String municipality,
+    String neighborhood,
+    String city,
+    String constructionType,
+    Integer level,
+    Integer constructionYear,
+    BusinessLine businessLine,
+    List<Guarantee> guarantees,
+    String catastrophicZone,
+    ValidationStatus validationStatus,
+    List<BlockingAlert> blockingAlerts
+) {}
+
+// location/domain/model/BusinessLine.java
+public record BusinessLine(String code, String fireKey, String description) {}
+
+// location/domain/model/Guarantee.java
+public record Guarantee(String code, BigDecimal insuredValue) {}
+
+// location/domain/model/BlockingAlert.java
+public record BlockingAlert(String code, String message) {}
+
+// location/domain/model/ValidationStatus.java
+public enum ValidationStatus { COMPLETE, INCOMPLETE }
+
+// location/domain/model/BlockingAlertCode.java
+public enum BlockingAlertCode {
+    MISSING_ZIP_CODE,
+    MISSING_FIRE_KEY,
+    NO_TARIFABLE_GUARANTEES
+}
+```
+
+### API Endpoints
+
+#### GET /v1/quotes/{folio}/locations
+
+- **Descripción:** Lista todas las ubicaciones con detalle completo
+- **Auth requerida:** no
+- **Path param:** `folio` — número de folio (ej. `FOL-2026-00042`)
+- **Response 200:**
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "locations": [
+      {
+        "index": 1,
+        "locationName": "Bodega Principal",
+        "address": "Av. Insurgentes 1000",
+        "zipCode": "06600",
+        "state": "Ciudad de México",
+        "municipality": "Cuauhtémoc",
+        "neighborhood": "Juárez",
+        "city": "Ciudad de México",
+        "constructionType": "MASONRY",
+        "level": 2,
+        "constructionYear": 1995,
+        "businessLine": {
+          "code": "BL-001",
+          "fireKey": "FK-INC-01",
+          "description": "Bodega de mercancías"
+        },
+        "guarantees": [
+          { "code": "GUA-FIRE", "insuredValue": 5000000 }
+        ],
+        "catastrophicZone": "ZONE_A",
+        "validationStatus": "COMPLETE",
+        "blockingAlerts": []
+      }
+    ],
+    "version": 4
+  }
+  ```
+- **Response 404:** `{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}`
+
+---
+
+#### PUT /v1/quotes/{folio}/locations
+
+- **Descripción:** Reemplaza la lista completa de ubicaciones y recalcula alertas
+- **Auth requerida:** no
+- **Request Body:**
+  ```json
+  {
+    "locations": [
+      {
+        "index": 1,
+        "locationName": "Bodega Principal",
+        "address": "Av. Insurgentes 1000",
+        "zipCode": "06600",
+        "constructionType": "MASONRY",
+        "level": 2,
+        "constructionYear": 1995,
+        "businessLine": { "code": "BL-001", "fireKey": "FK-INC-01" },
+        "guarantees": [{ "code": "GUA-FIRE", "insuredValue": 5000000 }]
+      }
+    ],
+    "version": 4
+  }
+  ```
+- **Response 200:**
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "locations": [ { "...detalle completo con validationStatus y blockingAlerts..." } ],
+    "updatedAt": "2026-04-21T15:30:00Z",
+    "version": 5
+  }
+  ```
+- **Response 404:** `{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}`
+- **Response 409:** `{"error": "Optimistic lock conflict", "code": "VERSION_CONFLICT"}`
+- **Response 422:** `{"error": "Validation failed", "code": "VALIDATION_ERROR", "fields": [...]}`
+
+---
+
+#### PATCH /v1/quotes/{folio}/locations/{index}
+
+- **Descripción:** Actualización parcial — solo campos presentes en el body
+- **Auth requerida:** no
+- **Path params:** `folio`, `index` (entero 1-based)
+- **Request Body** (todos los campos son opcionales salvo `version`):
+  ```json
+  {
+    "locationName": "Bodega Norte",
+    "zipCode": "44100",
+    "guarantees": [{ "code": "GUA-FIRE", "insuredValue": 7000000 }],
+    "version": 5
+  }
+  ```
+- **Response 200:**
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "location": {
+      "index": 1,
+      "locationName": "Bodega Norte",
+      "zipCode": "44100",
+      "validationStatus": "COMPLETE",
+      "blockingAlerts": [],
+      "...resto de campos sin modificar..."
+    },
+    "updatedAt": "2026-04-21T15:35:00Z",
+    "version": 6
+  }
+  ```
+- **Response 404 (folio):** `{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}`
+- **Response 404 (location):** `{"error": "Location index not found", "code": "LOCATION_NOT_FOUND"}`
+- **Response 409:** `{"error": "Optimistic lock conflict", "code": "VERSION_CONFLICT"}`
+
+---
+
+#### GET /v1/quotes/{folio}/locations/summary
+
+- **Descripción:** Resumen de validación — proyección reducida sin detalle de campos
+- **Auth requerida:** no
+- **Response 200:**
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "totalLocations": 3,
+    "completeLocations": 2,
+    "incompleteLocations": 1,
+    "locations": [
+      {
+        "index": 1,
+        "locationName": "Bodega Principal",
+        "validationStatus": "COMPLETE",
+        "blockingAlerts": []
+      },
+      {
+        "index": 2,
+        "locationName": "Oficina Sur",
+        "validationStatus": "INCOMPLETE",
+        "blockingAlerts": [
+          { "code": "MISSING_ZIP_CODE", "message": "Código postal requerido" },
+          { "code": "MISSING_FIRE_KEY", "message": "Clave incendio requerida" }
+        ]
+      }
+    ]
+  }
+  ```
+- **Response 404:** `{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}`
+
+---
+
+### Arquitectura Hexagonal — Descomposición de Componentes
+
+#### Contexto: `location`
+
+```
+com.sofka.insurancequoter.back.location/
+├── domain/
+│   ├── model/
+│   │   ├── Location.java                              ← Record (todos los campos)
+│   │   ├── BusinessLine.java                          ← Record (code, fireKey, description)
+│   │   ├── Guarantee.java                             ← Record (code, insuredValue)
+│   │   ├── BlockingAlert.java                         ← Record (code, message)
+│   │   ├── BlockingAlertCode.java                     ← Enum: MISSING_ZIP_CODE, MISSING_FIRE_KEY, NO_TARIFABLE_GUARANTEES
+│   │   └── ValidationStatus.java                     ← Enum: COMPLETE, INCOMPLETE
+│   ├── service/
+│   │   └── LocationValidationService.java            ← Domain service: recalcula blockingAlerts dado los datos + result de zipCode
+│   └── port/
+│       ├── in/
+│       │   ├── GetLocationsUseCase.java               ← Input Port: LocationsResponse getLocations(String folio)
+│       │   ├── ReplaceLocationsUseCase.java           ← Input Port: LocationsResponse replaceLocations(ReplaceLocationsCommand)
+│       │   ├── PatchLocationUseCase.java              ← Input Port: LocationPatchResponse patchLocation(PatchLocationCommand)
+│       │   └── GetLocationsSummaryUseCase.java        ← Input Port: LocationsSummaryResponse getSummary(String folio)
+│       └── out/
+│           ├── LocationRepository.java               ← Output Port: findByFolio / replaceAll / patchOne / findSummaryByFolio
+│           ├── QuoteVersionRepository.java           ← Output Port: findVersionByFolio / incrementVersion
+│           └── ZipCodeValidationClient.java          ← Output Port: ZipCodeInfo validate(String zipCode)
+├── application/
+│   └── usecase/
+│       ├── GetLocationsUseCaseImpl.java
+│       ├── ReplaceLocationsUseCaseImpl.java          ← Orquesta: validar versión → validar cada ubicación → recalcular alertas → persistir
+│       ├── PatchLocationUseCaseImpl.java             ← Orquesta: buscar ubicación → merge parcial → validar → recalcular alertas → persistir
+│       ├── GetLocationsSummaryUseCaseImpl.java
+│       ├── command/
+│       │   ├── ReplaceLocationsCommand.java          ← Record: folio, locations, version
+│       │   └── PatchLocationCommand.java             ← Record: folio, index, patch fields (todos Optional<>), version
+│       └── dto/
+│           ├── LocationsResponse.java
+│           ├── LocationPatchResponse.java
+│           └── LocationsSummaryResponse.java
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/
+    │   │   └── rest/
+    │   │       ├── LocationController.java            ← implementa LocationApi
+    │   │       ├── swaggerdocs/
+    │   │       │   └── LocationApi.java               ← @Tag Locations; @Operation por endpoint
+    │   │       ├── dto/
+    │   │       │   ├── request/
+    │   │       │   │   ├── ReplaceLocationsRequest.java
+    │   │       │   │   ├── LocationItemRequest.java
+    │   │       │   │   ├── BusinessLineRequest.java
+    │   │       │   │   ├── GuaranteeRequest.java
+    │   │       │   │   └── PatchLocationRequest.java  ← todos los campos son Optional<> excepto version
+    │   │       │   └── response/
+    │   │       │       ├── LocationsListResponse.java
+    │   │       │       ├── LocationDetailResponse.java
+    │   │       │       ├── LocationSummaryItemResponse.java
+    │   │       │       ├── BlockingAlertResponse.java
+    │   │       │       └── LocationsSummaryWrapperResponse.java
+    │   │       └── mapper/
+    │   │           └── LocationRestMapper.java
+    │   └── out/
+    │       ├── persistence/
+    │       │   ├── adapter/
+    │       │   │   └── LocationJpaAdapter.java        ← implementa LocationRepository
+    │       │   ├── repositories/
+    │       │   │   └── LocationJpaRepository.java     ← extiende JpaRepository<LocationJpa, Long>
+    │       │   ├── entities/
+    │       │   │   ├── LocationJpa.java               ← @Entity tabla locations; @ManyToOne QuoteJpa
+    │       │   │   └── BlockingAlertEmbeddable.java   ← @Embeddable para @ElementCollection
+    │       │   └── mappers/
+    │       │       └── LocationPersistenceMapper.java ← Location ↔ LocationJpa
+    │       └── http/
+    │           ├── adapter/
+    │           │   └── ZipCodeValidationClientAdapter.java ← implementa ZipCodeValidationClient; llama GET /v1/zip-codes/{zipCode} al core
+    │           └── dto/
+    │               └── ZipCodeResponse.java           ← {zipCode, state, municipality, city, catastrophicZone, valid}
+    └── config/
+        └── LocationConfig.java                        ← @Bean wiring de los 4 use cases + RestClient para core
+```
+
+#### Contratos de interfaces clave
+
+```java
+// domain/port/in/GetLocationsUseCase.java
+public interface GetLocationsUseCase {
+    LocationsResponse getLocations(String folioNumber);
+}
+
+// domain/port/in/ReplaceLocationsUseCase.java
+public interface ReplaceLocationsUseCase {
+    LocationsResponse replaceLocations(ReplaceLocationsCommand command);
+}
+
+// domain/port/in/PatchLocationUseCase.java
+public interface PatchLocationUseCase {
+    LocationPatchResponse patchLocation(PatchLocationCommand command);
+}
+
+// domain/port/in/GetLocationsSummaryUseCase.java
+public interface GetLocationsSummaryUseCase {
+    LocationsSummaryResponse getSummary(String folioNumber);
+}
+
+// domain/port/out/LocationRepository.java
+public interface LocationRepository {
+    List<Location> findByFolioNumber(String folioNumber);
+    List<Location> replaceAll(String folioNumber, List<Location> locations);
+    Location patchOne(String folioNumber, int index, Location mergedLocation);
+    List<LocationSummary> findSummaryByFolioNumber(String folioNumber);
+    boolean existsByFolioAndIndex(String folioNumber, int index);
+}
+
+// domain/port/out/ZipCodeValidationClient.java
+public interface ZipCodeValidationClient {
+    Optional<ZipCodeInfo> validate(String zipCode);  // empty si 404 o invalid
+}
+
+// domain/service/LocationValidationService.java
+public class LocationValidationService {
+    public List<BlockingAlert> calculateAlerts(Location location, Optional<ZipCodeInfo> zipCodeInfo) {
+        // Returns list of blocking alerts based on validation rules
+    }
+    public ValidationStatus deriveValidationStatus(List<BlockingAlert> alerts) {
+        return alerts.isEmpty() ? ValidationStatus.COMPLETE : ValidationStatus.INCOMPLETE;
+    }
+}
+```
+
+#### Flujo de llamada — PUT (reemplazo)
+
+```
+LocationController.replaceLocations(folio, request)
+  → ReplaceLocationsUseCase.replaceLocations(command)
+      1. QuoteVersionRepository.findVersionByFolio(folio) → verificar version == command.version; si no → VersionConflictException
+      2. Para cada location en command.locations:
+         a. ZipCodeValidationClient.validate(location.zipCode)         ← llamada al core si zipCode presente
+         b. LocationValidationService.calculateAlerts(location, zipInfo)← calcula MISSING_ZIP_CODE, MISSING_FIRE_KEY, NO_TARIFABLE_GUARANTEES
+         c. location.withValidationStatus(derived) y location.withBlockingAlerts(alerts)
+      3. LocationRepository.replaceAll(folio, enrichedLocations)
+      4. QuoteVersionRepository.incrementVersion(folio)
+      5. return LocationsResponse
+  ← ResponseEntity<LocationsListResponse>(200)
+```
+
+#### Manejo de excepciones
+
+| Excepción de dominio | HTTP | Código |
+|---------------------|------|--------|
+| `FolioNotFoundException` | 404 | `FOLIO_NOT_FOUND` |
+| `LocationNotFoundException` | 404 | `LOCATION_NOT_FOUND` |
+| `VersionConflictException` | 409 | `VERSION_CONFLICT` |
+| `MethodArgumentNotValidException` | 422 | `VALIDATION_ERROR` |
+
+> `GlobalExceptionHandler` (ya existente de SPEC-002) debe agregar handlers para `LocationNotFoundException` y `VersionConflictException`.
+
+### Notas de Implementación
+
+- **PATCH con `Optional<>`:** `PatchLocationRequest` usa `Optional<String>`, `Optional<Integer>`, etc. para distinguir campo ausente (no enviar) de campo nulo (borrar). Alternativa: usar `JsonNullable` de OpenAPI Generator o un `Map<String, Object>`. El enfoque con `Optional<>` + Jackson `@JsonInclude(NON_NULL)` es suficiente para este caso.
+- **`guarantees` como JSONB:** la serialización/deserialización de la lista de garantías como JSONB en PostgreSQL requiere un `@Type(JsonType.class)` de Hypersistence (o un `@Convert` con `AttributeConverter<List<Guarantee>, String>`). Evaluar si ya existe la dependencia en el proyecto.
+- **`@ElementCollection` para blockingAlerts:** `BlockingAlertEmbeddable` con `@CollectionTable(name = "location_blocking_alerts")`. Hibernate borra y reinserta toda la colección en cada save — es el comportamiento esperado dado que las alertas se recalculan siempre desde cero.
+- **Orden de routing:** Spring MVC puede confundir `GET /v1/quotes/{folio}/locations/summary` con `GET /v1/quotes/{folio}/locations/{index}` si ambos están en el mismo controller. Usar `@GetMapping("/summary")` antes que `@GetMapping("/{index}")`, o asegurar que `summary` no sea un entero válido para `{index}`.
+- **`QuoteVersionRepository`:** reutilizar el `QuoteJpaRepository` ya existente de SPEC-002 para leer/actualizar el campo `version` de `quotes`. No crear un nuevo repositorio JPA; exponer un método en el output port o compartir el `QuoteRepository` existente.
+- **`ZipCodeValidationClientAdapter`:** debe manejar el caso en que el core service retorne 404 como `Optional.empty()`, sin lanzar excepción — la alerta la pone `LocationValidationService`.
+- **Migración Flyway:** las migraciones V3 y V4 deben ir en `src/main/resources/db/migration/`. Verificar que V1 y V2 ya existan por SPEC-001/SPEC-002 antes de nombrar.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable. Marcar cada ítem (`[x]`) al completarlo.
+
+### Backend
+
+#### Base de Datos
+- [ ] Crear migración `V3__create_locations_table.sql` — tabla `locations` con todos los campos, FK a `quotes`, UNIQUE `(quote_id, location_index)`
+- [ ] Crear migración `V4__create_location_blocking_alerts_table.sql` — tabla `location_blocking_alerts`, FK a `locations` con CASCADE
+- [ ] Crear índices: `idx_locations_quote_id`, `idx_location_alerts_location_id`
+
+#### Dominio
+- [ ] Crear records `Location`, `BusinessLine`, `Guarantee`, `BlockingAlert` en `location/domain/model/`
+- [ ] Crear enums `ValidationStatus`, `BlockingAlertCode` en `location/domain/model/`
+- [ ] Crear `LocationValidationService` en `location/domain/service/` — método `calculateAlerts(Location, Optional<ZipCodeInfo>)`
+- [ ] Crear Input Port `GetLocationsUseCase` en `location/domain/port/in/`
+- [ ] Crear Input Port `ReplaceLocationsUseCase` en `location/domain/port/in/`
+- [ ] Crear Input Port `PatchLocationUseCase` en `location/domain/port/in/`
+- [ ] Crear Input Port `GetLocationsSummaryUseCase` en `location/domain/port/in/`
+- [ ] Crear Output Port `LocationRepository` en `location/domain/port/out/`
+- [ ] Crear Output Port `ZipCodeValidationClient` en `location/domain/port/out/`
+
+#### Aplicación
+- [ ] Crear record `ReplaceLocationsCommand` en `location/application/usecase/command/`
+- [ ] Crear record `PatchLocationCommand` en `location/application/usecase/command/` — campos con `Optional<>`
+- [ ] Crear `GetLocationsUseCaseImpl` en `location/application/usecase/`
+- [ ] Crear `ReplaceLocationsUseCaseImpl` en `location/application/usecase/` — validar versión → validar zip → calcular alertas → persistir
+- [ ] Crear `PatchLocationUseCaseImpl` en `location/application/usecase/` — buscar → merge → validar → calcular alertas → persistir
+- [ ] Crear `GetLocationsSummaryUseCaseImpl` en `location/application/usecase/`
+- [ ] Crear excepciones `FolioNotFoundException`, `LocationNotFoundException`, `VersionConflictException` (si no existen de SPEC-002)
+
+#### Infraestructura — Persistencia
+- [ ] Crear `BlockingAlertEmbeddable` en `location/infrastructure/adapter/out/persistence/entities/` — `@Embeddable`
+- [ ] Crear `LocationJpa` en `location/infrastructure/adapter/out/persistence/entities/` — `@Entity @Table(name = "locations")`, `@ManyToOne QuoteJpa`, `@ElementCollection` para alerts
+- [ ] Crear `LocationJpaRepository` en `location/infrastructure/adapter/out/persistence/repositories/` — extiende `JpaRepository<LocationJpa, Long>`; métodos: `findByQuoteJpa_FolioNumber`, `deleteByQuoteJpa_FolioNumber`
+- [ ] Crear `LocationPersistenceMapper` en `location/infrastructure/adapter/out/persistence/mappers/`
+- [ ] Crear `LocationJpaAdapter` en `location/infrastructure/adapter/out/persistence/adapter/` — implementa `LocationRepository`
+
+#### Infraestructura — HTTP Client
+- [ ] Crear `ZipCodeResponse` DTO en `location/infrastructure/adapter/out/http/dto/`
+- [ ] Crear `ZipCodeValidationClientAdapter` en `location/infrastructure/adapter/out/http/adapter/` — implementa `ZipCodeValidationClient`; llama `GET /v1/zip-codes/{zipCode}` al core; retorna `Optional.empty()` si 404
+
+#### Infraestructura — REST
+- [ ] Crear DTOs de request: `ReplaceLocationsRequest`, `LocationItemRequest`, `BusinessLineRequest`, `GuaranteeRequest`, `PatchLocationRequest` en `location/infrastructure/adapter/in/rest/dto/request/`
+- [ ] Crear DTOs de response: `LocationsListResponse`, `LocationDetailResponse`, `LocationSummaryItemResponse`, `BlockingAlertResponse`, `LocationsSummaryWrapperResponse` en `location/infrastructure/adapter/in/rest/dto/response/`
+- [ ] Crear `LocationRestMapper` en `location/infrastructure/adapter/in/rest/mapper/`
+- [ ] Crear Swagger interface `LocationApi` en `location/infrastructure/adapter/in/rest/swaggerdocs/` — `@Tag`, `@Operation` para los 4 endpoints
+- [ ] Crear `LocationController` en `location/infrastructure/adapter/in/rest/` — implementa `LocationApi`; inyecta los 4 use cases y mapper
+- [ ] Actualizar `GlobalExceptionHandler` — agregar handlers para `LocationNotFoundException` → 404 `LOCATION_NOT_FOUND`, `VersionConflictException` → 409 `VERSION_CONFLICT`
+
+#### Configuración
+- [ ] Crear `LocationConfig` en `location/infrastructure/config/` — `@Bean` wiring de los 4 use cases y `ZipCodeValidationClientAdapter`
+
+#### Tests Backend (TDD — escribir el test ANTES de la implementación)
+
+**LocationValidationService**
+- [ ] `LocationValidationServiceTest` — zipCode nulo/ausente → alerta MISSING_ZIP_CODE
+- [ ] `LocationValidationServiceTest` — zipCode inválido (Optional.empty del client) → alerta MISSING_ZIP_CODE
+- [ ] `LocationValidationServiceTest` — businessLine sin fireKey → alerta MISSING_FIRE_KEY
+- [ ] `LocationValidationServiceTest` — businessLine null → alerta MISSING_FIRE_KEY
+- [ ] `LocationValidationServiceTest` — sin guarantees → alerta NO_TARIFABLE_GUARANTEES
+- [ ] `LocationValidationServiceTest` — todas las guarantees no tarifables → alerta NO_TARIFABLE_GUARANTEES
+- [ ] `LocationValidationServiceTest` — datos completos y válidos → sin alertas, validationStatus COMPLETE
+
+**GetLocationsUseCaseImpl**
+- [ ] `GetLocationsUseCaseImplTest` — folio existente → retorna lista de ubicaciones
+- [ ] `GetLocationsUseCaseImplTest` — folio inexistente → lanza FolioNotFoundException
+
+**ReplaceLocationsUseCaseImpl**
+- [ ] `ReplaceLocationsUseCaseImplTest` — version conflict → lanza VersionConflictException sin persistir
+- [ ] `ReplaceLocationsUseCaseImplTest` — reemplazo exitoso con zipCode válido → persistido con validationStatus COMPLETE y version incrementada
+- [ ] `ReplaceLocationsUseCaseImplTest` — reemplazo con zipCode inválido → MISSING_ZIP_CODE en resultado
+- [ ] `ReplaceLocationsUseCaseImplTest` — reemplazo sin fireKey → MISSING_FIRE_KEY en resultado
+- [ ] `ReplaceLocationsUseCaseImplTest` — reemplazo sin guarantees tarifables → NO_TARIFABLE_GUARANTEES en resultado
+- [ ] `ReplaceLocationsUseCaseImplTest` — múltiples ubicaciones: algunas completas, otras incompletas
+
+**PatchLocationUseCaseImpl**
+- [ ] `PatchLocationUseCaseImplTest` — index inexistente → lanza LocationNotFoundException
+- [ ] `PatchLocationUseCaseImplTest` — version conflict → lanza VersionConflictException
+- [ ] `PatchLocationUseCaseImplTest` — patch parcial: solo locationName → resto de campos sin cambio
+- [ ] `PatchLocationUseCaseImplTest` — patch con zipCode válido → alerta MISSING_ZIP_CODE eliminada
+- [ ] `PatchLocationUseCaseImplTest` — patch con zipCode inválido → alerta MISSING_ZIP_CODE presente
+
+**GetLocationsSummaryUseCaseImpl**
+- [ ] `GetLocationsSummaryUseCaseImplTest` — folio existente → totales correctos y proyección reducida
+- [ ] `GetLocationsSummaryUseCaseImplTest` — folio inexistente → lanza FolioNotFoundException
+
+**LocationJpaAdapter**
+- [ ] `LocationJpaAdapterTest` — findByFolioNumber retorna lista vacía si no hay ubicaciones
+- [ ] `LocationJpaAdapterTest` — replaceAll elimina existentes y persiste nuevas
+- [ ] `LocationJpaAdapterTest` — patchOne actualiza solo la ubicación con el index dado
+
+**LocationController**
+- [ ] `LocationControllerTest` — GET /v1/quotes/{folio}/locations → HTTP 200 con locations
+- [ ] `LocationControllerTest` — GET /v1/quotes/{folio}/locations con folio inexistente → HTTP 404
+- [ ] `LocationControllerTest` — PUT /v1/quotes/{folio}/locations → HTTP 200 con version incrementada
+- [ ] `LocationControllerTest` — PUT con version conflict → HTTP 409
+- [ ] `LocationControllerTest` — PATCH /v1/quotes/{folio}/locations/{index} → HTTP 200 con campo actualizado
+- [ ] `LocationControllerTest` — PATCH con index inexistente → HTTP 404 LOCATION_NOT_FOUND
+- [ ] `LocationControllerTest` — GET /v1/quotes/{folio}/locations/summary → HTTP 200 solo con campos de resumen
+
+**Tests de integración**
+- [ ] `LocationManagementIntegrationTest` — `@SpringBootTest` + Testcontainers PostgreSQL + WireMock para core: PUT luego GET retorna datos persistidos
+- [ ] `LocationManagementIntegrationTest` — PUT con zipCode inválido: WireMock retorna 404 para core → alerta MISSING_ZIP_CODE en respuesta
+- [ ] `LocationManagementIntegrationTest` — PATCH parcial preserva campos no enviados
+- [ ] `LocationManagementIntegrationTest` — GET summary retorna conteos correctos
+
+### QA
+- [ ] Ejecutar skill `/gherkin-case-generator` → escenarios para CRITERIO-1.1…4.2
+- [ ] Ejecutar skill `/risk-identifier` → clasificación ASD (concurrencia en version, core unavailable, JSONB serialization)
+- [ ] Validar manualmente con Bruno/Postman: los 4 endpoints
+- [ ] Verificar que blockingAlerts se recalcula correctamente en cada escritura
+- [ ] Verificar que GET /summary NO retorna campos de detalle (address, zipCode, etc.)
+- [ ] Verificar que PATCH no sobreescribe campos no enviados
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/docs/output/qa/location-management-gherkin.md
+++ b/docs/output/qa/location-management-gherkin.md
@@ -1,0 +1,331 @@
+# Escenarios Gherkin — Gestión de Ubicaciones (SPEC-004)
+
+> Generado desde los criterios de aceptación CRITERIO-1.1…4.2
+> Feature: `location-management` | Spec: `SPEC-004`
+
+---
+
+```gherkin
+#language: es
+Característica: Gestión de ubicaciones de cotización
+  Como agente de seguros
+  Quiero gestionar las ubicaciones de una cotización
+  Para registrar los datos completos de cada inmueble y conocer su estado de validación
+
+  Antecedentes:
+    Dado que el sistema tiene un folio activo "FOL-2026-00042" con versión 4
+    Y el core service responde en "http://localhost:8081"
+
+  # ─────────────────────────────────────────────
+  # HU-01: Consultar todas las ubicaciones
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @HU-01 @CRITERIO-1.1
+  Escenario: Listado exitoso de ubicaciones con detalle completo
+    Dado que el folio "FOL-2026-00042" tiene dos ubicaciones registradas
+      | index | locationName     | zipCode | businessLine.fireKey | validationStatus |
+      | 1     | Bodega Principal | 06600   | FK-INC-01            | COMPLETE         |
+      | 2     | Oficina Sur      | 44100   | FK-COM-02            | COMPLETE         |
+    Cuando se consultan las ubicaciones del folio "FOL-2026-00042"
+    Entonces la respuesta es HTTP 200
+    Y el cuerpo contiene el folio "FOL-2026-00042"
+    Y "locations" es un arreglo con 2 elementos
+    Y cada ubicación incluye los campos: index, locationName, address, zipCode, state,
+      municipality, neighborhood, city, constructionType, level, constructionYear,
+      businessLine, guarantees, catastrophicZone, validationStatus y blockingAlerts
+    Y "version" refleja la versión actual de la cotización
+
+  @error-path @HU-01 @CRITERIO-1.2
+  Escenario: Consulta de ubicaciones con folio inexistente retorna 404
+    Dado que el folio "FOL-9999-00001" no existe en el sistema
+    Cuando se consultan las ubicaciones del folio "FOL-9999-00001"
+    Entonces la respuesta es HTTP 404
+    Y el cuerpo contiene '{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}'
+
+  @edge-case @HU-01 @CRITERIO-1.3
+  Escenario: Consulta de ubicaciones cuando la cotización no tiene ubicaciones registradas
+    Dado que el folio "FOL-2026-00042" existe pero no tiene ubicaciones registradas
+    Cuando se consultan las ubicaciones del folio "FOL-2026-00042"
+    Entonces la respuesta es HTTP 200
+    Y "locations" es un arreglo vacío
+
+  # ─────────────────────────────────────────────
+  # HU-02: Reemplazar lista completa de ubicaciones
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @HU-02 @CRITERIO-2.1
+  Escenario: Reemplazo exitoso de ubicaciones sin alertas
+    Dado que el folio "FOL-2026-00042" tiene versión 4
+    Y el core service valida que el código postal "06600" es válido
+      y retorna estado "Ciudad de México", municipio "Cuauhtémoc", zona catastrófica "ZONE_A"
+    Cuando se reemplaza la lista de ubicaciones del folio "FOL-2026-00042" con versión 4
+      | index | locationName     | zipCode | businessLine.code | businessLine.fireKey | guarantee.code | insuredValue |
+      | 1     | Bodega Principal | 06600   | BL-001            | FK-INC-01            | GUA-FIRE       | 5000000      |
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].validationStatus" es "COMPLETE"
+    Y "locations[0].blockingAlerts" es vacío
+    Y "version" es 5
+    Y "updatedAt" tiene formato ISO-8601 UTC
+
+  @happy-path @HU-02 @CRITERIO-2.2
+  Escenario: Reemplazo con código postal inválido genera alerta MISSING_ZIP_CODE
+    Dado que el folio "FOL-2026-00042" tiene versión 4
+    Y el core service retorna 404 para el código postal "00000"
+    Cuando se reemplaza la lista de ubicaciones con una ubicación que tiene zipCode "00000"
+      y versión 4
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].validationStatus" es "INCOMPLETE"
+    Y "locations[0].blockingAlerts" contiene el código "MISSING_ZIP_CODE"
+      con mensaje "Código postal requerido"
+
+  @happy-path @HU-02 @CRITERIO-2.3
+  Escenario: Reemplazo con businessLine sin clave incendio genera alerta MISSING_FIRE_KEY
+    Dado que el folio "FOL-2026-00042" tiene versión 4
+    Y una ubicación no tiene fireKey en su businessLine
+    Cuando se reemplaza la lista de ubicaciones con esa ubicación y versión 4
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].validationStatus" es "INCOMPLETE"
+    Y "locations[0].blockingAlerts" contiene el código "MISSING_FIRE_KEY"
+      con mensaje "Clave incendio requerida"
+
+  @happy-path @HU-02 @CRITERIO-2.4
+  Escenario: Reemplazo sin garantías tarifables genera alerta NO_TARIFABLE_GUARANTEES
+    Dado que el folio "FOL-2026-00042" tiene versión 4
+    Y una ubicación no tiene guarantees registradas
+    Cuando se reemplaza la lista de ubicaciones con esa ubicación y versión 4
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].validationStatus" es "INCOMPLETE"
+    Y "locations[0].blockingAlerts" contiene el código "NO_TARIFABLE_GUARANTEES"
+      con mensaje "Sin garantías tarifables"
+
+  @happy-path @HU-02 @CRITERIO-2.4b
+  Escenario: Reemplazo con guarantees ninguna tarifable también genera alerta
+    Dado que el folio "FOL-2026-00042" tiene versión 4
+    Y una ubicación tiene guarantees pero ninguna con tarifable igual a true
+    Cuando se reemplaza la lista de ubicaciones con esa ubicación y versión 4
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].blockingAlerts" contiene el código "NO_TARIFABLE_GUARANTEES"
+
+  @error-path @HU-02 @CRITERIO-2.5
+  Escenario: Conflicto de versión optimista en reemplazo retorna 409
+    Dado que el folio "FOL-2026-00042" tiene versión actual 5
+    Cuando se reemplaza la lista de ubicaciones con versión 4 (desactualizada)
+    Entonces la respuesta es HTTP 409
+    Y el cuerpo contiene '{"error": "Optimistic lock conflict", "code": "VERSION_CONFLICT"}'
+    Y no se persiste ningún cambio
+
+  @error-path @HU-02 @CRITERIO-2.6
+  Escenario: Reemplazo de ubicaciones con folio inexistente retorna 404
+    Dado que el folio "FOL-9999-00001" no existe en el sistema
+    Cuando se reemplaza la lista de ubicaciones del folio "FOL-9999-00001"
+    Entonces la respuesta es HTTP 404
+    Y el cuerpo contiene '{"code": "FOLIO_NOT_FOUND"}'
+
+  @edge-case @HU-02
+  Escenario: Reemplazo con múltiples ubicaciones mezcla de completas e incompletas
+    Dado que el folio "FOL-2026-00042" tiene versión 4
+    Y el core service valida "06600" como válido
+    Y el core service retorna 404 para "00000"
+    Cuando se reemplaza la lista con dos ubicaciones
+      | index | locationName     | zipCode | businessLine.fireKey |
+      | 1     | Bodega Principal | 06600   | FK-INC-01            |
+      | 2     | Almacén Inválido | 00000   | (ausente)            |
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].validationStatus" es "COMPLETE"
+    Y "locations[1].validationStatus" es "INCOMPLETE"
+    Y "locations[1].blockingAlerts" contiene "MISSING_ZIP_CODE" y "MISSING_FIRE_KEY"
+
+  # ─────────────────────────────────────────────
+  # HU-03: Actualización parcial de una ubicación
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @HU-03 @CRITERIO-3.1
+  Escenario: PATCH aplica solo los campos enviados y preserva los demás
+    Dado que el folio "FOL-2026-00042" tiene versión 5
+    Y la ubicación con índice 1 tiene locationName "Bodega Norte", zipCode "06600"
+      y constructionYear 1995
+    Cuando se actualiza parcialmente la ubicación índice 1 con solo locationName "Almacén Central"
+      y versión 5
+    Entonces la respuesta es HTTP 200
+    Y "location.locationName" es "Almacén Central"
+    Y "location.zipCode" sigue siendo "06600"
+    Y "location.constructionYear" sigue siendo 1995
+    Y "version" es 6
+    Y "blockingAlerts" se recalcula con el nuevo estado de la ubicación
+
+  @happy-path @HU-03 @CRITERIO-3.2
+  Escenario: PATCH con código postal válido elimina alerta MISSING_ZIP_CODE
+    Dado que el folio "FOL-2026-00042" tiene versión 5
+    Y la ubicación con índice 2 tiene blockingAlerts con "MISSING_ZIP_CODE"
+    Y el core service valida que "06600" es válido
+    Cuando se actualiza parcialmente la ubicación índice 2 con zipCode "06600" y versión 5
+    Entonces la respuesta es HTTP 200
+    Y "location.validationStatus" es "COMPLETE"
+    Y "location.blockingAlerts" no contiene "MISSING_ZIP_CODE"
+    Y "location.state", "location.municipality" y "location.city" se enriquecen con datos del core
+
+  @error-path @HU-03 @CRITERIO-3.3
+  Escenario: PATCH con índice de ubicación inexistente retorna 404
+    Dado que el folio "FOL-2026-00042" tiene 2 ubicaciones con índices 1 y 2
+    Cuando se actualiza parcialmente la ubicación con índice 5
+    Entonces la respuesta es HTTP 404
+    Y el cuerpo contiene '{"error": "Location index not found", "code": "LOCATION_NOT_FOUND"}'
+
+  @error-path @HU-03 @CRITERIO-3.4
+  Escenario: Conflicto de versión en actualización parcial retorna 409
+    Dado que el folio "FOL-2026-00042" tiene versión actual 6
+    Cuando se actualiza parcialmente la ubicación índice 1 con versión 4 (desactualizada)
+    Entonces la respuesta es HTTP 409
+    Y el cuerpo contiene '{"code": "VERSION_CONFLICT"}'
+
+  @edge-case @HU-03
+  Escenario: PATCH que corrige businessLine con fireKey elimina alerta MISSING_FIRE_KEY
+    Dado que la ubicación índice 1 tiene alerta "MISSING_FIRE_KEY"
+    Y el folio "FOL-2026-00042" tiene versión 5
+    Cuando se actualiza parcialmente con businessLine que incluye fireKey "FK-INC-01" y versión 5
+    Entonces la respuesta es HTTP 200
+    Y "location.blockingAlerts" no contiene "MISSING_FIRE_KEY"
+
+  @edge-case @HU-03
+  Escenario: PATCH con zipCode inválido agrega alerta MISSING_ZIP_CODE
+    Dado que la ubicación índice 1 está COMPLETE en el folio "FOL-2026-00042" con versión 5
+    Y el core service retorna 404 para el código postal "99999"
+    Cuando se actualiza parcialmente la ubicación índice 1 con zipCode "99999" y versión 5
+    Entonces la respuesta es HTTP 200
+    Y "location.validationStatus" es "INCOMPLETE"
+    Y "location.blockingAlerts" contiene "MISSING_ZIP_CODE"
+
+  # ─────────────────────────────────────────────
+  # HU-04: Resumen de validación de ubicaciones
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @HU-04 @CRITERIO-4.1
+  Escenario: Resumen de validación muestra conteos correctos y solo campos de resumen
+    Dado que el folio "FOL-2026-00042" tiene 3 ubicaciones
+      | index | locationName     | validationStatus |
+      | 1     | Bodega Principal | COMPLETE         |
+      | 2     | Oficina Sur      | COMPLETE         |
+      | 3     | Almacén Inválido | INCOMPLETE       |
+    Y la ubicación 3 tiene alertas "MISSING_ZIP_CODE" y "MISSING_FIRE_KEY"
+    Cuando se consulta el resumen de validación del folio "FOL-2026-00042"
+    Entonces la respuesta es HTTP 200
+    Y "totalLocations" es 3
+    Y "completeLocations" es 2
+    Y "incompleteLocations" es 1
+    Y cada elemento de "locations" contiene solo: index, locationName, validationStatus, blockingAlerts
+    Y ningún elemento de "locations" contiene: address, zipCode, constructionType,
+      constructionYear, businessLine, guarantees, catastrophicZone, state, municipality
+    Y "locations[2].blockingAlerts" contiene "MISSING_ZIP_CODE" y "MISSING_FIRE_KEY"
+
+  @error-path @HU-04 @CRITERIO-4.2
+  Escenario: Resumen de validación con folio inexistente retorna 404
+    Dado que el folio "FOL-9999-00001" no existe en el sistema
+    Cuando se consulta el resumen de validación del folio "FOL-9999-00001"
+    Entonces la respuesta es HTTP 404
+    Y el cuerpo contiene '{"code": "FOLIO_NOT_FOUND"}'
+
+  @edge-case @HU-04
+  Escenario: Resumen de validación sin ubicaciones registradas
+    Dado que el folio "FOL-2026-00042" existe pero no tiene ubicaciones
+    Cuando se consulta el resumen de validación del folio "FOL-2026-00042"
+    Entonces la respuesta es HTTP 200
+    Y "totalLocations" es 0
+    Y "completeLocations" es 0
+    Y "incompleteLocations" es 0
+    Y "locations" es un arreglo vacío
+
+  # ─────────────────────────────────────────────
+  # Reglas de negocio transversales
+  # ─────────────────────────────────────────────
+
+  @edge-case @regla-negocio
+  Escenario: blockingAlerts se recalcula desde cero en cada escritura
+    Dado que la ubicación índice 1 tenía alerta "MISSING_ZIP_CODE"
+    Y el folio "FOL-2026-00042" tiene versión 5
+    Cuando se reemplaza la lista completa con la ubicación índice 1 ahora con zipCode válido,
+      businessLine con fireKey y al menos una guarantee
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].blockingAlerts" es vacío
+    Y "locations[0].validationStatus" es "COMPLETE"
+
+  @edge-case @regla-negocio
+  Escenario: Enriquecimiento automático de datos geográficos al validar código postal
+    Dado que el core service valida "44100" como válido
+      y retorna estado "Jalisco", municipio "Guadalajara", ciudad "Guadalajara", zona catastrófica "ZONE_B"
+    Cuando se reemplaza la lista con una ubicación con zipCode "44100"
+    Entonces la respuesta es HTTP 200
+    Y "locations[0].state" es "Jalisco"
+    Y "locations[0].municipality" es "Guadalajara"
+    Y "locations[0].city" es "Guadalajara"
+    Y "locations[0].catastrophicZone" es "ZONE_B"
+```
+
+---
+
+## Datos de Prueba Sintéticos
+
+| Escenario | Campo | Valor válido | Valor inválido | Borde |
+|-----------|-------|-------------|----------------|-------|
+| Validación zipCode | `zipCode` | `"06600"` (CDMX) / `"44100"` (GDL) | `"00000"` (core 404) | `"99999"` (desconocido) |
+| Versión optimista | `version` | versión actual del folio | versión anterior | `0` |
+| Índice de ubicación | `index` | `1`, `2` (existentes) | `5` (inexistente) | `0` (fuera de rango) |
+| fireKey | `businessLine.fireKey` | `"FK-INC-01"` | `null` / `""` | `" "` (espacio) |
+| Guarantees tarifables | `guarantees` | `[{"code": "GUA-FIRE", "insuredValue": 5000000}]` | `[]` (vacío) | lista con tarifable=false |
+| locationName (PATCH) | `locationName` | `"Almacén Central"` | — | `null` (no enviar) |
+
+### Folios de prueba
+
+| Folio | Estado | Versión | Uso |
+|-------|--------|---------|-----|
+| `FOL-2026-00042` | CREATED | 4 | Happy paths HU-01..04 |
+| `FOL-2026-00099` | CREATED | 5 | Escenarios con version conflict |
+| `FOL-9999-00001` | (inexistente) | — | Error paths 404 |
+
+### Respuestas WireMock para core service
+
+```json
+// GET /v1/zip-codes/06600 → 200
+{
+  "zipCode": "06600",
+  "state": "Ciudad de México",
+  "municipality": "Cuauhtémoc",
+  "city": "Ciudad de México",
+  "catastrophicZone": "ZONE_A",
+  "valid": true
+}
+
+// GET /v1/zip-codes/44100 → 200
+{
+  "zipCode": "44100",
+  "state": "Jalisco",
+  "municipality": "Guadalajara",
+  "city": "Guadalajara",
+  "catastrophicZone": "ZONE_B",
+  "valid": true
+}
+
+// GET /v1/zip-codes/00000 → 404
+// GET /v1/zip-codes/99999 → 404
+```
+
+---
+
+## Cobertura por criterio
+
+| Criterio | Escenario Gherkin | Etiquetas |
+|----------|-------------------|-----------|
+| CRITERIO-1.1 | Listado exitoso con detalle completo | `@smoke @critico @HU-01` |
+| CRITERIO-1.2 | Folio inexistente en GET | `@error-path @HU-01` |
+| CRITERIO-1.3 | GET sin ubicaciones → array vacío | `@edge-case @HU-01` |
+| CRITERIO-2.1 | Reemplazo exitoso → COMPLETE | `@smoke @critico @HU-02` |
+| CRITERIO-2.2 | zipCode inválido → MISSING_ZIP_CODE | `@happy-path @HU-02` |
+| CRITERIO-2.3 | Sin fireKey → MISSING_FIRE_KEY | `@happy-path @HU-02` |
+| CRITERIO-2.4 | Sin guarantees → NO_TARIFABLE_GUARANTEES | `@happy-path @HU-02` |
+| CRITERIO-2.5 | Version conflict PUT → 409 | `@error-path @HU-02` |
+| CRITERIO-2.6 | Folio inexistente en PUT | `@error-path @HU-02` |
+| CRITERIO-3.1 | PATCH parcial preserva campos | `@smoke @critico @HU-03` |
+| CRITERIO-3.2 | PATCH zipCode válido elimina alerta | `@happy-path @HU-03` |
+| CRITERIO-3.3 | Índice inexistente → 404 | `@error-path @HU-03` |
+| CRITERIO-3.4 | Version conflict PATCH → 409 | `@error-path @HU-03` |
+| CRITERIO-4.1 | Summary: conteos y proyección reducida | `@smoke @critico @HU-04` |
+| CRITERIO-4.2 | Folio inexistente en summary | `@error-path @HU-04` |

--- a/docs/output/qa/location-management-risks.md
+++ b/docs/output/qa/location-management-risks.md
@@ -1,0 +1,120 @@
+# Matriz de Riesgos — Gestión de Ubicaciones (SPEC-004)
+
+> Generado por `/risk-identifier` | Feature: `location-management`
+> Spec: `SPEC-004` | Fecha: 2026-04-21
+
+---
+
+## Resumen
+
+Total: 10 | Alto (A): 4 | Medio (S): 4 | Bajo (D): 2
+
+---
+
+## Detalle
+
+| ID    | HU           | Descripción del Riesgo                                                                 | Factores                                              | Nivel | Testing       |
+|-------|--------------|----------------------------------------------------------------------------------------|-------------------------------------------------------|-------|---------------|
+| R-001 | HU-02 / HU-03| Operación `replaceAll` elimina todas las ubicaciones y reinserta; sin rollback parcial visible si falla a mitad de la transacción | Operación destructiva irrecuperable, integridad transaccional | **A** | Obligatorio |
+| R-002 | HU-02 / HU-03| Versionado optimista manual: la verificación `version == command.version` corre ANTES de persistir; condición de carrera si dos requests concurrentes leen la misma versión simultáneamente antes de que ninguno haya incrementado | Concurrencia, integraciones, SLA | **A** | Obligatorio |
+| R-003 | HU-02 / HU-03| Integración con core service (`GET /v1/zip-codes/{zipCode}`): si core no responde → alerta MISSING_ZIP_CODE incorrecta; si responde con datos parciales → enriquecimiento geográfico incompleto (`state`, `municipality`, `city`, `catastrophicZone`) | Integración con sistema externo | **A** | Obligatorio |
+| R-004 | HU-02 / HU-03| Serialización JSONB de `guarantees` via `AttributeConverter` Jackson: deserialización silenciosa puede retornar lista vacía si el JSON en BD es inválido, disparando falsa alerta `NO_TARIFABLE_GUARANTEES` | Lógica de negocio compleja, código nuevo sin historial | **A** | Obligatorio |
+| R-005 | HU-03        | Merge parcial en PATCH: campo no enviado (`Optional.empty`) debe preservarse exactamente; un error de lógica en el merge puede silenciosamente borrar datos persistidos | Lógica compleja, alta frecuencia de uso | **S** | Recomendado |
+| R-006 | HU-02 / HU-03| `@ElementCollection` de `blockingAlerts`: Hibernate borra y reinserta la colección completa en cada save; si la transacción falla después del delete y antes del insert, la ubicación queda sin alertas (estado inconsistente) | Operación destructiva, integridad transaccional | **S** | Recomendado |
+| R-007 | HU-04        | Routing ambiguo: `GET /v1/quotes/{folio}/locations/summary` vs `GET /v1/quotes/{folio}/locations/{index}`; si Spring MVC resuelve `/summary` como `index="summary"` → 400 o comportamiento inesperado | Código nuevo sin historial, lógica de routing | **S** | Recomendado |
+| R-008 | HU-02 / HU-03| Recálculo de alertas siempre desde cero: si una alerta fue corregida pero otra regla falla simultáneamente, el resultado acumulado puede diferir del esperado por el agente | Lógica de negocio compleja, múltiples reglas que interactúan | **S** | Recomendado |
+| R-009 | HU-04        | `GET /summary` no debe exponer `version`: si un mapper mapea todos los campos por defecto, la versión puede filtrarse inadvertidamente, exponiendo dato de control interno | Feature interna de proyección | **D** | Opcional |
+| R-010 | HU-01        | `GET /locations` devuelve detalle completo incluyendo `guarantees` como array JSON; si la serialización incluye tipos numéricos incorrectos para `insuredValue` (`String` vs `Number`) → contrato roto con el frontend | Ajuste de serialización, sin cambio de lógica | **D** | Opcional |
+
+---
+
+## Plan de Mitigación — Riesgos ALTO
+
+---
+
+### R-001: Operación replaceAll destructiva sin rollback parcial
+
+**Descripción:** `LocationJpaAdapter.replaceAll` ejecuta un DELETE masivo seguido de INSERTs. Si la transacción no está correctamente delimitada (`@Transactional` en el use case impl o en el adapter), un fallo entre el DELETE y el INSERT deja la cotización sin ubicaciones — dato irrecuperable sin respaldo.
+
+**Mitigación:**
+- Verificar que `replaceAll` corre dentro de una única transacción (`@Transactional` en el use case o en el JPA adapter).
+- Test de integración que simula fallo en INSERT después de DELETE (forzando excepción) y verifica que el rollback restaura el estado previo.
+- No usar `deleteAll + saveAll` en dos llamadas separadas fuera de un mismo `@Transactional`.
+
+**Tests obligatorios:**
+- `LocationManagementIntegrationTest` — transaction rollback: PUT que falla a mitad → GET posterior retorna las ubicaciones originales.
+- `LocationJpaAdapterTest` — `replaceAll` ejecuta ambas operaciones en la misma transacción.
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+### R-002: Condición de carrera en versionado optimista manual
+
+**Descripción:** El use case lee la versión actual con `QuoteVersionRepository.findVersionByFolioNumber`, la compara con `command.version`, y solo entonces persiste. Si dos threads concurrentes superan la validación simultáneamente (ambos leen version=4, ambos validan OK), el segundo save puede sobrescribir al primero sin disparar 409.
+
+**Mitigación:**
+- La comparación manual es una pre-validación de UX (error más descriptivo). El control final de concurrencia lo garantiza `@Version` de Hibernate en `QuoteJpa` — el segundo save lanza `ObjectOptimisticLockingFailureException` que el `GlobalExceptionHandler` traduce a 409.
+- Verificar que `@Version` en `QuoteJpa` esté correctamente mapeado y que `incrementVersion` use un `save()` que dispare el incremento de Hibernate.
+- Test de integración con dos threads concurrentes sobre el mismo folio.
+
+**Tests obligatorios:**
+- `ReplaceLocationsUseCaseImplTest` — version conflict en check manual → `VersionConflictException`.
+- `LocationManagementIntegrationTest` — dos PUTs concurrentes: primero OK (200), segundo → 409.
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+### R-003: Integración con core service inestable
+
+**Descripción:** `ZipCodeValidationClientAdapter` llama `GET /v1/zip-codes/{zipCode}` al core (puerto 8081). Si el core no responde (timeout, connection refused) el adapter debe retornar `Optional.empty()` para que `LocationValidationService` genere `MISSING_ZIP_CODE` — sin lanzar excepción que rompa el flujo del PUT/PATCH. Un manejo incorrecto de la excepción de red puede propagar un 500 al agente en lugar de generar la alerta correspondiente.
+
+**Mitigación:**
+- `ZipCodeValidationClientAdapter` captura `RestClientException` (timeout, connection refused) y retorna `Optional.empty()` — nunca propaga al use case.
+- WireMock en tests de integración simula: (a) 404, (b) 200 válido, (c) timeout/connection refused.
+- Documentar en `LocationConfig` el timeout configurado para el `RestClient` del core.
+
+**Tests obligatorios:**
+- `ZipCodeValidationClientAdapterTest` — 404 del core → `Optional.empty()`.
+- `ZipCodeValidationClientAdapterTest` — timeout/connection refused → `Optional.empty()` (no excepción).
+- `LocationManagementIntegrationTest` — WireMock 404 para zipCode → respuesta 200 con alerta `MISSING_ZIP_CODE`.
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+### R-004: Serialización JSONB de guarantees con AttributeConverter
+
+**Descripción:** `GuaranteesConverter` usa Jackson para serializar/deserializar `List<Guarantee>` hacia/desde `JSONB`. Si la columna `guarantees` contiene JSON malformado (migración manual, bug en versión anterior), la deserialización puede retornar `null` o lista vacía en lugar de lanzar excepción, disparando falsamente `NO_TARIFABLE_GUARANTEES` en ubicaciones que sí tenían guarantees.
+
+**Mitigación:**
+- `GuaranteesConverter.convertToEntityAttribute` debe retornar lista vacía (no null) ante JSON inválido, y loguear el error con el `location_id` para auditoría.
+- Test unitario que pase JSON malformado al converter y verifique comportamiento controlado.
+- Script de validación de integridad de datos en BD para verificar que `guarantees` en filas existentes es JSON válido (ejecutar post-migración V5).
+
+**Tests obligatorios:**
+- `GuaranteesConverterTest` — JSON válido → lista correcta; JSON inválido → lista vacía + log de error.
+- `LocationManagementIntegrationTest` — round-trip: PUT con guarantees → GET retorna mismas guarantees con tipos correctos.
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+## Riesgos MEDIO — Acciones Recomendadas
+
+| ID    | Acción recomendada |
+|-------|--------------------|
+| R-005 | Test exhaustivo del merge parcial en `PatchLocationUseCaseImplTest`: enviar body con 1 campo → verificar que los otros N-1 campos no cambian. Cubrir también `Optional<null>` vs campo ausente. |
+| R-006 | Verificar que `@Transactional` envuelve todo el ciclo de `@ElementCollection` (delete+insert). Revisar que `CascadeType` y `orphanRemoval` en `@ElementCollection` estén configurados para limpiar alertas huérfanas. |
+| R-007 | Test de controller (`LocationControllerTest`) que llama `GET /v1/quotes/{folio}/locations/summary` y verifica que el handler correcto responde (no el de `/{index}`). Verificar orden de `@GetMapping` en el controller. |
+| R-008 | Test parametrizado en `LocationValidationServiceTest` con todas las combinaciones de alertas (7 casos cubiertos por TDD). Agregar caso con múltiples alertas simultáneas para verificar acumulación correcta. |
+
+---
+
+## Riesgos BAJO — Backlog
+
+| ID    | Acción sugerida |
+|-------|-----------------|
+| R-009 | Agregar test de snapshot del response de `GET /summary` para detectar si campos inesperados se filtran. |
+| R-010 | Verificar en `LocationControllerTest` que `insuredValue` en el response de guarantees serializa como número JSON (no string). |

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
 import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
 import com.sofka.insurancequoter.back.folio.application.usecase.InvalidReferenceException;
 import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.LocationNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -27,6 +29,24 @@ public class GlobalExceptionHandler {
                 .body(Map.of(
                         "error", "Folio not found",
                         "code", "FOLIO_NOT_FOUND"
+                ));
+    }
+
+    @ExceptionHandler(VersionConflictException.class)
+    public ResponseEntity<Map<String, String>> handleVersionConflict(VersionConflictException ex) {
+        return ResponseEntity.status(409)
+                .body(Map.of(
+                        "error", "Optimistic lock conflict",
+                        "code", "VERSION_CONFLICT"
+                ));
+    }
+
+    @ExceptionHandler(LocationNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleLocationNotFound(LocationNotFoundException ex) {
+        return ResponseEntity.status(404)
+                .body(Map.of(
+                        "error", "Location index not found",
+                        "code", "LOCATION_NOT_FOUND"
                 ));
     }
 

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/repositories/QuoteJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/repositories/QuoteJpaRepository.java
@@ -2,7 +2,11 @@ package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persiste
 
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.Optional;
 
 // Spring Data derives the idempotency query from the method name
@@ -15,4 +19,8 @@ public interface QuoteJpaRepository extends JpaRepository<QuoteJpa, Long> {
     );
 
     Optional<QuoteJpa> findByFolioNumber(String folioNumber);
+
+    @Modifying
+    @Query(value = "UPDATE quotes SET version = version + 1, updated_at = :now WHERE folio_number = :folioNumber", nativeQuery = true)
+    void incrementVersionByFolioNumber(@Param("folioNumber") String folioNumber, @Param("now") Instant now);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsSummaryUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsSummaryUseCaseImpl.java
@@ -1,0 +1,37 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.LocationSummary;
+import com.sofka.insurancequoter.back.location.domain.model.ValidationStatus;
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationsSummaryUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+
+import java.util.List;
+
+// Returns a compact validation summary for all locations in a quote
+public class GetLocationsSummaryUseCaseImpl implements GetLocationsSummaryUseCase {
+
+    private final LocationRepository locationRepository;
+    private final QuoteVersionRepository quoteVersionRepository;
+
+    public GetLocationsSummaryUseCaseImpl(LocationRepository locationRepository,
+                                          QuoteVersionRepository quoteVersionRepository) {
+        this.locationRepository = locationRepository;
+        this.quoteVersionRepository = quoteVersionRepository;
+    }
+
+    @Override
+    public SummaryResult getSummary(String folioNumber) {
+        quoteVersionRepository.findVersionByFolioNumber(folioNumber); // validates folio exists
+
+        List<LocationSummary> summaries = locationRepository.findSummaryByFolioNumber(folioNumber);
+
+        int total = summaries.size();
+        int complete = (int) summaries.stream()
+                .filter(s -> ValidationStatus.COMPLETE.equals(s.validationStatus()))
+                .count();
+        int incomplete = total - complete;
+
+        return new SummaryResult(folioNumber, total, complete, incomplete, summaries);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsUseCaseImpl.java
@@ -1,0 +1,25 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationsUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+
+// Retrieves all active locations and the current version for a given folio
+public class GetLocationsUseCaseImpl implements GetLocationsUseCase {
+
+    private final LocationRepository locationRepository;
+    private final QuoteVersionRepository quoteVersionRepository;
+
+    public GetLocationsUseCaseImpl(LocationRepository locationRepository,
+                                   QuoteVersionRepository quoteVersionRepository) {
+        this.locationRepository = locationRepository;
+        this.quoteVersionRepository = quoteVersionRepository;
+    }
+
+    @Override
+    public LocationsResult getLocations(String folioNumber) {
+        Long version = quoteVersionRepository.findVersionByFolioNumber(folioNumber);
+        var locations = locationRepository.findByFolioNumber(folioNumber);
+        return new LocationsResult(folioNumber, locations, version);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/LocationNotFoundException.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/LocationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+// Thrown when a location index does not exist within a quote
+public class LocationNotFoundException extends RuntimeException {
+
+    public LocationNotFoundException(String folioNumber, int index) {
+        super("Location index " + index + " not found for folio " + folioNumber);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/PatchLocationUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/PatchLocationUseCaseImpl.java
@@ -1,0 +1,97 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import com.sofka.insurancequoter.back.location.domain.port.in.PatchLocationUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.ZipCodeValidationClient;
+import com.sofka.insurancequoter.back.location.domain.service.LocationValidationService;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+// Partially updates a single location, recalculates alerts, and increments the quote version
+public class PatchLocationUseCaseImpl implements PatchLocationUseCase {
+
+    private final LocationRepository locationRepository;
+    private final QuoteVersionRepository quoteVersionRepository;
+    private final ZipCodeValidationClient zipCodeValidationClient;
+    private final LocationValidationService locationValidationService;
+
+    public PatchLocationUseCaseImpl(LocationRepository locationRepository,
+                                    QuoteVersionRepository quoteVersionRepository,
+                                    ZipCodeValidationClient zipCodeValidationClient,
+                                    LocationValidationService locationValidationService) {
+        this.locationRepository = locationRepository;
+        this.quoteVersionRepository = quoteVersionRepository;
+        this.zipCodeValidationClient = zipCodeValidationClient;
+        this.locationValidationService = locationValidationService;
+    }
+
+    @Override
+    @Transactional
+    public PatchLocationResult patchLocation(PatchLocationCommand command) {
+        Long storedVersion = quoteVersionRepository.findVersionByFolioNumber(command.folioNumber());
+        if (!storedVersion.equals(command.version())) {
+            throw new VersionConflictException(command.folioNumber(), command.version(), storedVersion);
+        }
+
+        if (!locationRepository.existsByFolioAndIndex(command.folioNumber(), command.index())) {
+            throw new LocationNotFoundException(command.folioNumber(), command.index());
+        }
+
+        Location existing = locationRepository.findByFolioNumber(command.folioNumber())
+                .stream()
+                .filter(l -> l.index() == command.index())
+                .findFirst()
+                .orElseThrow(() -> new LocationNotFoundException(command.folioNumber(), command.index()));
+
+        // Apply partial merge — only overwrite fields that were explicitly provided
+        String locationName = command.locationName().orElse(existing.locationName());
+        String address = command.address().orElse(existing.address());
+        String zipCode = command.zipCode().orElse(existing.zipCode());
+        String constructionType = command.constructionType().orElse(existing.constructionType());
+        Integer level = command.level().orElse(existing.level());
+        Integer constructionYear = command.constructionYear().orElse(existing.constructionYear());
+        BusinessLine businessLine = command.businessLine().orElse(existing.businessLine());
+        List<Guarantee> guarantees = command.guarantees().orElse(existing.guarantees());
+
+        Optional<ZipCodeInfo> zipInfo = zipCode != null && !zipCode.isBlank()
+                ? zipCodeValidationClient.validate(zipCode)
+                : Optional.empty();
+
+        Location merged = new Location(
+                existing.index(), existing.active(), locationName, address, zipCode,
+                zipInfo.map(ZipCodeInfo::state).orElse(existing.state()),
+                zipInfo.map(ZipCodeInfo::municipality).orElse(existing.municipality()),
+                existing.neighborhood(),
+                zipInfo.map(ZipCodeInfo::city).orElse(existing.city()),
+                constructionType, level, constructionYear,
+                businessLine, guarantees,
+                zipInfo.map(ZipCodeInfo::catastrophicZone).orElse(existing.catastrophicZone()),
+                ValidationStatus.INCOMPLETE, List.of()
+        );
+
+        List<BlockingAlert> alerts = locationValidationService.calculateAlerts(merged, zipInfo);
+        ValidationStatus status = locationValidationService.deriveStatus(alerts);
+
+        Location withStatus = new Location(
+                merged.index(), merged.active(), merged.locationName(), merged.address(), merged.zipCode(),
+                merged.state(), merged.municipality(), merged.neighborhood(), merged.city(),
+                merged.constructionType(), merged.level(), merged.constructionYear(),
+                merged.businessLine(), merged.guarantees(), merged.catastrophicZone(),
+                status, alerts
+        );
+
+        Location saved = locationRepository.patchOne(command.folioNumber(), command.index(), withStatus);
+        quoteVersionRepository.incrementVersion(command.folioNumber());
+
+        return new PatchLocationResult(
+                command.folioNumber(),
+                saved,
+                quoteVersionRepository.getUpdatedAt(command.folioNumber()),
+                storedVersion + 1
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/ReplaceLocationsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/ReplaceLocationsUseCaseImpl.java
@@ -1,0 +1,88 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import com.sofka.insurancequoter.back.location.domain.port.in.ReplaceLocationsUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.ZipCodeValidationClient;
+import com.sofka.insurancequoter.back.location.domain.service.LocationValidationService;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+// Replaces all locations of a quote and recalculates blocking alerts for each one
+public class ReplaceLocationsUseCaseImpl implements ReplaceLocationsUseCase {
+
+    private final LocationRepository locationRepository;
+    private final QuoteVersionRepository quoteVersionRepository;
+    private final ZipCodeValidationClient zipCodeValidationClient;
+    private final LocationValidationService locationValidationService;
+
+    public ReplaceLocationsUseCaseImpl(LocationRepository locationRepository,
+                                       QuoteVersionRepository quoteVersionRepository,
+                                       ZipCodeValidationClient zipCodeValidationClient,
+                                       LocationValidationService locationValidationService) {
+        this.locationRepository = locationRepository;
+        this.quoteVersionRepository = quoteVersionRepository;
+        this.zipCodeValidationClient = zipCodeValidationClient;
+        this.locationValidationService = locationValidationService;
+    }
+
+    @Override
+    @Transactional
+    public ReplaceLocationsResult replaceLocations(ReplaceLocationsCommand command) {
+        Long storedVersion = quoteVersionRepository.findVersionByFolioNumber(command.folioNumber());
+        if (!storedVersion.equals(command.version())) {
+            throw new VersionConflictException(command.folioNumber(), command.version(), storedVersion);
+        }
+
+        List<Location> enriched = command.locations().stream()
+                .map(data -> enrich(data, command.folioNumber()))
+                .toList();
+
+        List<Location> saved = locationRepository.replaceAll(command.folioNumber(), enriched);
+        quoteVersionRepository.incrementVersion(command.folioNumber());
+
+        return new ReplaceLocationsResult(
+                command.folioNumber(),
+                saved,
+                quoteVersionRepository.getUpdatedAt(command.folioNumber()),
+                storedVersion + 1
+        );
+    }
+
+    private Location enrich(LocationData data, String folioNumber) {
+        Optional<ZipCodeInfo> zipInfo = data.zipCode() != null && !data.zipCode().isBlank()
+                ? zipCodeValidationClient.validate(data.zipCode())
+                : Optional.empty();
+
+        // Build preliminary location without computed fields to pass into validation service
+        Location preliminary = new Location(
+                data.index(), true, data.locationName(), data.address(), data.zipCode(),
+                zipInfo.map(ZipCodeInfo::state).orElse(null),
+                zipInfo.map(ZipCodeInfo::municipality).orElse(null),
+                null, // neighborhood not provided by core zip endpoint
+                zipInfo.map(ZipCodeInfo::city).orElse(null),
+                data.constructionType(), data.level(), data.constructionYear(),
+                data.businessLine(), data.guarantees(),
+                zipInfo.map(ZipCodeInfo::catastrophicZone).orElse(null),
+                ValidationStatus.INCOMPLETE, List.of()
+        );
+
+        List<BlockingAlert> alerts = locationValidationService.calculateAlerts(preliminary, zipInfo);
+        ValidationStatus status = locationValidationService.deriveStatus(alerts);
+
+        return new Location(
+                data.index(), true, data.locationName(), data.address(), data.zipCode(),
+                zipInfo.map(ZipCodeInfo::state).orElse(null),
+                zipInfo.map(ZipCodeInfo::municipality).orElse(null),
+                null,
+                zipInfo.map(ZipCodeInfo::city).orElse(null),
+                data.constructionType(), data.level(), data.constructionYear(),
+                data.businessLine(), data.guarantees(),
+                zipInfo.map(ZipCodeInfo::catastrophicZone).orElse(null),
+                status, alerts
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImpl.java
@@ -61,7 +61,11 @@ public class SaveLocationLayoutUseCaseImpl implements SaveLocationLayoutUseCase 
             if (requested > maxExistingIndex) {
                 List<Location> newLocations = new ArrayList<>();
                 for (int i = maxExistingIndex + 1; i <= requested; i++) {
-                    newLocations.add(new Location(i, true));
+                    newLocations.add(new Location(i, true, null, null, null,
+                            null, null, null, null, null, null, null,
+                            null, null, null,
+                            com.sofka.insurancequoter.back.location.domain.model.ValidationStatus.INCOMPLETE,
+                            java.util.List.of()));
                 }
                 locationRepository.insertAll(existing.id(), newLocations);
             }

--- a/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/VersionConflictException.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/application/usecase/VersionConflictException.java
@@ -1,0 +1,10 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+// Thrown when the version supplied by the client does not match the stored version (optimistic lock)
+public class VersionConflictException extends RuntimeException {
+
+    public VersionConflictException(String folioNumber, Long expected, Long actual) {
+        super("Version conflict on folio " + folioNumber
+                + ": expected " + expected + " but got " + actual);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/BlockingAlert.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/BlockingAlert.java
@@ -1,0 +1,5 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+// Value object representing a blocking alert that prevents tarification of a location
+public record BlockingAlert(String code, String message) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/BlockingAlertCode.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/BlockingAlertCode.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+// Enumeration of known codes that identify the cause of a blocking alert on a location
+public enum BlockingAlertCode {
+    MISSING_ZIP_CODE,
+    MISSING_FIRE_KEY,
+    NO_TARIFABLE_GUARANTEES
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/BusinessLine.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/BusinessLine.java
@@ -1,0 +1,5 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+// Value object representing the business line classification for a location
+public record BusinessLine(String code, String fireKey, String description) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/Guarantee.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/Guarantee.java
@@ -1,0 +1,7 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+import java.math.BigDecimal;
+
+// Value object representing a coverage guarantee with its insured value
+public record Guarantee(String code, BigDecimal insuredValue) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/Location.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/Location.java
@@ -1,5 +1,25 @@
 package com.sofka.insurancequoter.back.location.domain.model;
 
-// Domain model for a single location within a quote
-public record Location(int index, boolean active) {
+import java.util.List;
+
+// Domain model for a single location within a quote, including all tarification data
+public record Location(
+        int index,
+        boolean active,
+        String locationName,
+        String address,
+        String zipCode,
+        String state,
+        String municipality,
+        String neighborhood,
+        String city,
+        String constructionType,
+        Integer level,
+        Integer constructionYear,
+        BusinessLine businessLine,
+        List<Guarantee> guarantees,
+        String catastrophicZone,
+        ValidationStatus validationStatus,
+        List<BlockingAlert> blockingAlerts
+) {
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/LocationSummary.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/LocationSummary.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+import java.util.List;
+
+// Reduced projection of a location used in summary responses
+public record LocationSummary(
+        int index,
+        String locationName,
+        ValidationStatus validationStatus,
+        List<BlockingAlert> blockingAlerts
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/ValidationStatus.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/ValidationStatus.java
@@ -1,0 +1,7 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+// Indicates whether a location has all required data to be tarifiable
+public enum ValidationStatus {
+    COMPLETE,
+    INCOMPLETE
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/model/ZipCodeInfo.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/model/ZipCodeInfo.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.location.domain.model;
+
+// Domain value object returned by the zip code validation port
+public record ZipCodeInfo(
+        String zipCode,
+        String state,
+        String municipality,
+        String city,
+        String catastrophicZone,
+        boolean valid
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/GetLocationsSummaryUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/GetLocationsSummaryUseCase.java
@@ -1,0 +1,19 @@
+package com.sofka.insurancequoter.back.location.domain.port.in;
+
+import com.sofka.insurancequoter.back.location.domain.model.LocationSummary;
+
+import java.util.List;
+
+// Input port for retrieving a validation summary of all locations in a quote
+public interface GetLocationsSummaryUseCase {
+
+    SummaryResult getSummary(String folioNumber);
+
+    record SummaryResult(
+            String folioNumber,
+            int totalLocations,
+            int completeLocations,
+            int incompleteLocations,
+            List<LocationSummary> locations
+    ) {}
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/GetLocationsUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/GetLocationsUseCase.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.back.location.domain.port.in;
+
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+
+import java.util.List;
+
+// Input port for retrieving all locations of a quote
+public interface GetLocationsUseCase {
+
+    // Returns all active locations and the current version for the given folio
+    LocationsResult getLocations(String folioNumber);
+
+    record LocationsResult(String folioNumber, List<Location> locations, Long version) {}
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/PatchLocationUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/PatchLocationUseCase.java
@@ -1,0 +1,36 @@
+package com.sofka.insurancequoter.back.location.domain.port.in;
+
+import com.sofka.insurancequoter.back.location.domain.model.BusinessLine;
+import com.sofka.insurancequoter.back.location.domain.model.Guarantee;
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+// Input port for partially updating a single location within a quote
+public interface PatchLocationUseCase {
+
+    PatchLocationResult patchLocation(PatchLocationCommand command);
+
+    record PatchLocationCommand(
+            String folioNumber,
+            int index,
+            Long version,
+            Optional<String> locationName,
+            Optional<String> address,
+            Optional<String> zipCode,
+            Optional<String> constructionType,
+            Optional<Integer> level,
+            Optional<Integer> constructionYear,
+            Optional<BusinessLine> businessLine,
+            Optional<List<Guarantee>> guarantees
+    ) {}
+
+    record PatchLocationResult(
+            String folioNumber,
+            Location location,
+            Instant updatedAt,
+            Long version
+    ) {}
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/ReplaceLocationsUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/in/ReplaceLocationsUseCase.java
@@ -1,0 +1,33 @@
+package com.sofka.insurancequoter.back.location.domain.port.in;
+
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+
+import java.time.Instant;
+import java.util.List;
+
+// Input port for replacing all locations of a quote in one operation
+public interface ReplaceLocationsUseCase {
+
+    ReplaceLocationsResult replaceLocations(ReplaceLocationsCommand command);
+
+    record ReplaceLocationsCommand(String folioNumber, List<LocationData> locations, Long version) {}
+
+    record LocationData(
+            int index,
+            String locationName,
+            String address,
+            String zipCode,
+            String constructionType,
+            Integer level,
+            Integer constructionYear,
+            com.sofka.insurancequoter.back.location.domain.model.BusinessLine businessLine,
+            java.util.List<com.sofka.insurancequoter.back.location.domain.model.Guarantee> guarantees
+    ) {}
+
+    record ReplaceLocationsResult(
+            String folioNumber,
+            List<Location> locations,
+            Instant updatedAt,
+            Long version
+    ) {}
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/LocationRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/LocationRepository.java
@@ -1,6 +1,7 @@
 package com.sofka.insurancequoter.back.location.domain.port.out;
 
 import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.LocationSummary;
 
 import java.util.List;
 
@@ -16,4 +17,16 @@ public interface LocationRepository {
     void deactivateByIndices(Long quoteId, List<Integer> indices);
 
     void reactivateByIndices(Long quoteId, List<Integer> indices);
+
+    // --- location management ---
+
+    List<Location> findByFolioNumber(String folioNumber);
+
+    List<Location> replaceAll(String folioNumber, List<Location> locations);
+
+    Location patchOne(String folioNumber, int index, Location mergedLocation);
+
+    List<LocationSummary> findSummaryByFolioNumber(String folioNumber);
+
+    boolean existsByFolioAndIndex(String folioNumber, int index);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/QuoteVersionRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/QuoteVersionRepository.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.back.location.domain.port.out;
+
+import java.time.Instant;
+
+// Output port for reading and updating the optimistic lock version on a quote
+public interface QuoteVersionRepository {
+
+    // Returns the current version; throws FolioNotFoundException if folio does not exist
+    Long findVersionByFolioNumber(String folioNumber);
+
+    void incrementVersion(String folioNumber);
+
+    Instant getUpdatedAt(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/ZipCodeValidationClient.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/port/out/ZipCodeValidationClient.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.location.domain.port.out;
+
+import com.sofka.insurancequoter.back.location.domain.model.ZipCodeInfo;
+
+import java.util.Optional;
+
+// Output port for validating zip codes against the core service
+public interface ZipCodeValidationClient {
+
+    Optional<ZipCodeInfo> validate(String zipCode);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/domain/service/LocationValidationService.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/domain/service/LocationValidationService.java
@@ -1,0 +1,46 @@
+package com.sofka.insurancequoter.back.location.domain.service;
+
+import com.sofka.insurancequoter.back.location.domain.model.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+// Domain service that calculates blocking alerts and validation status for a location
+public class LocationValidationService {
+
+    public List<BlockingAlert> calculateAlerts(Location location, Optional<ZipCodeInfo> zipCodeInfo) {
+        List<BlockingAlert> alerts = new ArrayList<>();
+
+        // MISSING_ZIP_CODE: zip code is blank or the core service did not recognise it
+        if (isBlank(location.zipCode()) || zipCodeInfo.isEmpty()) {
+            alerts.add(new BlockingAlert(
+                    BlockingAlertCode.MISSING_ZIP_CODE.name(),
+                    "Código postal requerido"));
+        }
+
+        // MISSING_FIRE_KEY: business line absent or fire key not set
+        if (location.businessLine() == null || isBlank(location.businessLine().fireKey())) {
+            alerts.add(new BlockingAlert(
+                    BlockingAlertCode.MISSING_FIRE_KEY.name(),
+                    "Clave incendio requerida"));
+        }
+
+        // NO_TARIFABLE_GUARANTEES: no guarantees provided at all
+        if (location.guarantees() == null || location.guarantees().isEmpty()) {
+            alerts.add(new BlockingAlert(
+                    BlockingAlertCode.NO_TARIFABLE_GUARANTEES.name(),
+                    "Se requiere al menos una garantía tarifable"));
+        }
+
+        return alerts;
+    }
+
+    public ValidationStatus deriveStatus(List<BlockingAlert> alerts) {
+        return alerts.isEmpty() ? ValidationStatus.COMPLETE : ValidationStatus.INCOMPLETE;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationController.java
@@ -1,0 +1,68 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.location.domain.port.in.*;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.PatchLocationRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.ReplaceLocationsRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper.LocationRestMapper;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.swaggerdocs.LocationApi;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+// REST controller for location management operations on a quote
+@RestController
+@RequestMapping("/v1/quotes/{folio}/locations")
+public class LocationController implements LocationApi {
+
+    private final GetLocationsUseCase getLocationsUseCase;
+    private final ReplaceLocationsUseCase replaceLocationsUseCase;
+    private final PatchLocationUseCase patchLocationUseCase;
+    private final GetLocationsSummaryUseCase getLocationsSummaryUseCase;
+    private final LocationRestMapper mapper;
+
+    public LocationController(GetLocationsUseCase getLocationsUseCase,
+                              ReplaceLocationsUseCase replaceLocationsUseCase,
+                              PatchLocationUseCase patchLocationUseCase,
+                              GetLocationsSummaryUseCase getLocationsSummaryUseCase,
+                              LocationRestMapper mapper) {
+        this.getLocationsUseCase = getLocationsUseCase;
+        this.replaceLocationsUseCase = replaceLocationsUseCase;
+        this.patchLocationUseCase = patchLocationUseCase;
+        this.getLocationsSummaryUseCase = getLocationsSummaryUseCase;
+        this.mapper = mapper;
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<?> getLocations(@PathVariable String folio) {
+        var result = getLocationsUseCase.getLocations(folio);
+        return ResponseEntity.ok(mapper.toLocationsListResponse(result));
+    }
+
+    @Override
+    @PutMapping
+    public ResponseEntity<?> replaceLocations(@PathVariable String folio,
+                                              @RequestBody @Valid ReplaceLocationsRequest request) {
+        var command = mapper.toReplaceCommand(folio, request);
+        var result = replaceLocationsUseCase.replaceLocations(command);
+        return ResponseEntity.ok(mapper.toLocationsListResponseWithTimestamp(result));
+    }
+
+    // NOTE: /summary must be declared BEFORE /{index} to avoid routing conflict
+    @Override
+    @GetMapping("/summary")
+    public ResponseEntity<?> getLocationsSummary(@PathVariable String folio) {
+        var result = getLocationsSummaryUseCase.getSummary(folio);
+        return ResponseEntity.ok(mapper.toSummaryWrapperResponse(result));
+    }
+
+    @Override
+    @PatchMapping("/{index}")
+    public ResponseEntity<?> patchLocation(@PathVariable String folio,
+                                           @PathVariable int index,
+                                           @RequestBody PatchLocationRequest request) {
+        var command = mapper.toPatchCommand(folio, index, request);
+        var result = patchLocationUseCase.patchLocation(command);
+        return ResponseEntity.ok(mapper.toPatchWrapperResponse(result));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/BusinessLineRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/BusinessLineRequest.java
@@ -1,0 +1,4 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request;
+
+public record BusinessLineRequest(String code, String fireKey, String description) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/GuaranteeRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/GuaranteeRequest.java
@@ -1,0 +1,6 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request;
+
+import java.math.BigDecimal;
+
+public record GuaranteeRequest(String code, BigDecimal insuredValue) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/LocationItemRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/LocationItemRequest.java
@@ -1,0 +1,16 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request;
+
+import java.util.List;
+
+public record LocationItemRequest(
+        Integer index,
+        String locationName,
+        String address,
+        String zipCode,
+        String constructionType,
+        Integer level,
+        Integer constructionYear,
+        BusinessLineRequest businessLine,
+        List<GuaranteeRequest> guarantees
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/PatchLocationRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/PatchLocationRequest.java
@@ -1,0 +1,30 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+public record PatchLocationRequest(
+        Optional<String> locationName,
+        Optional<String> address,
+        Optional<String> zipCode,
+        Optional<String> constructionType,
+        Optional<Integer> level,
+        Optional<Integer> constructionYear,
+        Optional<BusinessLineRequest> businessLine,
+        Optional<List<GuaranteeRequest>> guarantees,
+        @NotNull Long version
+) {
+    // Default absent fields to Optional.empty() when not present in JSON
+    public PatchLocationRequest {
+        locationName = locationName != null ? locationName : Optional.empty();
+        address = address != null ? address : Optional.empty();
+        zipCode = zipCode != null ? zipCode : Optional.empty();
+        constructionType = constructionType != null ? constructionType : Optional.empty();
+        level = level != null ? level : Optional.empty();
+        constructionYear = constructionYear != null ? constructionYear : Optional.empty();
+        businessLine = businessLine != null ? businessLine : Optional.empty();
+        guarantees = guarantees != null ? guarantees : Optional.empty();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/ReplaceLocationsRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/request/ReplaceLocationsRequest.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record ReplaceLocationsRequest(
+        @NotNull List<LocationItemRequest> locations,
+        @NotNull Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/BlockingAlertResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/BlockingAlertResponse.java
@@ -1,0 +1,4 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+public record BlockingAlertResponse(String code, String message) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/BusinessLineResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/BusinessLineResponse.java
@@ -1,0 +1,4 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+public record BusinessLineResponse(String code, String fireKey, String description) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/GuaranteeResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/GuaranteeResponse.java
@@ -1,0 +1,6 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+import java.math.BigDecimal;
+
+public record GuaranteeResponse(String code, BigDecimal insuredValue) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationDetailResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationDetailResponse.java
@@ -1,0 +1,23 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+import java.util.List;
+
+public record LocationDetailResponse(
+        int index,
+        String locationName,
+        String address,
+        String zipCode,
+        String state,
+        String municipality,
+        String neighborhood,
+        String city,
+        String constructionType,
+        Integer level,
+        Integer constructionYear,
+        BusinessLineResponse businessLine,
+        List<GuaranteeResponse> guarantees,
+        String catastrophicZone,
+        String validationStatus,
+        List<BlockingAlertResponse> blockingAlerts
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationPatchWrapperResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationPatchWrapperResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+import java.time.Instant;
+
+// Response for PATCH /v1/quotes/{folio}/locations/{index}
+public record LocationPatchWrapperResponse(
+        String folioNumber,
+        LocationDetailResponse location,
+        Instant updatedAt,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationSummaryItemResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationSummaryItemResponse.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+import java.util.List;
+
+public record LocationSummaryItemResponse(
+        int index,
+        String locationName,
+        String validationStatus,
+        List<BlockingAlertResponse> blockingAlerts
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationsListResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationsListResponse.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+import java.util.List;
+
+// Response for GET /v1/quotes/{folio}/locations
+public record LocationsListResponse(
+        String folioNumber,
+        List<LocationDetailResponse> locations,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationsListResponseWithTimestamp.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationsListResponseWithTimestamp.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+// Response for PUT /v1/quotes/{folio}/locations (includes updatedAt)
+public record LocationsListResponseWithTimestamp(
+        String folioNumber,
+        List<LocationDetailResponse> locations,
+        Instant updatedAt,
+        Long version
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationsSummaryWrapperResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/dto/response/LocationsSummaryWrapperResponse.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response;
+
+import java.util.List;
+
+// Response for GET /v1/quotes/{folio}/locations/summary
+public record LocationsSummaryWrapperResponse(
+        String folioNumber,
+        int totalLocations,
+        int completeLocations,
+        int incompleteLocations,
+        List<LocationSummaryItemResponse> locations
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/mapper/LocationRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/mapper/LocationRestMapper.java
@@ -1,0 +1,122 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import com.sofka.insurancequoter.back.location.domain.port.in.*;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.*;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.*;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+// Maps between REST DTOs and domain port types for the location management feature
+@Component
+public class LocationRestMapper {
+
+    // --- Request → Command ---
+
+    public ReplaceLocationsUseCase.ReplaceLocationsCommand toReplaceCommand(
+            String folio, ReplaceLocationsRequest request) {
+        List<ReplaceLocationsUseCase.LocationData> locations = request.locations().stream()
+                .map(this::toLocationData)
+                .toList();
+        return new ReplaceLocationsUseCase.ReplaceLocationsCommand(folio, locations, request.version());
+    }
+
+    private ReplaceLocationsUseCase.LocationData toLocationData(LocationItemRequest req) {
+        BusinessLine bl = req.businessLine() != null
+                ? new BusinessLine(req.businessLine().code(), req.businessLine().fireKey(), req.businessLine().description())
+                : null;
+        List<Guarantee> guarantees = req.guarantees() != null
+                ? req.guarantees().stream().map(g -> new Guarantee(g.code(), g.insuredValue())).toList()
+                : List.of();
+        return new ReplaceLocationsUseCase.LocationData(
+                req.index() != null ? req.index() : 0,
+                req.locationName(), req.address(), req.zipCode(),
+                req.constructionType(), req.level(), req.constructionYear(),
+                bl, guarantees);
+    }
+
+    public PatchLocationUseCase.PatchLocationCommand toPatchCommand(
+            String folio, int index, PatchLocationRequest request) {
+        Optional<BusinessLine> bl = request.businessLine().map(b ->
+                new BusinessLine(b.code(), b.fireKey(), b.description()));
+        Optional<List<Guarantee>> guarantees = request.guarantees().map(list ->
+                list.stream().map(g -> new Guarantee(g.code(), g.insuredValue())).toList());
+
+        return new PatchLocationUseCase.PatchLocationCommand(
+                folio, index, request.version(),
+                request.locationName(), request.address(), request.zipCode(),
+                request.constructionType(), request.level(), request.constructionYear(),
+                bl, guarantees);
+    }
+
+    // --- Domain → Response ---
+
+    public LocationsListResponse toLocationsListResponse(GetLocationsUseCase.LocationsResult result) {
+        List<LocationDetailResponse> details = result.locations().stream()
+                .map(this::toDetail)
+                .toList();
+        return new LocationsListResponse(result.folioNumber(), details, result.version());
+    }
+
+    public LocationsListResponseWithTimestamp toLocationsListResponseWithTimestamp(
+            ReplaceLocationsUseCase.ReplaceLocationsResult result) {
+        List<LocationDetailResponse> details = result.locations().stream()
+                .map(this::toDetail)
+                .toList();
+        return new LocationsListResponseWithTimestamp(result.folioNumber(), details, result.updatedAt(), result.version());
+    }
+
+    public LocationPatchWrapperResponse toPatchWrapperResponse(PatchLocationUseCase.PatchLocationResult result) {
+        return new LocationPatchWrapperResponse(
+                result.folioNumber(),
+                toDetail(result.location()),
+                result.updatedAt(),
+                result.version());
+    }
+
+    public LocationsSummaryWrapperResponse toSummaryWrapperResponse(
+            GetLocationsSummaryUseCase.SummaryResult result) {
+        List<LocationSummaryItemResponse> items = result.locations().stream()
+                .map(s -> new LocationSummaryItemResponse(
+                        s.index(), s.locationName(),
+                        s.validationStatus() != null ? s.validationStatus().name() : null,
+                        s.blockingAlerts().stream()
+                                .map(a -> new BlockingAlertResponse(a.code(), a.message()))
+                                .toList()))
+                .toList();
+        return new LocationsSummaryWrapperResponse(
+                result.folioNumber(),
+                result.totalLocations(),
+                result.completeLocations(),
+                result.incompleteLocations(),
+                items);
+    }
+
+    private LocationDetailResponse toDetail(Location loc) {
+        BusinessLineResponse bl = loc.businessLine() != null
+                ? new BusinessLineResponse(
+                        loc.businessLine().code(),
+                        loc.businessLine().fireKey(),
+                        loc.businessLine().description())
+                : null;
+        List<GuaranteeResponse> guarantees = loc.guarantees() != null
+                ? loc.guarantees().stream()
+                        .map(g -> new GuaranteeResponse(g.code(), g.insuredValue()))
+                        .toList()
+                : List.of();
+        List<BlockingAlertResponse> alerts = loc.blockingAlerts() != null
+                ? loc.blockingAlerts().stream()
+                        .map(a -> new BlockingAlertResponse(a.code(), a.message()))
+                        .toList()
+                : List.of();
+        return new LocationDetailResponse(
+                loc.index(), loc.locationName(), loc.address(), loc.zipCode(),
+                loc.state(), loc.municipality(), loc.neighborhood(), loc.city(),
+                loc.constructionType(), loc.level(), loc.constructionYear(),
+                bl, guarantees, loc.catastrophicZone(),
+                loc.validationStatus() != null ? loc.validationStatus().name() : null,
+                alerts);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/swaggerdocs/LocationApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/swaggerdocs/LocationApi.java
@@ -1,0 +1,29 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.PatchLocationRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.ReplaceLocationsRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Locations", description = "Manage locations within a quote")
+public interface LocationApi {
+
+    @Operation(summary = "Get all locations for a quote")
+    ResponseEntity<?> getLocations(@PathVariable String folio);
+
+    @Operation(summary = "Replace all locations for a quote")
+    ResponseEntity<?> replaceLocations(@PathVariable String folio,
+                                       @RequestBody @Valid ReplaceLocationsRequest request);
+
+    @Operation(summary = "Get locations validation summary")
+    ResponseEntity<?> getLocationsSummary(@PathVariable String folio);
+
+    @Operation(summary = "Patch a single location")
+    ResponseEntity<?> patchLocation(@PathVariable String folio,
+                                    @PathVariable int index,
+                                    @RequestBody PatchLocationRequest request);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/http/adapter/ZipCodeValidationClientAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/http/adapter/ZipCodeValidationClientAdapter.java
@@ -1,0 +1,44 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.http.adapter;
+
+import com.sofka.insurancequoter.back.location.domain.model.ZipCodeInfo;
+import com.sofka.insurancequoter.back.location.domain.port.out.ZipCodeValidationClient;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.http.dto.ZipCodeResponse;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.util.Optional;
+
+// Calls the core service to validate a zip code and return geographic enrichment data
+public class ZipCodeValidationClientAdapter implements ZipCodeValidationClient {
+
+    private final RestClient restClient;
+
+    public ZipCodeValidationClientAdapter(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @Override
+    public Optional<ZipCodeInfo> validate(String zipCode) {
+        try {
+            ZipCodeResponse response = restClient.get()
+                    .uri("/v1/zip-codes/{zipCode}", zipCode)
+                    .retrieve()
+                    .body(ZipCodeResponse.class);
+
+            if (response == null || Boolean.FALSE.equals(response.valid())) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new ZipCodeInfo(
+                    response.zipCode(),
+                    response.state(),
+                    response.municipality(),
+                    response.city(),
+                    response.catastrophicZone(),
+                    true
+            ));
+        } catch (HttpClientErrorException.NotFound e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/http/dto/ZipCodeResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/http/dto/ZipCodeResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.http.dto;
+
+// DTO for the GET /v1/zip-codes/{zipCode} response from the core service
+public record ZipCodeResponse(
+        String zipCode,
+        String state,
+        String municipality,
+        String city,
+        String catastrophicZone,
+        Boolean valid
+) {
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/LocationJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/LocationJpaAdapter.java
@@ -1,11 +1,16 @@
 package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter;
 
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
 import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.LocationSummary;
 import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -14,11 +19,14 @@ import java.util.List;
 public class LocationJpaAdapter implements LocationRepository {
 
     private final LocationJpaRepository locationJpaRepository;
+    private final QuoteJpaRepository quoteJpaRepository;
     private final LocationPersistenceMapper mapper;
 
     public LocationJpaAdapter(LocationJpaRepository locationJpaRepository,
+                              QuoteJpaRepository quoteJpaRepository,
                               LocationPersistenceMapper mapper) {
         this.locationJpaRepository = locationJpaRepository;
+        this.quoteJpaRepository = quoteJpaRepository;
         this.mapper = mapper;
     }
 
@@ -61,5 +69,91 @@ public class LocationJpaAdapter implements LocationRepository {
         List<LocationJpa> rows = locationJpaRepository.findByQuoteIdAndIndexIn(quoteId, indices);
         rows.forEach(jpa -> jpa.setActive(true));
         locationJpaRepository.saveAll(rows);
+    }
+
+    @Override
+    public List<Location> findByFolioNumber(String folioNumber) {
+        QuoteJpa quote = requireQuote(folioNumber);
+        return locationJpaRepository.findByQuoteId(quote.getId())
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public List<Location> replaceAll(String folioNumber, List<Location> locations) {
+        QuoteJpa quote = requireQuote(folioNumber);
+        locationJpaRepository.deleteByQuoteId(quote.getId());
+        locationJpaRepository.flush();
+
+        List<LocationJpa> entities = locations.stream()
+                .map(l -> mapper.toLocationJpa(quote.getId(), l))
+                .toList();
+        List<LocationJpa> saved = locationJpaRepository.saveAll(entities);
+        return saved.stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    @Transactional
+    public Location patchOne(String folioNumber, int index, Location mergedLocation) {
+        QuoteJpa quote = requireQuote(folioNumber);
+        LocationJpa existing = locationJpaRepository
+                .findByQuoteIdAndIndex(quote.getId(), index)
+                .orElseThrow(() -> new com.sofka.insurancequoter.back.location.application.usecase
+                        .LocationNotFoundException(folioNumber, index));
+
+        // Update mutable fields in-place to preserve @CreationTimestamp and id
+        existing.setLocationName(mergedLocation.locationName());
+        existing.setAddress(mergedLocation.address());
+        existing.setZipCode(mergedLocation.zipCode());
+        existing.setState(mergedLocation.state());
+        existing.setMunicipality(mergedLocation.municipality());
+        existing.setNeighborhood(mergedLocation.neighborhood());
+        existing.setCity(mergedLocation.city());
+        existing.setConstructionType(mergedLocation.constructionType());
+        existing.setLevel(mergedLocation.level());
+        existing.setConstructionYear(mergedLocation.constructionYear());
+        existing.setBusinessLineCode(mergedLocation.businessLine() != null ? mergedLocation.businessLine().code() : null);
+        existing.setBusinessLineFireKey(mergedLocation.businessLine() != null ? mergedLocation.businessLine().fireKey() : null);
+        existing.setBusinessLineDescription(mergedLocation.businessLine() != null ? mergedLocation.businessLine().description() : null);
+        existing.setGuarantees(mergedLocation.guarantees());
+        existing.setCatastrophicZone(mergedLocation.catastrophicZone());
+        existing.setValidationStatus(mergedLocation.validationStatus() != null
+                ? mergedLocation.validationStatus().name()
+                : "INCOMPLETE");
+
+        // Replace blocking alerts collection
+        existing.getBlockingAlerts().clear();
+        if (mergedLocation.blockingAlerts() != null) {
+            mergedLocation.blockingAlerts().forEach(a ->
+                    existing.getBlockingAlerts().add(
+                            new com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities
+                                    .BlockingAlertEmbeddable(a.code(), a.message())));
+        }
+
+        LocationJpa saved = locationJpaRepository.save(existing);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public List<LocationSummary> findSummaryByFolioNumber(String folioNumber) {
+        QuoteJpa quote = requireQuote(folioNumber);
+        return locationJpaRepository.findByQuoteId(quote.getId())
+                .stream()
+                .map(mapper::toSummary)
+                .toList();
+    }
+
+    @Override
+    public boolean existsByFolioAndIndex(String folioNumber, int index) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .map(q -> locationJpaRepository.existsByQuoteIdAndIndex(q.getId(), index))
+                .orElse(false);
+    }
+
+    private QuoteJpa requireQuote(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/QuoteVersionJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/QuoteVersionJpaAdapter.java
@@ -1,0 +1,43 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+// Reads and increments the optimistic lock version on the quotes table
+@Component
+public class QuoteVersionJpaAdapter implements QuoteVersionRepository {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+
+    public QuoteVersionJpaAdapter(QuoteJpaRepository quoteJpaRepository) {
+        this.quoteJpaRepository = quoteJpaRepository;
+    }
+
+    @Override
+    public Long findVersionByFolioNumber(String folioNumber) {
+        return requireQuote(folioNumber).getVersion();
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementVersion(String folioNumber) {
+        quoteJpaRepository.incrementVersionByFolioNumber(folioNumber, Instant.now());
+    }
+
+    @Override
+    public Instant getUpdatedAt(String folioNumber) {
+        return requireQuote(folioNumber).getUpdatedAt();
+    }
+
+    private QuoteJpa requireQuote(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/converter/GuaranteesConverter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/converter/GuaranteesConverter.java
@@ -1,0 +1,42 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofka.insurancequoter.back.location.domain.model.Guarantee;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+// Converts List<Guarantee> to JSON string for JSONB storage and back
+@Converter
+public class GuaranteesConverter implements AttributeConverter<List<Guarantee>, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<List<Guarantee>> TYPE_REF = new TypeReference<>() {};
+
+    @Override
+    public String convertToDatabaseColumn(List<Guarantee> guarantees) {
+        if (guarantees == null || guarantees.isEmpty()) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(guarantees);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize guarantees to JSON", e);
+        }
+    }
+
+    @Override
+    public List<Guarantee> convertToEntityAttribute(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        try {
+            return MAPPER.readValue(json, TYPE_REF);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize guarantees from JSON", e);
+        }
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/entities/BlockingAlertEmbeddable.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/entities/BlockingAlertEmbeddable.java
@@ -1,0 +1,23 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// Embeddable mapping for the location_blocking_alerts table rows
+@Embeddable
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlockingAlertEmbeddable {
+
+    @Column(name = "alert_code", nullable = false, length = 50)
+    private String alertCode;
+
+    @Column(name = "alert_message", nullable = false, length = 255)
+    private String alertMessage;
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/entities/LocationJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/entities/LocationJpa.java
@@ -1,11 +1,15 @@
 package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities;
 
+import com.sofka.insurancequoter.back.location.domain.model.Guarantee;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.converter.GuaranteesConverter;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "locations",
@@ -33,6 +37,64 @@ public class LocationJpa {
 
     @Column(name = "location_name")
     private String locationName;
+
+    // --- detail columns added in V5 ---
+
+    @Column(name = "address", length = 500)
+    private String address;
+
+    @Column(name = "zip_code", length = 10)
+    private String zipCode;
+
+    @Column(name = "state", length = 100)
+    private String state;
+
+    @Column(name = "municipality", length = 100)
+    private String municipality;
+
+    @Column(name = "neighborhood", length = 100)
+    private String neighborhood;
+
+    @Column(name = "city", length = 100)
+    private String city;
+
+    @Column(name = "construction_type", length = 50)
+    private String constructionType;
+
+    @Column(name = "level")
+    private Integer level;
+
+    @Column(name = "construction_year")
+    private Integer constructionYear;
+
+    @Column(name = "business_line_code", length = 50)
+    private String businessLineCode;
+
+    @Column(name = "business_line_fire_key", length = 50)
+    private String businessLineFireKey;
+
+    @Column(name = "business_line_description", length = 255)
+    private String businessLineDescription;
+
+    @Convert(converter = GuaranteesConverter.class)
+    @Column(name = "guarantees", columnDefinition = "text")
+    private List<Guarantee> guarantees;
+
+    @Column(name = "catastrophic_zone", length = 50)
+    private String catastrophicZone;
+
+    @Column(name = "validation_status", nullable = false, length = 20)
+    @Builder.Default
+    private String validationStatus = "INCOMPLETE";
+
+    // --- blocking alerts (V6 table) ---
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "location_blocking_alerts",
+            joinColumns = @JoinColumn(name = "location_id"))
+    @Builder.Default
+    private List<BlockingAlertEmbeddable> blockingAlerts = new ArrayList<>();
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/mappers/LocationPersistenceMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/mappers/LocationPersistenceMapper.java
@@ -2,9 +2,13 @@ package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persi
 
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
 import com.sofka.insurancequoter.back.location.application.usecase.QuoteLayoutData;
-import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.BlockingAlertEmbeddable;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 // Maps between domain/application objects and JPA entities for the location bounded context
 @Component
@@ -22,14 +26,85 @@ public class LocationPersistenceMapper {
     }
 
     public LocationJpa toLocationJpa(Long quoteId, Location location) {
+        List<BlockingAlertEmbeddable> alerts = location.blockingAlerts() == null
+                ? new ArrayList<>()
+                : location.blockingAlerts().stream()
+                        .map(a -> new BlockingAlertEmbeddable(a.code(), a.message()))
+                        .toList();
+
         return LocationJpa.builder()
                 .quoteId(quoteId)
                 .index(location.index())
                 .active(location.active())
+                .locationName(location.locationName())
+                .address(location.address())
+                .zipCode(location.zipCode())
+                .state(location.state())
+                .municipality(location.municipality())
+                .neighborhood(location.neighborhood())
+                .city(location.city())
+                .constructionType(location.constructionType())
+                .level(location.level())
+                .constructionYear(location.constructionYear())
+                .businessLineCode(location.businessLine() != null ? location.businessLine().code() : null)
+                .businessLineFireKey(location.businessLine() != null ? location.businessLine().fireKey() : null)
+                .businessLineDescription(location.businessLine() != null ? location.businessLine().description() : null)
+                .guarantees(location.guarantees())
+                .catastrophicZone(location.catastrophicZone())
+                .validationStatus(location.validationStatus() != null
+                        ? location.validationStatus().name()
+                        : ValidationStatus.INCOMPLETE.name())
+                .blockingAlerts(alerts)
                 .build();
     }
 
     public Location toDomain(LocationJpa jpa) {
-        return new Location(jpa.getIndex(), jpa.getActive());
+        BusinessLine businessLine = (jpa.getBusinessLineCode() != null || jpa.getBusinessLineFireKey() != null)
+                ? new BusinessLine(jpa.getBusinessLineCode(), jpa.getBusinessLineFireKey(), jpa.getBusinessLineDescription())
+                : null;
+
+        List<BlockingAlert> alerts = jpa.getBlockingAlerts() == null
+                ? List.of()
+                : jpa.getBlockingAlerts().stream()
+                        .map(a -> new BlockingAlert(a.getAlertCode(), a.getAlertMessage()))
+                        .toList();
+
+        ValidationStatus status = jpa.getValidationStatus() != null
+                ? ValidationStatus.valueOf(jpa.getValidationStatus())
+                : ValidationStatus.INCOMPLETE;
+
+        return new Location(
+                jpa.getIndex(),
+                jpa.getActive(),
+                jpa.getLocationName(),
+                jpa.getAddress(),
+                jpa.getZipCode(),
+                jpa.getState(),
+                jpa.getMunicipality(),
+                jpa.getNeighborhood(),
+                jpa.getCity(),
+                jpa.getConstructionType(),
+                jpa.getLevel(),
+                jpa.getConstructionYear(),
+                businessLine,
+                jpa.getGuarantees() != null ? jpa.getGuarantees() : List.of(),
+                jpa.getCatastrophicZone(),
+                status,
+                alerts
+        );
+    }
+
+    public LocationSummary toSummary(LocationJpa jpa) {
+        List<BlockingAlert> alerts = jpa.getBlockingAlerts() == null
+                ? List.of()
+                : jpa.getBlockingAlerts().stream()
+                        .map(a -> new BlockingAlert(a.getAlertCode(), a.getAlertMessage()))
+                        .toList();
+
+        ValidationStatus status = jpa.getValidationStatus() != null
+                ? ValidationStatus.valueOf(jpa.getValidationStatus())
+                : ValidationStatus.INCOMPLETE;
+
+        return new LocationSummary(jpa.getIndex(), jpa.getLocationName(), status, alerts);
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/repositories/LocationJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/repositories/LocationJpaRepository.java
@@ -2,8 +2,12 @@ package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persi
 
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LocationJpaRepository extends JpaRepository<LocationJpa, Long> {
 
@@ -12,4 +16,12 @@ public interface LocationJpaRepository extends JpaRepository<LocationJpa, Long> 
     List<LocationJpa> findByQuoteId(Long quoteId);
 
     List<LocationJpa> findByQuoteIdAndIndexIn(Long quoteId, List<Integer> indices);
+
+    Optional<LocationJpa> findByQuoteIdAndIndex(Long quoteId, Integer index);
+
+    boolean existsByQuoteIdAndIndex(Long quoteId, Integer index);
+
+    @Modifying
+    @Query("DELETE FROM LocationJpa l WHERE l.quoteId = :quoteId")
+    void deleteByQuoteId(@Param("quoteId") Long quoteId);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/config/LocationConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/config/LocationConfig.java
@@ -1,0 +1,67 @@
+package com.sofka.insurancequoter.back.location.infrastructure.config;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.*;
+import com.sofka.insurancequoter.back.location.domain.port.in.*;
+import com.sofka.insurancequoter.back.location.domain.port.out.*;
+import com.sofka.insurancequoter.back.location.domain.service.LocationValidationService;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.http.adapter.ZipCodeValidationClientAdapter;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter.QuoteVersionJpaAdapter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+// Wires location management use cases with their output port adapters
+@Configuration
+public class LocationConfig {
+
+    @Bean
+    public LocationValidationService locationValidationService() {
+        return new LocationValidationService();
+    }
+
+    @Bean
+    public QuoteVersionRepository quoteVersionRepository(QuoteJpaRepository quoteJpaRepository) {
+        return new QuoteVersionJpaAdapter(quoteJpaRepository);
+    }
+
+    @Bean
+    public ZipCodeValidationClient zipCodeValidationClient(
+            @Value("${core.service.base-url:http://localhost:8081}") String baseUrl) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+        return new ZipCodeValidationClientAdapter(restClient);
+    }
+
+    @Bean
+    public GetLocationsUseCase getLocationsUseCase(LocationRepository locationRepository,
+                                                   QuoteVersionRepository quoteVersionRepository) {
+        return new GetLocationsUseCaseImpl(locationRepository, quoteVersionRepository);
+    }
+
+    @Bean
+    public ReplaceLocationsUseCase replaceLocationsUseCase(LocationRepository locationRepository,
+                                                           QuoteVersionRepository quoteVersionRepository,
+                                                           ZipCodeValidationClient zipCodeValidationClient,
+                                                           LocationValidationService locationValidationService) {
+        return new ReplaceLocationsUseCaseImpl(locationRepository, quoteVersionRepository,
+                zipCodeValidationClient, locationValidationService);
+    }
+
+    @Bean
+    public PatchLocationUseCase patchLocationUseCase(LocationRepository locationRepository,
+                                                     QuoteVersionRepository quoteVersionRepository,
+                                                     ZipCodeValidationClient zipCodeValidationClient,
+                                                     LocationValidationService locationValidationService) {
+        return new PatchLocationUseCaseImpl(locationRepository, quoteVersionRepository,
+                zipCodeValidationClient, locationValidationService);
+    }
+
+    @Bean
+    public GetLocationsSummaryUseCase getLocationsSummaryUseCase(LocationRepository locationRepository,
+                                                                  QuoteVersionRepository quoteVersionRepository) {
+        return new GetLocationsSummaryUseCaseImpl(locationRepository, quoteVersionRepository);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA / Hibernate
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.open-in-view=false
 

--- a/src/main/resources/db/migration/V5__add_location_detail_columns.sql
+++ b/src/main/resources/db/migration/V5__add_location_detail_columns.sql
@@ -1,0 +1,17 @@
+-- Adds detail columns to locations table for location management feature
+ALTER TABLE locations
+    ADD COLUMN IF NOT EXISTS address                   VARCHAR(500),
+    ADD COLUMN IF NOT EXISTS zip_code                  VARCHAR(10),
+    ADD COLUMN IF NOT EXISTS state                     VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS municipality              VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS neighborhood              VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS city                      VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS construction_type         VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS level                     INT,
+    ADD COLUMN IF NOT EXISTS construction_year         INT,
+    ADD COLUMN IF NOT EXISTS business_line_code        VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS business_line_fire_key    VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS business_line_description VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS guarantees                TEXT,
+    ADD COLUMN IF NOT EXISTS catastrophic_zone         VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS validation_status         VARCHAR(20) NOT NULL DEFAULT 'INCOMPLETE';

--- a/src/main/resources/db/migration/V6__create_location_blocking_alerts_table.sql
+++ b/src/main/resources/db/migration/V6__create_location_blocking_alerts_table.sql
@@ -1,0 +1,8 @@
+-- Creates table for storing blocking alerts per location
+CREATE TABLE IF NOT EXISTS location_blocking_alerts (
+    location_id   BIGINT       NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+    alert_code    VARCHAR(50)  NOT NULL,
+    alert_message VARCHAR(255) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_location_alerts_location_id ON location_blocking_alerts (location_id);

--- a/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsSummaryUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsSummaryUseCaseImplTest.java
@@ -1,0 +1,64 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.BlockingAlert;
+import com.sofka.insurancequoter.back.location.domain.model.BlockingAlertCode;
+import com.sofka.insurancequoter.back.location.domain.model.LocationSummary;
+import com.sofka.insurancequoter.back.location.domain.model.ValidationStatus;
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationsSummaryUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetLocationsSummaryUseCaseImplTest {
+
+    @Mock private LocationRepository locationRepository;
+    @Mock private QuoteVersionRepository quoteVersionRepository;
+
+    @InjectMocks
+    private GetLocationsSummaryUseCaseImpl useCase;
+
+    @Test
+    void getSummary_returnsCorrectCounts_whenFolioExists() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(4L);
+        List<LocationSummary> summaries = List.of(
+                new LocationSummary(1, "Bodega", ValidationStatus.COMPLETE, List.of()),
+                new LocationSummary(2, "Oficina", ValidationStatus.INCOMPLETE,
+                        List.of(new BlockingAlert(BlockingAlertCode.MISSING_ZIP_CODE.name(), "CP requerido"))),
+                new LocationSummary(3, "Almacen", ValidationStatus.COMPLETE, List.of())
+        );
+        when(locationRepository.findSummaryByFolioNumber("FOL-001")).thenReturn(summaries);
+
+        // WHEN
+        GetLocationsSummaryUseCase.SummaryResult result = useCase.getSummary("FOL-001");
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-001");
+        assertThat(result.totalLocations()).isEqualTo(3);
+        assertThat(result.completeLocations()).isEqualTo(2);
+        assertThat(result.incompleteLocations()).isEqualTo(1);
+        assertThat(result.locations()).hasSize(3);
+    }
+
+    @Test
+    void getSummary_throwsFolioNotFoundException_whenFolioDoesNotExist() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("UNKNOWN"))
+                .thenThrow(new FolioNotFoundException("UNKNOWN"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.getSummary("UNKNOWN"))
+                .isInstanceOf(FolioNotFoundException.class);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/GetLocationsUseCaseImplTest.java
@@ -1,0 +1,63 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.ValidationStatus;
+import com.sofka.insurancequoter.back.location.domain.port.in.GetLocationsUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetLocationsUseCaseImplTest {
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @Mock
+    private QuoteVersionRepository quoteVersionRepository;
+
+    @InjectMocks
+    private GetLocationsUseCaseImpl useCase;
+
+    private static Location loc(int index) {
+        return new Location(index, true, "Loc " + index, null, null,
+                null, null, null, null, null, null, null,
+                null, null, null, ValidationStatus.INCOMPLETE, List.of());
+    }
+
+    @Test
+    void getLocations_returnsLocationsAndVersion_whenFolioExists() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(3L);
+        when(locationRepository.findByFolioNumber("FOL-001")).thenReturn(List.of(loc(1), loc(2)));
+
+        // WHEN
+        GetLocationsUseCase.LocationsResult result = useCase.getLocations("FOL-001");
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-001");
+        assertThat(result.locations()).hasSize(2);
+        assertThat(result.version()).isEqualTo(3L);
+    }
+
+    @Test
+    void getLocations_throwsFolioNotFoundException_whenFolioDoesNotExist() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("UNKNOWN"))
+                .thenThrow(new FolioNotFoundException("UNKNOWN"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.getLocations("UNKNOWN"))
+                .isInstanceOf(FolioNotFoundException.class);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/PatchLocationUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/PatchLocationUseCaseImplTest.java
@@ -1,0 +1,152 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import com.sofka.insurancequoter.back.location.domain.port.in.PatchLocationUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.ZipCodeValidationClient;
+import com.sofka.insurancequoter.back.location.domain.service.LocationValidationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PatchLocationUseCaseImplTest {
+
+    @Mock private LocationRepository locationRepository;
+    @Mock private QuoteVersionRepository quoteVersionRepository;
+    @Mock private ZipCodeValidationClient zipCodeValidationClient;
+    @Mock private LocationValidationService locationValidationService;
+
+    @InjectMocks
+    private PatchLocationUseCaseImpl useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    private Location baseLocation() {
+        return new Location(1, true, "Bodega Original", "Av. Test 100", "06600",
+                "CDMX", "Cuauhtemoc", null, "CDMX", "MASONRY", 2, 1990,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000))),
+                "ZONE_A", ValidationStatus.COMPLETE, List.of());
+    }
+
+    @Test
+    void patchLocation_indexNotFound_throwsLocationNotFoundException() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(4L);
+        when(locationRepository.existsByFolioAndIndex("FOL-001", 99)).thenReturn(false);
+
+        var command = new PatchLocationUseCase.PatchLocationCommand(
+                "FOL-001", 99, 4L,
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.patchLocation(command))
+                .isInstanceOf(LocationNotFoundException.class);
+    }
+
+    @Test
+    void patchLocation_versionConflict_throwsVersionConflictException() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(5L);
+
+        var command = new PatchLocationUseCase.PatchLocationCommand(
+                "FOL-001", 1, 3L, // wrong version
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.patchLocation(command))
+                .isInstanceOf(VersionConflictException.class);
+    }
+
+    @Test
+    void patchLocation_partialPatch_onlySentFieldsChange() {
+        // GIVEN
+        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(4L);
+        when(locationRepository.existsByFolioAndIndex("FOL-001", 1)).thenReturn(true);
+        when(locationRepository.findByFolioNumber("FOL-001")).thenReturn(List.of(baseLocation()));
+        when(zipCodeValidationClient.validate("06600")).thenReturn(Optional.of(zipInfo));
+        when(locationValidationService.calculateAlerts(any(), any())).thenReturn(List.of());
+        when(locationValidationService.deriveStatus(List.of())).thenReturn(ValidationStatus.COMPLETE);
+
+        Location patched = new Location(1, true, "Bodega Nueva", "Av. Test 100", "06600",
+                "CDMX", "Cuauhtemoc", null, "CDMX", "MASONRY", 2, 1990,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000))),
+                "ZONE_A", ValidationStatus.COMPLETE, List.of());
+        when(locationRepository.patchOne(any(), anyInt(), any())).thenReturn(patched);
+        when(quoteVersionRepository.getUpdatedAt("FOL-001")).thenReturn(NOW);
+
+        var command = new PatchLocationUseCase.PatchLocationCommand(
+                "FOL-001", 1, 4L,
+                Optional.of("Bodega Nueva"), // only name changes
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+
+        // WHEN
+        PatchLocationUseCase.PatchLocationResult result = useCase.patchLocation(command);
+
+        // THEN
+        assertThat(result.location().locationName()).isEqualTo("Bodega Nueva");
+        assertThat(result.location().address()).isEqualTo("Av. Test 100"); // unchanged
+        verify(quoteVersionRepository).incrementVersion("FOL-001");
+    }
+
+    @Test
+    void patchLocation_withValidZipCode_removesMissingZipCodeAlert() {
+        // GIVEN
+        ZipCodeInfo zipInfo = new ZipCodeInfo("44100", "Jalisco", "Guadalajara", "Guadalajara", "ZONE_B", true);
+        Location original = new Location(1, true, "Sucursal", null, null,
+                null, null, null, null, null, null, null,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(500_000))),
+                null, ValidationStatus.INCOMPLETE,
+                List.of(new BlockingAlert(BlockingAlertCode.MISSING_ZIP_CODE.name(), "CP requerido")));
+
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(4L);
+        when(locationRepository.existsByFolioAndIndex("FOL-001", 1)).thenReturn(true);
+        when(locationRepository.findByFolioNumber("FOL-001")).thenReturn(List.of(original));
+        when(zipCodeValidationClient.validate("44100")).thenReturn(Optional.of(zipInfo));
+        when(locationValidationService.calculateAlerts(any(), any())).thenReturn(List.of());
+        when(locationValidationService.deriveStatus(List.of())).thenReturn(ValidationStatus.COMPLETE);
+
+        Location fixed = new Location(1, true, "Sucursal", null, "44100",
+                "Jalisco", "Guadalajara", null, "Guadalajara", null, null, null,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(500_000))),
+                "ZONE_B", ValidationStatus.COMPLETE, List.of());
+        when(locationRepository.patchOne(any(), anyInt(), any())).thenReturn(fixed);
+        when(quoteVersionRepository.getUpdatedAt("FOL-001")).thenReturn(NOW);
+
+        var command = new PatchLocationUseCase.PatchLocationCommand(
+                "FOL-001", 1, 4L,
+                Optional.empty(), Optional.empty(), Optional.of("44100"),
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty());
+
+        // WHEN
+        PatchLocationUseCase.PatchLocationResult result = useCase.patchLocation(command);
+
+        // THEN
+        assertThat(result.location().validationStatus()).isEqualTo(ValidationStatus.COMPLETE);
+        assertThat(result.location().blockingAlerts()).isEmpty();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/ReplaceLocationsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/ReplaceLocationsUseCaseImplTest.java
@@ -1,0 +1,124 @@
+package com.sofka.insurancequoter.back.location.application.usecase;
+
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import com.sofka.insurancequoter.back.location.domain.port.in.ReplaceLocationsUseCase;
+import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.QuoteVersionRepository;
+import com.sofka.insurancequoter.back.location.domain.port.out.ZipCodeValidationClient;
+import com.sofka.insurancequoter.back.location.domain.service.LocationValidationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReplaceLocationsUseCaseImplTest {
+
+    @Mock private LocationRepository locationRepository;
+    @Mock private QuoteVersionRepository quoteVersionRepository;
+    @Mock private ZipCodeValidationClient zipCodeValidationClient;
+    @Mock private LocationValidationService locationValidationService;
+
+    @InjectMocks
+    private ReplaceLocationsUseCaseImpl useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    private ReplaceLocationsUseCase.LocationData validLocationData(int index) {
+        return new ReplaceLocationsUseCase.LocationData(
+                index, "Bodega " + index, "Av. Test 100", "06600",
+                "MASONRY", 2, 1990,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000)))
+        );
+    }
+
+    private Location savedLocation(int index) {
+        return new Location(index, true, "Bodega " + index, "Av. Test 100", "06600",
+                "CDMX", "Cuauhtemoc", null, "CDMX", "MASONRY", 2, 1990,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000))),
+                "ZONE_A", ValidationStatus.COMPLETE, List.of());
+    }
+
+    @Test
+    void replaceLocations_versionConflict_throwsVersionConflictException() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(5L);
+        var command = new ReplaceLocationsUseCase.ReplaceLocationsCommand(
+                "FOL-001", List.of(validLocationData(1)), 3L); // wrong version
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.replaceLocations(command))
+                .isInstanceOf(VersionConflictException.class);
+        verify(locationRepository, never()).replaceAll(anyString(), any());
+    }
+
+    @Test
+    void replaceLocations_validData_returnsCompleteStatus() {
+        // GIVEN
+        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(4L);
+        when(zipCodeValidationClient.validate("06600")).thenReturn(Optional.of(zipInfo));
+        when(locationValidationService.calculateAlerts(any(), any())).thenReturn(List.of());
+        when(locationValidationService.deriveStatus(List.of())).thenReturn(ValidationStatus.COMPLETE);
+        when(locationRepository.replaceAll(anyString(), any())).thenReturn(List.of(savedLocation(1)));
+        when(quoteVersionRepository.getUpdatedAt("FOL-001")).thenReturn(NOW);
+
+        var command = new ReplaceLocationsUseCase.ReplaceLocationsCommand(
+                "FOL-001", List.of(validLocationData(1)), 4L);
+
+        // WHEN
+        ReplaceLocationsUseCase.ReplaceLocationsResult result = useCase.replaceLocations(command);
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-001");
+        assertThat(result.locations()).hasSize(1);
+        assertThat(result.locations().get(0).validationStatus()).isEqualTo(ValidationStatus.COMPLETE);
+        verify(quoteVersionRepository).incrementVersion("FOL-001");
+    }
+
+    @Test
+    void replaceLocations_invalidZipCode_generates_MISSING_ZIP_CODE_alert() {
+        // GIVEN
+        when(quoteVersionRepository.findVersionByFolioNumber("FOL-001")).thenReturn(4L);
+        when(zipCodeValidationClient.validate("99999")).thenReturn(Optional.empty());
+        BlockingAlert alert = new BlockingAlert(BlockingAlertCode.MISSING_ZIP_CODE.name(), "CP requerido");
+        when(locationValidationService.calculateAlerts(any(), any())).thenReturn(List.of(alert));
+        when(locationValidationService.deriveStatus(List.of(alert))).thenReturn(ValidationStatus.INCOMPLETE);
+
+        Location savedWithAlert = new Location(1, true, "Bodega", null, "99999",
+                null, null, null, null, null, null, null,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000))),
+                null, ValidationStatus.INCOMPLETE, List.of(alert));
+        when(locationRepository.replaceAll(anyString(), any())).thenReturn(List.of(savedWithAlert));
+        when(quoteVersionRepository.getUpdatedAt("FOL-001")).thenReturn(NOW);
+
+        var data = new ReplaceLocationsUseCase.LocationData(
+                1, "Bodega", null, "99999", null, null, null,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000))));
+        var command = new ReplaceLocationsUseCase.ReplaceLocationsCommand("FOL-001", List.of(data), 4L);
+
+        // WHEN
+        ReplaceLocationsUseCase.ReplaceLocationsResult result = useCase.replaceLocations(command);
+
+        // THEN
+        assertThat(result.locations().get(0).validationStatus()).isEqualTo(ValidationStatus.INCOMPLETE);
+        assertThat(result.locations().get(0).blockingAlerts())
+                .anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_ZIP_CODE.name()));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/application/usecase/SaveLocationLayoutUseCaseImplTest.java
@@ -3,6 +3,7 @@ package com.sofka.insurancequoter.back.location.application.usecase;
 import com.sofka.insurancequoter.back.location.domain.model.LayoutConfiguration;
 import com.sofka.insurancequoter.back.location.domain.model.Location;
 import com.sofka.insurancequoter.back.location.domain.model.LocationType;
+import com.sofka.insurancequoter.back.location.domain.model.ValidationStatus;
 import com.sofka.insurancequoter.back.location.domain.port.out.LocationRepository;
 import com.sofka.insurancequoter.back.location.domain.port.out.QuoteLayoutRepository;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,13 @@ class SaveLocationLayoutUseCaseImplTest {
     private SaveLocationLayoutUseCaseImpl useCase;
 
     private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    // Helper to build minimal Location domain objects for layout tests
+    private static Location loc(int index, boolean active) {
+        return new Location(index, active, null, null, null,
+                null, null, null, null, null, null, null,
+                null, null, null, ValidationStatus.INCOMPLETE, List.of());
+    }
 
     private QuoteLayoutData quoteData(Long id, Integer currentLocations, String currentType, Long version) {
         return new QuoteLayoutData(id, "FOL-2026-00042", currentLocations, currentType, version, NOW);
@@ -79,8 +87,7 @@ class SaveLocationLayoutUseCaseImplTest {
         // GIVEN
         var existing = quoteData(10L, 2, "MULTIPLE", 3L);
         when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
-        when(locationRepository.findAllByQuoteId(10L))
-                .thenReturn(List.of(new Location(1, true), new Location(2, true)));
+        when(locationRepository.findAllByQuoteId(10L)).thenReturn(List.of(loc(1, true), loc(2, true)));
         when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         var command = new SaveLayoutCommand(
@@ -108,11 +115,7 @@ class SaveLocationLayoutUseCaseImplTest {
         var existing = quoteData(10L, 4, "MULTIPLE", 4L);
         when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
         when(locationRepository.findAllByQuoteId(10L))
-                .thenReturn(List.of(
-                        new Location(1, true),
-                        new Location(2, true),
-                        new Location(3, true),
-                        new Location(4, true)));
+                .thenReturn(List.of(loc(1, true), loc(2, true), loc(3, true), loc(4, true)));
         when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         var command = new SaveLayoutCommand(
@@ -139,11 +142,7 @@ class SaveLocationLayoutUseCaseImplTest {
         var existing = quoteData(10L, 2, "MULTIPLE", 5L);
         when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
         when(locationRepository.findAllByQuoteId(10L))
-                .thenReturn(List.of(
-                        new Location(1, true),
-                        new Location(2, true),
-                        new Location(3, false),
-                        new Location(4, false)));
+                .thenReturn(List.of(loc(1, true), loc(2, true), loc(3, false), loc(4, false)));
         when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         var command = new SaveLayoutCommand(
@@ -170,10 +169,7 @@ class SaveLocationLayoutUseCaseImplTest {
         var existing = quoteData(10L, 1, "MULTIPLE", 6L);
         when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
         when(locationRepository.findAllByQuoteId(10L))
-                .thenReturn(List.of(
-                        new Location(1, true),
-                        new Location(2, false),
-                        new Location(3, false)));
+                .thenReturn(List.of(loc(1, true), loc(2, false), loc(3, false)));
         when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         var command = new SaveLayoutCommand(
@@ -202,10 +198,7 @@ class SaveLocationLayoutUseCaseImplTest {
         var existing = quoteData(10L, 3, "MULTIPLE", 2L);
         when(quoteLayoutRepository.findByFolioNumber("FOL-2026-00042")).thenReturn(Optional.of(existing));
         when(locationRepository.findAllByQuoteId(10L))
-                .thenReturn(List.of(
-                        new Location(1, true),
-                        new Location(2, true),
-                        new Location(3, true)));
+                .thenReturn(List.of(loc(1, true), loc(2, true), loc(3, true)));
         when(quoteLayoutRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         var command = new SaveLayoutCommand(

--- a/src/test/java/com/sofka/insurancequoter/back/location/domain/service/LocationValidationServiceTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/domain/service/LocationValidationServiceTest.java
@@ -1,0 +1,88 @@
+package com.sofka.insurancequoter.back.location.domain.service;
+
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocationValidationServiceTest {
+
+    private LocationValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LocationValidationService();
+    }
+
+    private Location locationWith(String zipCode, BusinessLine businessLine, List<Guarantee> guarantees) {
+        return new Location(1, true, "Test", null, zipCode, null, null,
+                null, null, null, null, null,
+                businessLine, guarantees, null, ValidationStatus.INCOMPLETE, List.of());
+    }
+
+    @Test
+    void nullZipCode_generates_MISSING_ZIP_CODE_alert() {
+        Location location = locationWith(null, new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.empty());
+        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_ZIP_CODE.name()));
+    }
+
+    @Test
+    void emptyZipCode_generates_MISSING_ZIP_CODE_alert() {
+        Location location = locationWith("", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.empty());
+        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_ZIP_CODE.name()));
+    }
+
+    @Test
+    void zipCodeInfoEmpty_generates_MISSING_ZIP_CODE_alert() {
+        Location location = locationWith("99999", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.empty());
+        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_ZIP_CODE.name()));
+    }
+
+    @Test
+    void nullBusinessLine_generates_MISSING_FIRE_KEY_alert() {
+        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
+        Location location = locationWith("06600", null, List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_FIRE_KEY.name()));
+    }
+
+    @Test
+    void businessLineWithNullFireKey_generates_MISSING_FIRE_KEY_alert() {
+        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
+        Location location = locationWith("06600", new BusinessLine("BL-001", null, "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_FIRE_KEY.name()));
+    }
+
+    @Test
+    void emptyGuarantees_generates_NO_TARIFABLE_GUARANTEES_alert() {
+        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
+        Location location = locationWith("06600", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of());
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.NO_TARIFABLE_GUARANTEES.name()));
+    }
+
+    @Test
+    void validData_generates_no_alerts_and_status_is_COMPLETE() {
+        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
+        Location location = locationWith("06600", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        assertThat(alerts).isEmpty();
+        assertThat(service.deriveStatus(alerts)).isEqualTo(ValidationStatus.COMPLETE);
+    }
+
+    @Test
+    void alertsPresent_status_is_INCOMPLETE() {
+        Location location = locationWith(null, null, List.of());
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.empty());
+        assertThat(service.deriveStatus(alerts)).isEqualTo(ValidationStatus.INCOMPLETE);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationControllerTest.java
@@ -1,0 +1,178 @@
+package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.GlobalExceptionHandler;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.LocationNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import com.sofka.insurancequoter.back.location.domain.model.*;
+import com.sofka.insurancequoter.back.location.domain.port.in.*;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.*;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper.LocationRestMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class LocationControllerTest {
+
+    @Mock private GetLocationsUseCase getLocationsUseCase;
+    @Mock private ReplaceLocationsUseCase replaceLocationsUseCase;
+    @Mock private PatchLocationUseCase patchLocationUseCase;
+    @Mock private GetLocationsSummaryUseCase getLocationsSummaryUseCase;
+    @Mock private LocationRestMapper locationRestMapper;
+
+    private MockMvc mockMvc;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    @BeforeEach
+    void setUp() {
+        var controller = new LocationController(
+                getLocationsUseCase, replaceLocationsUseCase,
+                patchLocationUseCase, getLocationsSummaryUseCase,
+                locationRestMapper);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    private Location sampleLocation(int index) {
+        return new Location(index, true, "Bodega " + index, "Av. Test 100", "06600",
+                "CDMX", "Cuauhtemoc", null, "CDMX", "MASONRY", 2, 1990,
+                new BusinessLine("BL-001", "FK-01", "Bodega"),
+                List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000))),
+                "ZONE_A", ValidationStatus.COMPLETE, List.of());
+    }
+
+    @Test
+    void GET_locations_returns200_whenFolioExists() throws Exception {
+        var result = new GetLocationsUseCase.LocationsResult("FOL-001", List.of(sampleLocation(1)), 4L);
+        when(getLocationsUseCase.getLocations("FOL-001")).thenReturn(result);
+        when(locationRestMapper.toLocationsListResponse(result))
+                .thenReturn(new LocationsListResponse("FOL-001", List.of(), 4L));
+
+        mockMvc.perform(get("/v1/quotes/FOL-001/locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-001"))
+                .andExpect(jsonPath("$.version").value(4));
+    }
+
+    @Test
+    void GET_locations_returns404_whenFolioNotFound() throws Exception {
+        when(getLocationsUseCase.getLocations("UNKNOWN")).thenThrow(new FolioNotFoundException("UNKNOWN"));
+
+        mockMvc.perform(get("/v1/quotes/UNKNOWN/locations"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+    }
+
+    @Test
+    void PUT_locations_returns200_withVersionIncremented() throws Exception {
+        var replaceResult = new ReplaceLocationsUseCase.ReplaceLocationsResult(
+                "FOL-001", List.of(sampleLocation(1)), NOW, 5L);
+        when(replaceLocationsUseCase.replaceLocations(any())).thenReturn(replaceResult);
+        when(locationRestMapper.toLocationsListResponseWithTimestamp(replaceResult))
+                .thenReturn(new LocationsListResponseWithTimestamp("FOL-001", List.of(), NOW, 5L));
+
+        String body = """
+                {
+                  "locations": [{
+                    "index": 1,
+                    "locationName": "Bodega",
+                    "zipCode": "06600",
+                    "businessLine": {"code": "BL-001", "fireKey": "FK-01"},
+                    "guarantees": [{"code": "GUA-FIRE", "insuredValue": 1000000}]
+                  }],
+                  "version": 4
+                }
+                """;
+
+        mockMvc.perform(put("/v1/quotes/FOL-001/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.version").value(5));
+    }
+
+    @Test
+    void PUT_locations_returns409_whenVersionConflict() throws Exception {
+        when(replaceLocationsUseCase.replaceLocations(any()))
+                .thenThrow(new VersionConflictException("FOL-001", 3L, 5L));
+
+        String body = """
+                {"locations": [], "version": 3}
+                """;
+
+        mockMvc.perform(put("/v1/quotes/FOL-001/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("VERSION_CONFLICT"));
+    }
+
+    @Test
+    void PATCH_location_returns200() throws Exception {
+        var patchResult = new PatchLocationUseCase.PatchLocationResult("FOL-001", sampleLocation(1), NOW, 6L);
+        when(patchLocationUseCase.patchLocation(any())).thenReturn(patchResult);
+        when(locationRestMapper.toPatchWrapperResponse(patchResult))
+                .thenReturn(new LocationPatchWrapperResponse("FOL-001", null, NOW, 6L));
+
+        String body = """
+                {"locationName": "Bodega Nueva", "version": 5}
+                """;
+
+        mockMvc.perform(patch("/v1/quotes/FOL-001/locations/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.version").value(6));
+    }
+
+    @Test
+    void PATCH_location_returns404_whenIndexNotFound() throws Exception {
+        when(patchLocationUseCase.patchLocation(any()))
+                .thenThrow(new LocationNotFoundException("FOL-001", 99));
+
+        String body = """
+                {"locationName": "X", "version": 5}
+                """;
+
+        mockMvc.perform(patch("/v1/quotes/FOL-001/locations/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("LOCATION_NOT_FOUND"));
+    }
+
+    @Test
+    void GET_summary_returns200_withCorrectCounts() throws Exception {
+        var summaryResult = new GetLocationsSummaryUseCase.SummaryResult(
+                "FOL-001", 2, 1, 1,
+                List.of(new LocationSummary(1, "Bodega", ValidationStatus.COMPLETE, List.of())));
+        when(getLocationsSummaryUseCase.getSummary("FOL-001")).thenReturn(summaryResult);
+        when(locationRestMapper.toSummaryWrapperResponse(summaryResult))
+                .thenReturn(new LocationsSummaryWrapperResponse("FOL-001", 2, 1, 1, List.of()));
+
+        mockMvc.perform(get("/v1/quotes/FOL-001/locations/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalLocations").value(2))
+                .andExpect(jsonPath("$.completeLocations").value(1))
+                .andExpect(jsonPath("$.incompleteLocations").value(1));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationJpaAdapterTest.java
@@ -1,10 +1,14 @@
 package com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence;
 
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
 import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.ValidationStatus;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.adapter.LocationJpaAdapter;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -13,8 +17,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
@@ -27,8 +33,18 @@ class LocationJpaAdapterTest {
     @Mock
     private LocationPersistenceMapper mapper;
 
+    @Mock
+    private QuoteJpaRepository quoteJpaRepository;
+
     @InjectMocks
     private LocationJpaAdapter adapter;
+
+    // Helper: minimal Location domain object
+    private static Location loc(int index, boolean active) {
+        return new Location(index, active, null, null, null,
+                null, null, null, null, null, null, null,
+                null, null, null, ValidationStatus.INCOMPLETE, List.of());
+    }
 
     @Test
     void shouldReturnActiveLocations_whenQuoteHasActiveLocations() {
@@ -36,8 +52,8 @@ class LocationJpaAdapterTest {
         LocationJpa jpa1 = LocationJpa.builder().id(1L).quoteId(10L).index(1).active(true).build();
         LocationJpa jpa2 = LocationJpa.builder().id(2L).quoteId(10L).index(2).active(true).build();
         when(locationJpaRepository.findByQuoteIdAndActiveTrue(10L)).thenReturn(List.of(jpa1, jpa2));
-        when(mapper.toDomain(jpa1)).thenReturn(new Location(1, true));
-        when(mapper.toDomain(jpa2)).thenReturn(new Location(2, true));
+        when(mapper.toDomain(jpa1)).thenReturn(loc(1, true));
+        when(mapper.toDomain(jpa2)).thenReturn(loc(2, true));
 
         // WHEN
         List<Location> result = adapter.findActiveByQuoteId(10L);
@@ -53,8 +69,8 @@ class LocationJpaAdapterTest {
         LocationJpa active = LocationJpa.builder().id(1L).quoteId(10L).index(1).active(true).build();
         LocationJpa inactive = LocationJpa.builder().id(2L).quoteId(10L).index(2).active(false).build();
         when(locationJpaRepository.findByQuoteId(10L)).thenReturn(List.of(active, inactive));
-        when(mapper.toDomain(active)).thenReturn(new Location(1, true));
-        when(mapper.toDomain(inactive)).thenReturn(new Location(2, false));
+        when(mapper.toDomain(active)).thenReturn(loc(1, true));
+        when(mapper.toDomain(inactive)).thenReturn(loc(2, false));
 
         // WHEN
         List<Location> result = adapter.findAllByQuoteId(10L);
@@ -67,11 +83,13 @@ class LocationJpaAdapterTest {
     @Test
     void shouldInsertNewLocations_whenInsertAllCalled() {
         // GIVEN
-        List<Location> newLocations = List.of(new Location(3, true), new Location(4, true));
+        Location l3 = loc(3, true);
+        Location l4 = loc(4, true);
+        List<Location> newLocations = List.of(l3, l4);
         LocationJpa jpa3 = LocationJpa.builder().quoteId(10L).index(3).active(true).build();
         LocationJpa jpa4 = LocationJpa.builder().quoteId(10L).index(4).active(true).build();
-        when(mapper.toLocationJpa(10L, new Location(3, true))).thenReturn(jpa3);
-        when(mapper.toLocationJpa(10L, new Location(4, true))).thenReturn(jpa4);
+        when(mapper.toLocationJpa(10L, l3)).thenReturn(jpa3);
+        when(mapper.toLocationJpa(10L, l4)).thenReturn(jpa4);
 
         // WHEN
         adapter.insertAll(10L, newLocations);
@@ -123,5 +141,49 @@ class LocationJpaAdapterTest {
         assertThat(jpa3.getActive()).isTrue();
         assertThat(jpa4.getActive()).isTrue();
         verify(locationJpaRepository).saveAll(List.of(jpa3, jpa4));
+    }
+
+    @Test
+    void findByFolioNumber_returnsEmptyList_whenNoLocationsExist() {
+        // GIVEN
+        QuoteJpa quote = QuoteJpa.builder().id(10L).folioNumber("FOL-001").build();
+        when(quoteJpaRepository.findByFolioNumber("FOL-001")).thenReturn(Optional.of(quote));
+        when(locationJpaRepository.findByQuoteId(10L)).thenReturn(List.of());
+
+        // WHEN
+        List<Location> result = adapter.findByFolioNumber("FOL-001");
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findByFolioNumber_throwsFolioNotFoundException_whenFolioDoesNotExist() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber("UNKNOWN")).thenReturn(Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> adapter.findByFolioNumber("UNKNOWN"))
+                .isInstanceOf(FolioNotFoundException.class);
+    }
+
+    @Test
+    void replaceAll_deletesExistingAndPersistsNew() {
+        // GIVEN
+        QuoteJpa quote = QuoteJpa.builder().id(10L).folioNumber("FOL-001").build();
+        when(quoteJpaRepository.findByFolioNumber("FOL-001")).thenReturn(Optional.of(quote));
+        Location l1 = loc(1, true);
+        LocationJpa jpa1 = LocationJpa.builder().quoteId(10L).index(1).active(true).build();
+        when(mapper.toLocationJpa(10L, l1)).thenReturn(jpa1);
+        when(locationJpaRepository.saveAll(any())).thenReturn(List.of(jpa1));
+        when(mapper.toDomain(jpa1)).thenReturn(l1);
+
+        // WHEN
+        List<Location> result = adapter.replaceAll("FOL-001", List.of(l1));
+
+        // THEN
+        verify(locationJpaRepository).deleteByQuoteId(10L);
+        verify(locationJpaRepository).flush();
+        assertThat(result).hasSize(1);
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationPersistenceMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/LocationPersistenceMapperTest.java
@@ -49,7 +49,11 @@ class LocationPersistenceMapperTest {
     @Test
     void shouldMapLocationToJpa_withActiveTrue() {
         // GIVEN
-        Location location = new Location(2, true);
+        Location location = new Location(2, true, null, null, null,
+                null, null, null, null, null, null, null,
+                null, null, null,
+                com.sofka.insurancequoter.back.location.domain.model.ValidationStatus.INCOMPLETE,
+                java.util.List.of());
 
         // WHEN
         LocationJpa jpa = mapper.toLocationJpa(42L, location);


### PR DESCRIPTION
## Resumen
Implementación completa del módulo de gestión de ubicaciones (SPEC-004).

## Cambios

### Dominio
- `Location` record (17 campos), `BusinessLine`, `Guarantee`, `BlockingAlert`, `ValidationStatus`, `LocationSummary`, `ZipCodeInfo`
- `LocationValidationService` — validación CP, fire key, garantías tarificables

### Application
- `SaveLocationLayoutUseCase` — PUT layout inicial
- `ReplaceLocationsUseCase` — PUT replace con control de versión optimista
- `PatchLocationUseCase` — PATCH parcial por índice
- `GetLocationsUseCase` / `GetLocationsSummaryUseCase`

### Infraestructura
- Migraciones V5 (15 columnas) y V6 (tabla `location_blocking_alerts`)
- `GuaranteesConverter` — JSONB con Jackson sin Hypersistence
- `QuoteVersionJpaAdapter` — native SQL + `REQUIRES_NEW` para incremento atómico de versión
- `ZipCodeValidationClientAdapter` → core service (`http://localhost:8081`)
- `LocationController`: 4 endpoints bajo `/v1/quotes/{folioNumber}/locations`
- `GlobalExceptionHandler`: 404 `LOCATION_NOT_FOUND`, 409 `VERSION_CONFLICT`
- `ddl-auto=none` — Flyway gestiona esquema exclusivamente

### Tests
- 6 suites TDD (use cases, adapters, domain service, controller)

### QA
- 15 escenarios Gherkin (CRITERIO-1.1..4.2)
- Matriz de riesgos ASD: 4 ALTO, 4 MEDIO, 2 BAJO

## Issues
Cierra #82 #83 #84 #85 #86 #87 #88 #89 #90 #91 #92 #93 #94 #95 #96 #97 #98 #99 #100 #101 #102 #103 #104 #105 #106 #107 #108 #109 #110 #111 #112 #113 #114 #115 #116 #117 #118 #119 #120 #121 #122 #123 #124 #125