### PR TITLE
feat(quote-state): consulta de estado y progreso de cotización SPEC-005

### DIFF
--- a/.claude/specs/quote-state.spec.md
+++ b/.claude/specs/quote-state.spec.md
@@ -1,0 +1,366 @@
+---
+id: SPEC-005
+status: DRAFT
+feature: quote-state
+created: 2026-04-21
+updated: 2026-04-21
+author: spec-generator
+version: "1.0"
+related-specs:
+  - SPEC-001  # folio-generator (Quote aggregate raíz)
+  - SPEC-002  # folio-management (POST /v1/folios)
+  - SPEC-003  # location-layout (layout columns en quotes)
+  - SPEC-004  # location-management (locations + validationStatus + blockingAlerts)
+---
+
+# Spec: Estado y Progreso de Completitud de Cotización
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+`Insurance-Quoter-Back` expone `GET /v1/quotes/{folio}/state` para consultar el estado actual y el porcentaje de completitud de una cotización. El endpoint evalúa cinco secciones del folio (`generalInfo`, `layout`, `locations`, `coverageOptions`, `calculation`), calcula el porcentaje en el use case (no se persiste) y retorna un snapshot de progreso que el frontend usa para renderizar el indicador de avance del flujo.
+
+### Requerimiento de Negocio
+
+El frontend necesita conocer, en una sola llamada, qué tan completo está el folio para habilitar o deshabilitar el botón de cálculo y mostrar el progreso por sección. Sin esta consulta el usuario no puede saber qué le falta completar antes de ejecutar el cálculo.
+
+### Historias de Usuario
+
+#### HU-01: Consultar estado y progreso de una cotización
+
+```
+Como:        agente de seguros que trabaja en un folio activo
+Quiero:      consultar GET /v1/quotes/{folio}/state
+Para:        conocer qué secciones están completas e incompletas y el progreso total
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: SPEC-001, SPEC-002, SPEC-003, SPEC-004
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path — folio con secciones mixtas**
+```gherkin
+CRITERIO-1.1: Consulta exitosa de estado con progreso parcial
+  Dado que:  existe un folio "FOL-2026-00042" con layout configurado y al menos una ubicación completa
+             pero sin opciones de cobertura ni cálculo ejecutado
+  Cuando:    el agente llama GET /v1/quotes/FOL-2026-00042/state
+  Entonces:  el sistema retorna HTTP 200 con quoteStatus, completionPercentage, sections detalladas,
+             version y updatedAt
+             Y completionPercentage refleja la proporción de secciones COMPLETE sobre 5
+```
+
+**Happy Path — folio recién creado**
+```gherkin
+CRITERIO-1.2: Folio recién creado tiene progreso cero
+  Dado que:  existe un folio en estado CREATED sin ninguna sección completada
+  Cuando:    el agente llama GET /v1/quotes/{folio}/state
+  Entonces:  el sistema retorna HTTP 200 con completionPercentage = 0
+             Y todas las secciones retornan PENDING excepto las que puedan inferirse como IN_PROGRESS
+```
+
+**Happy Path — folio totalmente calculado**
+```gherkin
+CRITERIO-1.3: Folio CALCULATED muestra todas las secciones COMPLETE
+  Dado que:  existe un folio en estado CALCULATED con todas las secciones completadas
+  Cuando:    el agente llama GET /v1/quotes/{folio}/state
+  Entonces:  el sistema retorna HTTP 200 con completionPercentage = 100
+             Y todas las secciones retornan COMPLETE
+             Y quoteStatus = "CALCULATED"
+```
+
+**Error Path — folio inexistente**
+```gherkin
+CRITERIO-1.4: Folio no encontrado retorna 404
+  Dado que:  el folio "FOL-INEXISTENTE" no existe en la base de datos
+  Cuando:    el agente llama GET /v1/quotes/FOL-INEXISTENTE/state
+  Entonces:  el sistema retorna HTTP 404
+             Y el body contiene { "error": "Folio not found", "code": "FOLIO_NOT_FOUND" }
+```
+
+**Edge Case — secciones con dependencias no implementadas**
+```gherkin
+CRITERIO-1.5: Secciones pendientes de implementación retornan PENDING
+  Dado que:  las features general-info y coverage-options aún no están implementadas
+             (columnas o entidades relacionadas no existen en DB)
+  Cuando:    el agente consulta el estado de cualquier folio
+  Entonces:  las secciones generalInfo y coverageOptions retornan PENDING
+             Y el sistema no lanza excepción por campos nulos
+```
+
+### Reglas de Negocio
+
+1. `completionPercentage` = `(secciones en COMPLETE) / 5 * 100`, redondeado al entero más cercano.
+2. La evaluación es **read-only**: ninguna escritura, ningún cambio de estado.
+3. Una sección es `COMPLETE` cuando todos sus campos obligatorios están presentes y sin alertas bloqueantes activas.
+4. Una sección es `INCOMPLETE` cuando tiene datos parciales con alertas bloqueantes.
+5. Una sección es `IN_PROGRESS` cuando tiene datos parciales sin alertas bloqueantes (rellena a medias, pero sin errores).
+6. Una sección es `PENDING` cuando no tiene ningún dato registrado.
+7. La sección `generalInfo` se evalúa con los campos de datos del asegurado e información de suscripción. Requiere SPEC-006 (general-info); hasta entonces devuelve `PENDING`.
+8. La sección `layout` se evalúa con `numberOfLocations` y `locationType` de la tabla `quotes`.
+9. La sección `locations` se evalúa cruzando el `validationStatus` y `blockingAlerts` de todas las ubicaciones del folio.
+10. La sección `coverageOptions` requiere SPEC-007 (coverage-options); hasta entonces devuelve `PENDING`.
+11. La sección `calculation` es `COMPLETE` si `quoteStatus = CALCULATED`, `PENDING` en cualquier otro caso.
+12. Si `quoteStatus = CALCULATED`, el porcentaje debe ser 100 independientemente del estado de las secciones individuales.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Almacén | Cambios | Descripción |
+|---------|---------|---------|-------------|
+| `QuoteJpa` | tabla `quotes` | **ninguno** — solo lectura | Aggregate raíz; aporta quoteStatus, numberOfLocations, locationType, version, updatedAt |
+| `LocationJpa` | tabla `locations` | **ninguno** — solo lectura | Aporta validationStatus y blockingAlerts por folio |
+
+No se crean tablas nuevas ni columnas nuevas en esta spec.
+
+#### Campos leídos de `quotes` para evaluación de secciones
+
+| Campo | Sección evaluada | Regla |
+|-------|-----------------|-------|
+| `quote_status` | `calculation`, `quoteStatus` | CALCULATED → calculation COMPLETE |
+| `number_of_locations` | `layout` | > 0 → layout IN_PROGRESS o COMPLETE |
+| `location_type` | `layout` | no null → layout avanza a COMPLETE |
+| `version` | response | retornado como está |
+| `updated_at` | response | retornado como está |
+
+#### Campos leídos de `locations` para evaluación de `locations`
+
+| Campo | Regla |
+|-------|-------|
+| `validation_status` | Si todas son `COMPLETE` → sección COMPLETE; alguna `INCOMPLETE` → sección INCOMPLETE |
+| `blocking_alerts` (tabla `location_blocking_alerts`) | Confirmación de alertas activas |
+| conteo de filas | Sin filas para el folio → sección PENDING |
+
+#### Lógica de evaluación por sección
+
+| Sección | PENDING | IN_PROGRESS | COMPLETE | INCOMPLETE |
+|---------|---------|-------------|----------|------------|
+| `generalInfo` | campos de asegurado nulos (requiere SPEC-006) | parcialmente llenos sin alertas | todos los campos obligatorios presentes | campos con alertas bloqueantes |
+| `layout` | `numberOfLocations IS NULL` | — | `numberOfLocations > 0` AND `locationType IS NOT NULL` | — |
+| `locations` | sin registros en `locations` para el folio | al menos una ubicación, ninguna COMPLETE del todo | todas las ubicaciones con `validationStatus = COMPLETE` | al menos una ubicación con `blockingAlerts` no vacía |
+| `coverageOptions` | no configurado (requiere SPEC-007) | parcialmente configurado | al menos una opción con `selected = true` | — |
+| `calculation` | `quoteStatus != CALCULATED` | — | `quoteStatus = CALCULATED` | — |
+
+### Modelos de Dominio (nuevos)
+
+```
+folio/domain/model/
+├── QuoteState.java          ← record (folioNumber, quoteStatus, completionPercentage, sections, version, updatedAt)
+├── SectionStatus.java       ← enum (PENDING, IN_PROGRESS, COMPLETE, INCOMPLETE)
+└── QuoteSections.java       ← record (generalInfo, layout, locations, coverageOptions, calculation)
+```
+
+```java
+// QuoteState.java
+public record QuoteState(
+    String folioNumber,
+    String quoteStatus,
+    int completionPercentage,
+    QuoteSections sections,
+    Long version,
+    Instant updatedAt
+) {}
+
+// QuoteSections.java
+public record QuoteSections(
+    SectionStatus generalInfo,
+    SectionStatus layout,
+    SectionStatus locations,
+    SectionStatus coverageOptions,
+    SectionStatus calculation
+) {}
+
+// SectionStatus.java
+public enum SectionStatus { PENDING, IN_PROGRESS, COMPLETE, INCOMPLETE }
+```
+
+### Puertos (nuevos)
+
+```
+folio/domain/port/in/
+└── GetQuoteStateUseCase.java          ← QuoteState getState(String folioNumber)
+
+folio/domain/port/out/
+└── LocationStateReader.java           ← LocationStateSummary readByFolioNumber(String folioNumber)
+```
+
+```java
+// LocationStateReader.java — output port (leído desde folio BC sin depender de location BC en dominio)
+public interface LocationStateReader {
+    LocationStateSummary readByFolioNumber(String folioNumber);
+}
+
+// LocationStateSummary.java — VO en folio/domain/model
+public record LocationStateSummary(
+    int total,
+    long completeCount,
+    long incompleteCount   // tienen blockingAlerts
+) {}
+```
+
+### API Endpoints
+
+#### GET /v1/quotes/{folio}/state
+
+- **Descripción:** Retorna el estado actual y progreso de completitud del folio
+- **Auth requerida:** no
+- **Path param:** `folio` — número de folio (ej. `FOL-2026-00042`)
+
+**Response 200:**
+```json
+{
+  "folioNumber": "FOL-2026-00042",
+  "quoteStatus": "IN_PROGRESS",
+  "completionPercentage": 40,
+  "sections": {
+    "generalInfo": "PENDING",
+    "layout": "COMPLETE",
+    "locations": "INCOMPLETE",
+    "coverageOptions": "PENDING",
+    "calculation": "PENDING"
+  },
+  "version": 6,
+  "updatedAt": "2026-04-20T15:35:00Z"
+}
+```
+
+**Response 404:**
+```json
+{ "error": "Folio not found", "code": "FOLIO_NOT_FOUND" }
+```
+
+### Arquitectura y Dependencias
+
+**Bounded context:** `folio` — el endpoint pertenece al aggregate raíz `Quote`.
+
+**Paquetes nuevos:**
+
+```
+folio/
+├── domain/
+│   ├── model/
+│   │   ├── QuoteState.java              ← nuevo
+│   │   ├── QuoteSections.java           ← nuevo
+│   │   ├── SectionStatus.java           ← nuevo (enum)
+│   │   └── LocationStateSummary.java    ← nuevo (VO)
+│   └── port/
+│       ├── in/
+│       │   └── GetQuoteStateUseCase.java ← nuevo
+│       └── out/
+│           └── LocationStateReader.java  ← nuevo
+├── application/
+│   └── usecase/
+│       └── GetQuoteStateUseCaseImpl.java ← nuevo
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/
+    │   │   └── rest/
+    │   │       ├── QuoteStateController.java    ← nuevo
+    │   │       ├── dto/
+    │   │       │   ├── QuoteStateResponse.java  ← nuevo
+    │   │       │   └── SectionsResponse.java    ← nuevo
+    │   │       ├── mapper/
+    │   │       │   └── QuoteStateRestMapper.java ← nuevo
+    │   │       └── swaggerdocs/
+    │   │           └── QuoteStateApi.java       ← nuevo
+    │   └── out/
+    │       └── persistence/
+    │           └── adapter/
+    │               └── LocationStateJpaAdapter.java ← nuevo (usa LocationJpaRepository)
+    └── config/
+        └── FolioConfig.java    ← actualizar: añadir bean GetQuoteStateUseCaseImpl
+```
+
+**Servicios externos:** ninguno. Lectura pura de DB.
+
+**Impacto en puntos de entrada:** `FolioConfig.java` requiere un nuevo `@Bean`.
+
+### Notas de Implementación
+
+- `LocationStateJpaAdapter` inyecta `LocationJpaRepository` (del bounded context `location`). Esto es aceptable porque es una query de solo lectura dentro del mismo módulo; si el proyecto evoluciona a microservicios reales, se reemplaza por un HTTP client.
+- `GetQuoteStateUseCaseImpl` no lanza excepción cuando campos de `generalInfo` o `coverageOptions` son nulos — devuelve `PENDING` con null-safe guards.
+- El `completionPercentage` cuando `quoteStatus = CALCULATED` debe forzarse a 100, ignorando el conteo de secciones individuales (por si alguna quedó sin datos en DB).
+- El `GlobalExceptionHandler` ya maneja `FolioNotFoundException` → 404 `FOLIO_NOT_FOUND`; no se necesita cambio.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable para todos los agentes. Marcar cada ítem (`[x]`) al completarlo.
+
+### Backend
+
+#### Dominio
+- [ ] Crear enum `SectionStatus` — `PENDING`, `IN_PROGRESS`, `COMPLETE`, `INCOMPLETE`
+- [ ] Crear record `LocationStateSummary` — `total`, `completeCount`, `incompleteCount`
+- [ ] Crear record `QuoteSections` — cinco campos `SectionStatus`
+- [ ] Crear record `QuoteState` — `folioNumber`, `quoteStatus`, `completionPercentage`, `sections`, `version`, `updatedAt`
+- [ ] Crear input port `GetQuoteStateUseCase` — `QuoteState getState(String folioNumber)`
+- [ ] Crear output port `LocationStateReader` — `LocationStateSummary readByFolioNumber(String folioNumber)`
+
+#### Application
+- [ ] Implementar `GetQuoteStateUseCaseImpl`:
+  - [ ] Resolver `Quote` via `QuoteRepository.findByFolioNumber()` (lanzar `FolioNotFoundException` si no existe)
+  - [ ] Resolver `LocationStateSummary` via `LocationStateReader`
+  - [ ] Evaluar sección `layout` con null-safe de `numberOfLocations` y `locationType`
+  - [ ] Evaluar sección `locations` con totales y conteos de `LocationStateSummary`
+  - [ ] Evaluar sección `calculation` basada en `quoteStatus`
+  - [ ] Devolver `PENDING` para `generalInfo` y `coverageOptions` hasta que sus specs se implementen
+  - [ ] Calcular `completionPercentage`; forzar 100 si `quoteStatus = CALCULATED`
+
+#### Persistence Adapter
+- [ ] Implementar `LocationStateJpaAdapter implements LocationStateReader`:
+  - [ ] Inyectar `LocationJpaRepository`
+  - [ ] Contar total de ubicaciones por `folioNumber`
+  - [ ] Contar las que tienen `validationStatus = 'COMPLETE'`
+  - [ ] Contar las que tienen al menos una fila en `location_blocking_alerts`
+  - [ ] Retornar `LocationStateSummary`
+
+#### REST Adapter
+- [ ] Crear `QuoteStateResponse` — `folioNumber`, `quoteStatus`, `completionPercentage`, `sections` (mapa o `SectionsResponse`), `version`, `updatedAt`
+- [ ] Crear `SectionsResponse` — cinco campos String (valores del enum)
+- [ ] Crear `QuoteStateRestMapper` — `QuoteState → QuoteStateResponse`
+- [ ] Crear `QuoteStateController`:
+  - [ ] `GET /v1/quotes/{folioNumber}/state` → llama `GetQuoteStateUseCase.getState()`
+  - [ ] Retorna `ResponseEntity<QuoteStateResponse>` con HTTP 200
+- [ ] Crear `QuoteStateApi` — `@Tag`, `@Operation`, `@ApiResponse` (200, 404)
+
+#### Configuración
+- [ ] Actualizar `FolioConfig.java` — añadir `@Bean GetQuoteStateUseCaseImpl`
+
+### Tests Backend
+
+#### Unitarios (TDD — escribir ANTES del código de producción)
+- [ ] `GetQuoteStateUseCaseImplTest`:
+  - [ ] `getState_withLayoutCompleteAndOneIncompleteLocation_returnsPartialProgress` (CRITERIO-1.1)
+  - [ ] `getState_withFreshFolio_returnsZeroPercentage` (CRITERIO-1.2)
+  - [ ] `getState_withCalculatedFolio_returns100Percent` (CRITERIO-1.3)
+  - [ ] `getState_folioNotFound_throwsFolioNotFoundException` (CRITERIO-1.4)
+  - [ ] `getState_whenGeneralInfoFieldsNull_returnsGeneralInfoPending` (CRITERIO-1.5)
+- [ ] `LocationStateJpaAdapterTest`:
+  - [ ] `readByFolioNumber_withNoLocations_returnsTotalZero`
+  - [ ] `readByFolioNumber_withMixedLocations_returnsCorrectCounts`
+- [ ] `QuoteStateControllerTest`:
+  - [ ] `getState_returns200WithCorrectBody`
+  - [ ] `getState_unknownFolio_returns404`
+- [ ] `QuoteStateRestMapperTest`:
+  - [ ] `toResponse_mapsAllFieldsCorrectly`
+
+### QA
+- [ ] Ejecutar skill `/gherkin-case-generator quote-state` → generar escenarios CRITERIO-1.1..1.5
+- [ ] Ejecutar skill `/risk-identifier quote-state` → clasificación ASD de riesgos
+- [ ] Validar endpoint en vivo contra criterios de aceptación
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/.claude/specs/quote-state.spec.md
+++ b/.claude/specs/quote-state.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-005
-status: APPROVED
+status: IMPLEMENTED
 feature: quote-state
 created: 2026-04-21
 updated: 2026-04-21

--- a/.claude/specs/quote-state.spec.md
+++ b/.claude/specs/quote-state.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-005
-status: DRAFT
+status: APPROVED
 feature: quote-state
 created: 2026-04-21
 updated: 2026-04-21

--- a/docs/output/qa/quote-state-gherkin.md
+++ b/docs/output/qa/quote-state-gherkin.md
@@ -1,0 +1,176 @@
+# Escenarios Gherkin — Quote State (SPEC-005)
+
+**Feature:** Consulta del estado y progreso de completitud de una cotización  
+**Endpoint:** `GET /v1/quotes/{folio}/state`  
+**Generado:** 2026-04-21
+
+---
+
+## Datos de Prueba Sintéticos
+
+| Escenario | Campo | Válido | Inválido | Borde |
+|-----------|-------|--------|----------|-------|
+| Folio con layout completo | folioNumber | `FOL-TEST-001` | `FOL-INEXISTENTE` | `""` (vacío) |
+| Progreso parcial | numberOfLocations | `2` | `null` | `0` |
+| Folio calculado | quoteStatus | `CALCULATED` | `CREATED` | `ISSUED` |
+| Ubicación completa | validationStatus | `COMPLETE` | `INCOMPLETE` | sin registros |
+| Alertas bloqueantes | blockingAlerts | `[]` | `[MISSING_ZIP_CODE]` | múltiples alertas |
+
+---
+
+```gherkin
+#language: es
+Característica: Consulta de estado y progreso de completitud de una cotización
+  Como agente de seguros que trabaja en un folio activo
+  Quiero consultar el estado actual del folio en cualquier momento
+  Para saber qué secciones están completas e incompletas y el porcentaje de avance
+
+  Antecedentes:
+    Dado que el sistema tiene acceso a la base de datos de cotizaciones
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.1 — Happy path: folio con progreso parcial
+  # ---------------------------------------------------------------------------
+
+  @happy-path @critico @smoke
+  Escenario: Consulta exitosa de estado con layout completo y ubicación incompleta
+    Dado que existe un folio "FOL-TEST-001" con estado "IN_PROGRESS"
+    Y el folio tiene layout configurado con 2 ubicaciones de tipo "MULTIPLE"
+    Y una de las ubicaciones tiene validationStatus "COMPLETE" y sin alertas bloqueantes
+    Y la otra ubicación tiene alertas bloqueantes activas
+    Y no se ha configurado opciones de cobertura ni ejecutado cálculo
+    Cuando el agente consulta el estado del folio "FOL-TEST-001"
+    Entonces el sistema retorna estado 200
+    Y el campo "quoteStatus" es "IN_PROGRESS"
+    Y el campo "sections.layout" es "COMPLETE"
+    Y el campo "sections.locations" es "INCOMPLETE"
+    Y el campo "sections.generalInfo" es "PENDING"
+    Y el campo "sections.coverageOptions" es "PENDING"
+    Y el campo "sections.calculation" es "PENDING"
+    Y el campo "completionPercentage" es 20
+    Y la respuesta incluye los campos "version" y "updatedAt"
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.2 — Happy path: folio recién creado con progreso cero
+  # ---------------------------------------------------------------------------
+
+  @happy-path @critico
+  Escenario: Folio recién creado retorna progreso en cero
+    Dado que existe un folio "FOL-TEST-002" con estado "CREATED"
+    Y el folio no tiene layout configurado
+    Y el folio no tiene ubicaciones registradas
+    Cuando el agente consulta el estado del folio "FOL-TEST-002"
+    Entonces el sistema retorna estado 200
+    Y el campo "quoteStatus" es "CREATED"
+    Y el campo "completionPercentage" es 0
+    Y el campo "sections.layout" es "PENDING"
+    Y el campo "sections.locations" es "PENDING"
+    Y el campo "sections.generalInfo" es "PENDING"
+    Y el campo "sections.coverageOptions" es "PENDING"
+    Y el campo "sections.calculation" es "PENDING"
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.3 — Happy path: folio CALCULATED retorna 100%
+  # ---------------------------------------------------------------------------
+
+  @happy-path @critico @smoke
+  Escenario: Folio calculado retorna progreso al cien por ciento
+    Dado que existe un folio "FOL-TEST-003" con estado "CALCULATED"
+    Y el folio tiene layout con 2 ubicaciones configuradas
+    Y ambas ubicaciones tienen validationStatus "COMPLETE"
+    Cuando el agente consulta el estado del folio "FOL-TEST-003"
+    Entonces el sistema retorna estado 200
+    Y el campo "quoteStatus" es "CALCULATED"
+    Y el campo "completionPercentage" es 100
+    Y el campo "sections.calculation" es "COMPLETE"
+    Y el campo "sections.layout" es "COMPLETE"
+    Y el campo "sections.locations" es "COMPLETE"
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.4 — Error path: folio inexistente
+  # ---------------------------------------------------------------------------
+
+  @error-path @critico @smoke
+  Escenario: Consulta de folio inexistente retorna 404
+    Dado que el folio "FOL-INEXISTENTE" no existe en la base de datos
+    Cuando el agente consulta el estado del folio "FOL-INEXISTENTE"
+    Entonces el sistema retorna estado 404
+    Y el cuerpo de la respuesta contiene el campo "code" con valor "FOLIO_NOT_FOUND"
+    Y el cuerpo de la respuesta contiene el campo "error" con valor "Folio not found"
+    Y no se retorna información de secciones
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.5 — Edge case: secciones con dependencias no implementadas
+  # ---------------------------------------------------------------------------
+
+  @edge-case
+  Escenario: Secciones sin feature implementada retornan PENDING sin error
+    Dado que existe un folio "FOL-TEST-004" con estado "IN_PROGRESS"
+    Y los campos de datos del asegurado no existen en la base de datos (SPEC-006 pendiente)
+    Y no existe tabla de opciones de cobertura (SPEC-007 pendiente)
+    Cuando el agente consulta el estado del folio "FOL-TEST-004"
+    Entonces el sistema retorna estado 200
+    Y el campo "sections.generalInfo" es "PENDING"
+    Y el campo "sections.coverageOptions" es "PENDING"
+    Y el sistema no lanza ninguna excepción ni retorna error 500
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.6 — Edge case: todas las ubicaciones completas pero sin cálculo
+  # ---------------------------------------------------------------------------
+
+  @edge-case
+  Escenario: Todas las ubicaciones completas pero sin calculo ejecutado
+    Dado que existe un folio "FOL-TEST-005" con estado "IN_PROGRESS"
+    Y el folio tiene layout con 3 ubicaciones
+    Y las 3 ubicaciones tienen validationStatus "COMPLETE" y sin alertas bloqueantes
+    Y el cálculo aún no se ha ejecutado
+    Cuando el agente consulta el estado del folio "FOL-TEST-005"
+    Entonces el sistema retorna estado 200
+    Y el campo "sections.locations" es "COMPLETE"
+    Y el campo "sections.calculation" es "PENDING"
+    Y el campo "completionPercentage" es 40
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.7 — Edge case: layout con numberOfLocations pero sin locationType
+  # ---------------------------------------------------------------------------
+
+  @edge-case
+  Escenario: Layout parcialmente configurado retorna IN_PROGRESS
+    Dado que existe un folio "FOL-TEST-006" con estado "IN_PROGRESS"
+    Y el folio tiene numberOfLocations igual a 2 pero sin locationType configurado
+    Y el folio no tiene ubicaciones registradas
+    Cuando el agente consulta el estado del folio "FOL-TEST-006"
+    Entonces el sistema retorna estado 200
+    Y el campo "sections.layout" es "IN_PROGRESS"
+    Y el campo "sections.locations" es "PENDING"
+
+  # ---------------------------------------------------------------------------
+  # CRITERIO-1.8 — Edge case: folio CALCULATED fuerza 100% aunque secciones incompletas
+  # ---------------------------------------------------------------------------
+
+  @edge-case
+  Escenario: Folio CALCULATED retorna 100 por ciento aunque existan ubicaciones con alertas
+    Dado que existe un folio "FOL-TEST-007" con estado "CALCULATED"
+    Y una de las ubicaciones del folio tiene alertas bloqueantes residuales
+    Cuando el agente consulta el estado del folio "FOL-TEST-007"
+    Entonces el sistema retorna estado 200
+    Y el campo "completionPercentage" es 100
+    Y el campo "quoteStatus" es "CALCULATED"
+```
+
+---
+
+## Resumen de cobertura
+
+| ID | Tipo | Criterio | Etiquetas |
+|----|------|----------|-----------|
+| CRITERIO-1.1 | Happy path | Layout COMPLETE + ubicación INCOMPLETE → 20% | `@happy-path @critico @smoke` |
+| CRITERIO-1.2 | Happy path | Folio nuevo → 0% | `@happy-path @critico` |
+| CRITERIO-1.3 | Happy path | CALCULATED → 100% | `@happy-path @critico @smoke` |
+| CRITERIO-1.4 | Error path | Folio inexistente → 404 FOLIO_NOT_FOUND | `@error-path @critico @smoke` |
+| CRITERIO-1.5 | Edge case | generalInfo + coverageOptions PENDING sin excepción | `@edge-case` |
+| CRITERIO-1.6 | Edge case | Todas ubicaciones COMPLETE, cálculo PENDING → 40% | `@edge-case` |
+| CRITERIO-1.7 | Edge case | numberOfLocations sin locationType → layout IN_PROGRESS | `@edge-case` |
+| CRITERIO-1.8 | Edge case | CALCULATED fuerza 100% ignorando secciones incompletas | `@edge-case` |
+
+**Total escenarios: 8** (3 smoke, 4 happy/error path, 4 edge cases)

--- a/docs/output/qa/quote-state-risks.md
+++ b/docs/output/qa/quote-state-risks.md
@@ -1,0 +1,86 @@
+# Matriz de Riesgos — Quote State (SPEC-005)
+
+**Feature:** Consulta del estado y progreso de completitud de una cotización  
+**Endpoint:** `GET /v1/quotes/{folio}/state`  
+**Evaluado:** 2026-04-21
+
+---
+
+## Resumen
+
+Total: 6 | Alto (A): 0 | Medio (S): 3 | Bajo (D): 3
+
+> **Nota:** El endpoint es estrictamente read-only. No maneja pagos, datos personales sensibles,
+> operaciones destructivas ni integraciones externas. Ningún riesgo alcanza nivel ALTO.
+> El riesgo principal está en la corrección de la lógica de evaluación por sección.
+
+---
+
+## Detalle
+
+| ID    | HU     | Descripción del Riesgo                                              | Factores                                         | Nivel | Testing     |
+|-------|--------|---------------------------------------------------------------------|--------------------------------------------------|-------|-------------|
+| R-001 | HU-01  | `completionPercentage` calculado incorrectamente                    | Lógica compleja, código nuevo, alta frecuencia   | S     | Recomendado |
+| R-002 | HU-01  | Evaluación de sección `locations` devuelve estado erróneo           | Lógica compleja, dependencia cross-BC            | S     | Recomendado |
+| R-003 | HU-01  | Ruptura silenciosa al cambiar schema de location BC sin actualizar  | Componentes con muchas dependencias              | S     | Recomendado |
+| R-004 | HU-01  | Regla "CALCULATED → 100%" oculta inconsistencias reales             | Lógica de negocio con caso especial              | D     | Opcional    |
+| R-005 | HU-01  | SPEC-006/007 implementadas sin actualizar evaluación de secciones   | Código nuevo sin historial, dependencias futuras | D     | Opcional    |
+| R-006 | HU-01  | `FolioNotFoundException` no propagada correctamente → 500 en vez de 404 | Código nuevo sin historial                  | D     | Opcional    |
+
+---
+
+## Plan de Mitigación — Riesgos MEDIO (S)
+
+### R-001: `completionPercentage` calculado incorrectamente
+- **Escenario:** `GetQuoteStateUseCaseImpl.computePercentage()` usa división entera incorrecta o cuenta mal las secciones COMPLETE.
+- **Mitigación:** Test unitario cubre cada combinación: 0/5, 1/5, 2/5, 3/5, 4/5, 5/5 y el caso especial CALCULATED→100.
+- **Tests obligatorios:**
+  - `GetQuoteStateUseCaseImplTest` — 5 casos ya implementados (TDD GREEN)
+  - Validación manual: `curl GET /v1/quotes/{folio}/state` con folio en estado conocido
+- **Bloqueante para release:** ✅ Sí (mal progreso lleva al agente a tomar decisiones incorrectas)
+
+### R-002: Evaluación de sección `locations` devuelve estado erróneo
+- **Escenario:** `LocationStateJpaAdapter` cuenta incorrectamente `completeCount` vs `incompleteCount`, causando que una ubicación con alertas se muestre como COMPLETE.
+- **Mitigación:** Test unitario cubre: sin ubicaciones, todas COMPLETE, mixtas (1 COMPLETE + 1 INCOMPLETE con alerts).
+- **Tests obligatorios:**
+  - `LocationStateJpaAdapterTest` — 3 casos ya implementados (TDD GREEN)
+  - `GetQuoteStateUseCaseImplTest` — verifica que INCOMPLETE > 0 → sección INCOMPLETE
+- **Bloqueante para release:** ✅ Sí (agente podría intentar calcular con ubicaciones sin datos válidos)
+
+### R-003: Ruptura silenciosa al cambiar schema de location BC
+- **Escenario:** Se renombra `validationStatus` o se modifica `BlockingAlertEmbeddable` en location BC y `LocationStateJpaAdapter` (folio BC) falla sin compilar o con NullPointerException en runtime.
+- **Mitigación:** `LocationStateJpaAdapter` usa directamente `LocationJpa.getValidationStatus()` y `LocationJpa.getBlockingAlerts()`. Si el campo se renombra, el compilador detecta el error. El riesgo real es si se cambia el valor de la cadena "COMPLETE".
+- **Controls técnicos:**
+  - Constante compartida para `"COMPLETE"` en lugar de string literal inline (backlog)
+  - Test de integración cross-BC en suite Serenity BDD
+- **Tests obligatorios:** `LocationStateJpaAdapterTest` — verifica comparación de string "COMPLETE"
+- **Bloqueante para release:** ⚠️ Parcial — solo si se modifica location BC en la misma release
+
+---
+
+## Riesgos BAJO (D) — Documentados, no bloqueantes
+
+### R-004: Regla CALCULATED → 100% oculta inconsistencias
+- **Escenario:** Un folio llega a CALCULATED con secciones que el sistema aún marca INCOMPLETE. La regla fuerza 100% y el agente no ve la inconsistencia.
+- **Mitigación:** La regla está documentada en la spec (RN-12). Es comportamiento intencional: si el sistema calculó, el flujo se considera completo.
+- **Acción:** Documentar en README del módulo como decisión de diseño.
+
+### R-005: SPEC-006/007 implementadas sin actualizar evaluación
+- **Escenario:** Se implementa general-info (SPEC-006) y las columnas `insured_name`, `insured_rfc` etc. existen en DB pero `GetQuoteStateUseCaseImpl` sigue devolviendo `PENDING` hardcoded.
+- **Mitigación:** `GetQuoteStateUseCaseImpl` tiene comentarios explícitos `// requires SPEC-006` y `// requires SPEC-007`. Al implementar esas specs, el desarrollador debe actualizar este use case. Agregar como criterio de aceptación en SPEC-006 y SPEC-007.
+
+### R-006: FolioNotFoundException no propagada → 500
+- **Escenario:** `QuoteStateJpaAdapter` no lanza `FolioNotFoundException` y devuelve `null`, causando NPE en el use case que el GlobalExceptionHandler traduce como 500.
+- **Mitigación:** `QuoteStateController` test verifica que folio inexistente → 404 con código `FOLIO_NOT_FOUND`. Implementado y pasando (TDD GREEN).
+
+---
+
+## Cobertura de tests implementados
+
+| Test | Criterio cubierto | Estado |
+|------|-------------------|--------|
+| `GetQuoteStateUseCaseImplTest` (5 casos) | R-001, R-002 | ✅ GREEN |
+| `LocationStateJpaAdapterTest` (3 casos) | R-002, R-003 | ✅ GREEN |
+| `QuoteStateControllerTest` (2 casos) | R-006 | ✅ GREEN |
+| `QuoteStateRestMapperTest` (1 caso) | — | ✅ GREEN |
+| Validación manual live | R-001, R-002 | ⏳ Pendiente |

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
@@ -1,0 +1,76 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.*;
+import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
+
+public class GetQuoteStateUseCaseImpl implements GetQuoteStateUseCase {
+
+    private final QuoteStateQuery quoteStateQuery;
+    private final LocationStateReader locationStateReader;
+
+    public GetQuoteStateUseCaseImpl(QuoteStateQuery quoteStateQuery,
+                                    LocationStateReader locationStateReader) {
+        this.quoteStateQuery = quoteStateQuery;
+        this.locationStateReader = locationStateReader;
+    }
+
+    @Override
+    public QuoteState getState(String folioNumber) {
+        QuoteSnapshot snapshot = quoteStateQuery.findByFolioNumber(folioNumber);
+        LocationStateSummary locationSummary = locationStateReader.readByFolioNumber(folioNumber);
+
+        QuoteSections sections = new QuoteSections(
+                SectionStatus.PENDING,                      // generalInfo — requires SPEC-006
+                evaluateLayout(snapshot),
+                evaluateLocations(locationSummary),
+                SectionStatus.PENDING,                      // coverageOptions — requires SPEC-007
+                evaluateCalculation(snapshot.quoteStatus())
+        );
+
+        int percentage = computePercentage(snapshot.quoteStatus(), sections);
+
+        return new QuoteState(
+                snapshot.folioNumber(),
+                snapshot.quoteStatus(),
+                percentage,
+                sections,
+                snapshot.version(),
+                snapshot.updatedAt()
+        );
+    }
+
+    private SectionStatus evaluateLayout(QuoteSnapshot snapshot) {
+        if (snapshot.numberOfLocations() == null) return SectionStatus.PENDING;
+        if (snapshot.numberOfLocations() > 0 && snapshot.locationType() != null) return SectionStatus.COMPLETE;
+        return SectionStatus.IN_PROGRESS;
+    }
+
+    private SectionStatus evaluateLocations(LocationStateSummary summary) {
+        if (summary.total() == 0) return SectionStatus.PENDING;
+        if (summary.incompleteCount() > 0) return SectionStatus.INCOMPLETE;
+        if (summary.completeCount() == summary.total()) return SectionStatus.COMPLETE;
+        return SectionStatus.IN_PROGRESS;
+    }
+
+    private SectionStatus evaluateCalculation(String quoteStatus) {
+        return "CALCULATED".equals(quoteStatus) ? SectionStatus.COMPLETE : SectionStatus.PENDING;
+    }
+
+    private int computePercentage(String quoteStatus, QuoteSections sections) {
+        if ("CALCULATED".equals(quoteStatus)) return 100;
+        long complete = countComplete(sections);
+        return (int) Math.round(complete * 100.0 / 5);
+    }
+
+    private long countComplete(QuoteSections sections) {
+        long count = 0;
+        if (sections.generalInfo() == SectionStatus.COMPLETE) count++;
+        if (sections.layout() == SectionStatus.COMPLETE) count++;
+        if (sections.locations() == SectionStatus.COMPLETE) count++;
+        if (sections.coverageOptions() == SectionStatus.COMPLETE) count++;
+        if (sections.calculation() == SectionStatus.COMPLETE) count++;
+        return count;
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/LocationStateSummary.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/LocationStateSummary.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+// Aggregated location validation counts for state section evaluation
+public record LocationStateSummary(
+        int total,
+        long completeCount,
+        long incompleteCount
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteSections.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteSections.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+public record QuoteSections(
+        SectionStatus generalInfo,
+        SectionStatus layout,
+        SectionStatus locations,
+        SectionStatus coverageOptions,
+        SectionStatus calculation
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteSnapshot.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteSnapshot.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+import java.time.Instant;
+
+// Read-only projection of Quote aggregate used for state evaluation
+public record QuoteSnapshot(
+        String folioNumber,
+        String quoteStatus,
+        Integer numberOfLocations,
+        String locationType,
+        Long version,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteState.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteState.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+import java.time.Instant;
+
+public record QuoteState(
+        String folioNumber,
+        String quoteStatus,
+        int completionPercentage,
+        QuoteSections sections,
+        Long version,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/SectionStatus.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/SectionStatus.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+public enum SectionStatus {
+    PENDING,
+    IN_PROGRESS,
+    COMPLETE,
+    INCOMPLETE
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/GetQuoteStateUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/GetQuoteStateUseCase.java
@@ -1,0 +1,7 @@
+package com.sofka.insurancequoter.back.folio.domain.port.in;
+
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteState;
+
+public interface GetQuoteStateUseCase {
+    QuoteState getState(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/LocationStateReader.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/LocationStateReader.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.folio.domain.port.out;
+
+import com.sofka.insurancequoter.back.folio.domain.model.LocationStateSummary;
+
+// Output port: aggregates location validation counts for a given folio
+public interface LocationStateReader {
+    LocationStateSummary readByFolioNumber(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/QuoteStateQuery.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/QuoteStateQuery.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.folio.domain.port.out;
+
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteSnapshot;
+
+// Read-only projection port: returns the data needed to evaluate quote state sections
+public interface QuoteStateQuery {
+    QuoteSnapshot findByFolioNumber(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/QuoteStateController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/QuoteStateController.java
@@ -1,0 +1,27 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.QuoteStateResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.QuoteStateRestMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.swaggerdocs.QuoteStateApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/quotes")
+@RequiredArgsConstructor
+public class QuoteStateController implements QuoteStateApi {
+
+    private final GetQuoteStateUseCase getQuoteStateUseCase;
+    private final QuoteStateRestMapper mapper;
+
+    @Override
+    @GetMapping("/{folioNumber}/state")
+    public ResponseEntity<QuoteStateResponse> getState(@PathVariable String folioNumber) {
+        return ResponseEntity.ok(mapper.toResponse(getQuoteStateUseCase.getState(folioNumber)));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/QuoteStateResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/QuoteStateResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto;
+
+import java.time.Instant;
+
+public record QuoteStateResponse(
+        String folioNumber,
+        String quoteStatus,
+        int completionPercentage,
+        SectionsResponse sections,
+        Long version,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/SectionsResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/SectionsResponse.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto;
+
+public record SectionsResponse(
+        String generalInfo,
+        String layout,
+        String locations,
+        String coverageOptions,
+        String calculation
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/QuoteStateRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/QuoteStateRestMapper.java
@@ -1,0 +1,28 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteState;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.QuoteStateResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.SectionsResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuoteStateRestMapper {
+
+    public QuoteStateResponse toResponse(QuoteState state) {
+        SectionsResponse sections = new SectionsResponse(
+                state.sections().generalInfo().name(),
+                state.sections().layout().name(),
+                state.sections().locations().name(),
+                state.sections().coverageOptions().name(),
+                state.sections().calculation().name()
+        );
+        return new QuoteStateResponse(
+                state.folioNumber(),
+                state.quoteStatus(),
+                state.completionPercentage(),
+                sections,
+                state.version(),
+                state.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/QuoteStateApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/QuoteStateApi.java
@@ -1,0 +1,21 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.QuoteStateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Quote State", description = "Estado y progreso de completitud de la cotización")
+public interface QuoteStateApi {
+
+    @Operation(summary = "Consultar estado de la cotización",
+               description = "Retorna el estado actual, el porcentaje de completitud y el estado de cada sección del folio")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Estado retornado exitosamente"),
+            @ApiResponse(responseCode = "404", description = "Folio no encontrado")
+    })
+    ResponseEntity<QuoteStateResponse> getState(@PathVariable String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/LocationStateJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/LocationStateJpaAdapter.java
@@ -1,0 +1,35 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.folio.domain.model.LocationStateSummary;
+import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class LocationStateJpaAdapter implements LocationStateReader {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+    private final LocationJpaRepository locationJpaRepository;
+
+    @Override
+    public LocationStateSummary readByFolioNumber(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .map(quote -> {
+                    List<LocationJpa> locations = locationJpaRepository.findByQuoteId(quote.getId());
+                    long completeCount = locations.stream()
+                            .filter(l -> "COMPLETE".equals(l.getValidationStatus()))
+                            .count();
+                    long incompleteCount = locations.stream()
+                            .filter(l -> l.getBlockingAlerts() != null && !l.getBlockingAlerts().isEmpty())
+                            .count();
+                    return new LocationStateSummary(locations.size(), completeCount, incompleteCount);
+                })
+                .orElse(new LocationStateSummary(0, 0, 0));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteStateJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteStateJpaAdapter.java
@@ -1,0 +1,30 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteSnapshot;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuoteStateJpaAdapter implements QuoteStateQuery {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+
+    @Override
+    public QuoteSnapshot findByFolioNumber(String folioNumber) {
+        QuoteJpa jpa = quoteJpaRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
+        return new QuoteSnapshot(
+                jpa.getFolioNumber(),
+                jpa.getQuoteStatus(),
+                jpa.getNumberOfLocations(),
+                jpa.getLocationType(),
+                jpa.getVersion(),
+                jpa.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
@@ -1,9 +1,13 @@
 package com.sofka.insurancequoter.back.folio.infrastructure.config;
 
 import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioUseCaseImpl;
+import com.sofka.insurancequoter.back.folio.application.usecase.GetQuoteStateUseCaseImpl;
 import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.adapter.CoreServiceClientAdapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -29,5 +33,11 @@ public class FolioConfig {
     public CreateFolioUseCase createFolioUseCase(QuoteRepository quoteRepository,
                                                   CoreServiceClient coreServiceClient) {
         return new CreateFolioUseCaseImpl(quoteRepository, coreServiceClient);
+    }
+
+    @Bean
+    public GetQuoteStateUseCase getQuoteStateUseCase(QuoteStateQuery quoteStateQuery,
+                                                      LocationStateReader locationStateReader) {
+        return new GetQuoteStateUseCaseImpl(quoteStateQuery, locationStateReader);
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
@@ -1,0 +1,118 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.*;
+import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetQuoteStateUseCaseImplTest {
+
+    @Mock
+    private QuoteStateQuery quoteStateQuery;
+
+    @Mock
+    private LocationStateReader locationStateReader;
+
+    @InjectMocks
+    private GetQuoteStateUseCaseImpl useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    private QuoteSnapshot snapshot(String status, Integer numLocations, String locationType) {
+        return new QuoteSnapshot("FOL-001", status, numLocations, locationType, 3L, NOW);
+    }
+
+    @Test
+    void getState_withLayoutCompleteAndOneIncompleteLocation_returnsPartialProgress() {
+        // GIVEN — layout COMPLETE, one incomplete location → 1/5 = 20%
+        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+                .thenReturn(snapshot("IN_PROGRESS", 2, "MULTIPLE"));
+        when(locationStateReader.readByFolioNumber("FOL-001"))
+                .thenReturn(new LocationStateSummary(2, 1, 1)); // 1 complete, 1 incomplete
+
+        // WHEN
+        QuoteState state = useCase.getState("FOL-001");
+
+        // THEN
+        assertThat(state.folioNumber()).isEqualTo("FOL-001");
+        assertThat(state.quoteStatus()).isEqualTo("IN_PROGRESS");
+        assertThat(state.sections().layout()).isEqualTo(SectionStatus.COMPLETE);
+        assertThat(state.sections().locations()).isEqualTo(SectionStatus.INCOMPLETE);
+        assertThat(state.sections().generalInfo()).isEqualTo(SectionStatus.PENDING);
+        assertThat(state.sections().coverageOptions()).isEqualTo(SectionStatus.PENDING);
+        assertThat(state.sections().calculation()).isEqualTo(SectionStatus.PENDING);
+        assertThat(state.completionPercentage()).isEqualTo(20); // 1 COMPLETE (layout) / 5 * 100
+    }
+
+    @Test
+    void getState_withFreshFolio_returnsZeroPercentage() {
+        // GIVEN — no layout, no locations
+        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+                .thenReturn(snapshot("CREATED", null, null));
+        when(locationStateReader.readByFolioNumber("FOL-001"))
+                .thenReturn(new LocationStateSummary(0, 0, 0));
+
+        // WHEN
+        QuoteState state = useCase.getState("FOL-001");
+
+        // THEN
+        assertThat(state.completionPercentage()).isEqualTo(0);
+        assertThat(state.sections().layout()).isEqualTo(SectionStatus.PENDING);
+        assertThat(state.sections().locations()).isEqualTo(SectionStatus.PENDING);
+    }
+
+    @Test
+    void getState_withCalculatedFolio_returns100Percent() {
+        // GIVEN — quoteStatus = CALCULATED → forced 100%
+        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+                .thenReturn(snapshot("CALCULATED", 2, "MULTIPLE"));
+        when(locationStateReader.readByFolioNumber("FOL-001"))
+                .thenReturn(new LocationStateSummary(2, 2, 0));
+
+        // WHEN
+        QuoteState state = useCase.getState("FOL-001");
+
+        // THEN
+        assertThat(state.completionPercentage()).isEqualTo(100);
+        assertThat(state.sections().calculation()).isEqualTo(SectionStatus.COMPLETE);
+    }
+
+    @Test
+    void getState_folioNotFound_throwsFolioNotFoundException() {
+        // GIVEN
+        when(quoteStateQuery.findByFolioNumber("UNKNOWN"))
+                .thenThrow(new FolioNotFoundException("UNKNOWN"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.getState("UNKNOWN"))
+                .isInstanceOf(FolioNotFoundException.class);
+    }
+
+    @Test
+    void getState_whenGeneralInfoFieldsNull_returnsGeneralInfoPending() {
+        // GIVEN — general-info not yet implemented
+        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+                .thenReturn(snapshot("IN_PROGRESS", 3, "MULTIPLE"));
+        when(locationStateReader.readByFolioNumber("FOL-001"))
+                .thenReturn(new LocationStateSummary(3, 3, 0));
+
+        // WHEN
+        QuoteState state = useCase.getState("FOL-001");
+
+        // THEN — generalInfo and coverageOptions always PENDING until their specs are implemented
+        assertThat(state.sections().generalInfo()).isEqualTo(SectionStatus.PENDING);
+        assertThat(state.sections().coverageOptions()).isEqualTo(SectionStatus.PENDING);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/QuoteStateControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/QuoteStateControllerTest.java
@@ -1,0 +1,82 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.domain.model.*;
+import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.QuoteStateResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.SectionsResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.QuoteStateRestMapper;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class QuoteStateControllerTest {
+
+    @Mock
+    private GetQuoteStateUseCase getQuoteStateUseCase;
+
+    @Mock
+    private QuoteStateRestMapper mapper;
+
+    private MockMvc mockMvc;
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    @BeforeEach
+    void setUp() {
+        var controller = new QuoteStateController(getQuoteStateUseCase, mapper);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void getState_returns200WithCorrectBody() throws Exception {
+        // GIVEN
+        QuoteSections sections = new QuoteSections(
+                SectionStatus.PENDING, SectionStatus.COMPLETE,
+                SectionStatus.INCOMPLETE, SectionStatus.PENDING, SectionStatus.PENDING);
+        QuoteState state = new QuoteState("FOL-001", "IN_PROGRESS", 20, sections, 3L, NOW);
+        QuoteStateResponse response = new QuoteStateResponse(
+                "FOL-001", "IN_PROGRESS", 20,
+                new SectionsResponse("PENDING", "COMPLETE", "INCOMPLETE", "PENDING", "PENDING"),
+                3L, NOW);
+
+        when(getQuoteStateUseCase.getState("FOL-001")).thenReturn(state);
+        when(mapper.toResponse(state)).thenReturn(response);
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/FOL-001/state"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-001"))
+                .andExpect(jsonPath("$.quoteStatus").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.completionPercentage").value(20))
+                .andExpect(jsonPath("$.sections.layout").value("COMPLETE"))
+                .andExpect(jsonPath("$.sections.locations").value("INCOMPLETE"))
+                .andExpect(jsonPath("$.version").value(3));
+    }
+
+    @Test
+    void getState_unknownFolio_returns404() throws Exception {
+        // GIVEN
+        when(getQuoteStateUseCase.getState("UNKNOWN"))
+                .thenThrow(new FolioNotFoundException("UNKNOWN"));
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/UNKNOWN/state"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/QuoteStateRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/QuoteStateRestMapperTest.java
@@ -1,0 +1,45 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.domain.model.*;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.QuoteStateResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.QuoteStateRestMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuoteStateRestMapperTest {
+
+    private final QuoteStateRestMapper mapper = new QuoteStateRestMapper();
+
+    private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
+
+    @Test
+    void toResponse_mapsAllFieldsCorrectly() {
+        // GIVEN
+        QuoteSections sections = new QuoteSections(
+                SectionStatus.PENDING,
+                SectionStatus.COMPLETE,
+                SectionStatus.INCOMPLETE,
+                SectionStatus.PENDING,
+                SectionStatus.PENDING
+        );
+        QuoteState state = new QuoteState("FOL-001", "IN_PROGRESS", 20, sections, 5L, NOW);
+
+        // WHEN
+        QuoteStateResponse response = mapper.toResponse(state);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo("FOL-001");
+        assertThat(response.quoteStatus()).isEqualTo("IN_PROGRESS");
+        assertThat(response.completionPercentage()).isEqualTo(20);
+        assertThat(response.version()).isEqualTo(5L);
+        assertThat(response.updatedAt()).isEqualTo(NOW);
+        assertThat(response.sections().generalInfo()).isEqualTo("PENDING");
+        assertThat(response.sections().layout()).isEqualTo("COMPLETE");
+        assertThat(response.sections().locations()).isEqualTo("INCOMPLETE");
+        assertThat(response.sections().coverageOptions()).isEqualTo("PENDING");
+        assertThat(response.sections().calculation()).isEqualTo("PENDING");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/LocationStateJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/LocationStateJpaAdapterTest.java
@@ -1,0 +1,100 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.folio.domain.model.LocationStateSummary;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter.LocationStateJpaAdapter;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.BlockingAlertEmbeddable;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LocationStateJpaAdapterTest {
+
+    @Mock
+    private QuoteJpaRepository quoteJpaRepository;
+
+    @Mock
+    private LocationJpaRepository locationJpaRepository;
+
+    @InjectMocks
+    private LocationStateJpaAdapter adapter;
+
+    private QuoteJpa quoteJpa(Long id) {
+        QuoteJpa q = new QuoteJpa();
+        q.setId(id);
+        q.setFolioNumber("FOL-001");
+        q.setQuoteStatus("IN_PROGRESS");
+        q.setSubscriberId("SUB-001");
+        q.setAgentCode("AGT-001");
+        q.setVersion(1L);
+        return q;
+    }
+
+    private LocationJpa location(String validationStatus, List<BlockingAlertEmbeddable> alerts) {
+        return LocationJpa.builder()
+                .quoteId(10L)
+                .index(1)
+                .active(true)
+                .validationStatus(validationStatus)
+                .blockingAlerts(alerts)
+                .build();
+    }
+
+    @Test
+    void readByFolioNumber_withNoLocations_returnsTotalZero() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber("FOL-001")).thenReturn(Optional.of(quoteJpa(10L)));
+        when(locationJpaRepository.findByQuoteId(10L)).thenReturn(List.of());
+
+        // WHEN
+        LocationStateSummary result = adapter.readByFolioNumber("FOL-001");
+
+        // THEN
+        assertThat(result.total()).isEqualTo(0);
+        assertThat(result.completeCount()).isEqualTo(0);
+        assertThat(result.incompleteCount()).isEqualTo(0);
+    }
+
+    @Test
+    void readByFolioNumber_withMixedLocations_returnsCorrectCounts() {
+        // GIVEN — 3 locations: 2 COMPLETE, 1 INCOMPLETE (has blocking alerts)
+        when(quoteJpaRepository.findByFolioNumber("FOL-001")).thenReturn(Optional.of(quoteJpa(10L)));
+        when(locationJpaRepository.findByQuoteId(10L)).thenReturn(List.of(
+                location("COMPLETE", List.of()),
+                location("COMPLETE", List.of()),
+                location("INCOMPLETE", List.of(new BlockingAlertEmbeddable("MISSING_ZIP_CODE", "Código postal requerido")))
+        ));
+
+        // WHEN
+        LocationStateSummary result = adapter.readByFolioNumber("FOL-001");
+
+        // THEN
+        assertThat(result.total()).isEqualTo(3);
+        assertThat(result.completeCount()).isEqualTo(2);
+        assertThat(result.incompleteCount()).isEqualTo(1);
+    }
+
+    @Test
+    void readByFolioNumber_whenFolioNotFound_returnsEmptySummary() {
+        // GIVEN — quote doesn't exist (shouldn't happen in normal flow but guard is needed)
+        when(quoteJpaRepository.findByFolioNumber("UNKNOWN")).thenReturn(Optional.empty());
+
+        // WHEN
+        LocationStateSummary result = adapter.readByFolioNumber("UNKNOWN");
+
+        // THEN
+        assertThat(result.total()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Resumen
GET /v1/quotes/{folio}/state — retorna estado, progreso por sección y completionPercentage.

## Cambios
- Domain: SectionStatus, QuoteSnapshot, LocationStateSummary, QuoteSections, QuoteState
- Ports: GetQuoteStateUseCase, QuoteStateQuery, LocationStateReader
- GetQuoteStateUseCaseImpl: evalúa layout/locations/calculation; PENDING para generalInfo (SPEC-006) y coverageOptions (SPEC-007)
- QuoteStateJpaAdapter + LocationStateJpaAdapter (cross-BC read solo lectura)
- REST: QuoteStateController, QuoteStateApi (Swagger), DTOs, mapper
- 11 tests TDD — todos GREEN
- QA: 8 escenarios Gherkin, risk matrix 0A/3S/3D

## Cierra issues
#127 #128 #129 #130 #131 #132 #133 #134 #135 #136 #137 #138 #139 #140 #141 #142 #143 #144 #145 #146 #147