### PR TITLE
feat(coverage-options): implement SPEC-006 GET/PUT coverage options

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -1,6 +1,0 @@
-# Agent Memory — backend-developer
-
-- [folio-generator feature — implementation state](project_folio_feature.md) — SPEC-001 implementado, compila. Estructura de paquetes, decisiones de diseño y archivos clave.
-- [Insurance-Quoter-Core — setup y configuración base](project_core_setup.md) — Paquete base, puerto, DB, dependencias reales del proyecto core.
-- [location-layout feature — implementation state](project_location_layout_feature.md) — SPEC-003 implementado. Decisiones de diseño: optimistic lock manual, sin @Transactional en integration test, GlobalExceptionHandler ampliado.
-- [location-management feature — implementation state](project_location_management_feature.md) — SPEC-004 implementado, issues #82-#118 cerrados. Input ports con records internos, AttributeConverter para JSONB, @WebMvcTest no existe en Spring Boot 4.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"316cb6a9-76da-4fee-893d-c0aae8cf9dbe","pid":13080,"acquiredAt":1776825542966}

--- a/.claude/specs/coverage-options.spec.md
+++ b/.claude/specs/coverage-options.spec.md
@@ -1,0 +1,572 @@
+---
+id: SPEC-006
+status: DRAFT
+feature: coverage-options
+created: 2026-04-22
+updated: 2026-04-22
+author: spec-generator
+version: "1.0"
+related-specs:
+  - SPEC-001  # folio-generator (Quote aggregate raíz, QuoteJpa con @Version)
+  - SPEC-002  # folio-management (QuoteJpa, GlobalExceptionHandler)
+  - SPEC-005  # quote-state (QuoteSections.coverageOptions — SectionStatus)
+---
+
+# Spec: Opciones de Cobertura de Cotización
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+`Insurance-Quoter-Back` expone dos endpoints para gestionar las opciones de cobertura de una cotización: consultar la lista persistida y reemplazar/actualizar la lista completa. Las coberturas disponibles se validan contra el catálogo del servicio core (`GET /v1/catalogs/guarantees`). Solo se permite seleccionar coberturas cuyo código exista en el catálogo. El versionado optimista es obligatorio en la operación de escritura.
+
+### Requerimiento de Negocio
+
+> - `GET /v1/quotes/{folio}/coverage-options` — retorna las opciones de cobertura actualmente configuradas para la cotización.
+> - `PUT /v1/quotes/{folio}/coverage-options` — reemplaza la lista completa de opciones de cobertura. Valida que cada `code` exista en el catálogo del core service. Valida rangos de `deductiblePercentage` y `coinsurancePercentage` (0.0–100.0). Requiere `version` para control de concurrencia optimista.
+> - El catálogo de coberturas disponibles proviene de `GET /v1/catalogs/guarantees` del core service (puerto 8081).
+> - Solo se pueden seleccionar coberturas (`selected: true`) cuyo `code` exista en el catálogo del core.
+> - `deductiblePercentage` y `coinsurancePercentage`: valor decimal inclusivo entre 0.0 y 100.0.
+> - El versionado optimista se aplica sobre `QuoteJpa` (aggregate raíz), incrementando `version` en cada PUT exitoso.
+> - Entidad JPA: `CoverageOptionJpa` (tabla `coverage_options`), con FK a `quotes`.
+
+### Historias de Usuario
+
+#### HU-01: Consultar opciones de cobertura de una cotización
+
+```
+Como:        agente de seguros
+Quiero:      llamar GET /v1/quotes/{folio}/coverage-options
+Para:        visualizar las opciones de cobertura configuradas y su estado de selección
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: SPEC-002 (Quote existe en la tabla quotes)
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Consulta exitosa de opciones de cobertura configuradas
+  Dado que:  existe el folio "FOL-2026-00042" con dos opciones de cobertura persistidas
+  Cuando:    se realiza GET /v1/quotes/FOL-2026-00042/coverage-options
+  Entonces:  la respuesta tiene HTTP 200
+             Y el body contiene "folioNumber": "FOL-2026-00042"
+             Y "coverageOptions" es un array con las dos opciones
+             Y cada opción incluye: code, description, selected, deductiblePercentage, coinsurancePercentage
+             Y "version" refleja la versión actual de la cotización
+```
+
+**Edge Case — sin opciones configuradas**
+```gherkin
+CRITERIO-1.2: Cotización sin opciones de cobertura persistidas
+  Dado que:  existe el folio "FOL-2026-00042" sin ninguna opción de cobertura registrada
+  Cuando:    se realiza GET /v1/quotes/FOL-2026-00042/coverage-options
+  Entonces:  la respuesta tiene HTTP 200
+             Y "coverageOptions" es un array vacío []
+             Y "version" refleja la versión actual de la cotización
+```
+
+**Error Path**
+```gherkin
+CRITERIO-1.3: Folio inexistente
+  Dado que:  el folio "FOL-9999-00001" no existe en la base de datos
+  Cuando:    se realiza GET /v1/quotes/FOL-9999-00001/coverage-options
+  Entonces:  la respuesta tiene HTTP 404
+             Y el body es {"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}
+```
+
+---
+
+#### HU-02: Configurar opciones de cobertura de una cotización
+
+```
+Como:        agente de seguros
+Quiero:      llamar PUT /v1/quotes/{folio}/coverage-options con la lista de coberturas seleccionadas
+Para:        registrar qué coberturas aplican a la cotización con sus parámetros (deducible, coaseguro)
+
+Prioridad:   Alta
+Estimación:  M
+Dependencias: HU-01, SPEC-002
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-02
+
+**Happy Path — configuración exitosa**
+```gherkin
+CRITERIO-2.1: PUT exitoso con coberturas válidas del catálogo
+  Dado que:  existe el folio "FOL-2026-00042" con version 6
+             Y el core service retorna el catálogo con codes "GUA-FIRE" y "GUA-THEFT"
+             Y el request incluye ambos codes con deductiblePercentage y coinsurancePercentage en rango válido
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/coverage-options con version 6
+  Entonces:  la respuesta tiene HTTP 200
+             Y "coverageOptions" refleja la lista enviada con sus parámetros
+             Y "version" es 7
+             Y "updatedAt" es un timestamp ISO-8601 UTC
+```
+
+**Happy Path — mix de seleccionadas y no seleccionadas**
+```gherkin
+CRITERIO-2.2: PUT con coberturas seleccionadas y no seleccionadas
+  Dado que:  el catálogo del core tiene "GUA-FIRE" y "GUA-THEFT"
+  Cuando:    se realiza PUT con "GUA-FIRE" selected: true y "GUA-THEFT" selected: false
+  Entonces:  la respuesta tiene HTTP 200
+             Y "coverageOptions[0].selected" es true para GUA-FIRE
+             Y "coverageOptions[1].selected" es false para GUA-THEFT
+             Y la versión se incrementa en 1
+```
+
+**Error Path — version conflict**
+```gherkin
+CRITERIO-2.3: Conflicto de versión optimista
+  Dado que:  la versión actual del folio "FOL-2026-00042" es 7
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/coverage-options con version 6
+  Entonces:  la respuesta tiene HTTP 409
+             Y el body es {"error": "Optimistic lock conflict", "code": "VERSION_CONFLICT"}
+             Y los datos de cobertura no se modifican
+```
+
+**Error Path — code no existe en catálogo**
+```gherkin
+CRITERIO-2.4: Cobertura con code inválido rechazada
+  Dado que:  el catálogo del core NO contiene el code "COV-INVALID"
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/coverage-options con un elemento cuyo code es "COV-INVALID"
+  Entonces:  la respuesta tiene HTTP 422
+             Y el body contiene "code": "VALIDATION_ERROR"
+             Y "fields" identifica el code inválido
+```
+
+**Error Path — deductiblePercentage fuera de rango**
+```gherkin
+CRITERIO-2.5: Porcentaje de deducible fuera de rango [0,100]
+  Dado que:  el request incluye una cobertura con deductiblePercentage: 150.0
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/coverage-options
+  Entonces:  la respuesta tiene HTTP 422
+             Y el body contiene "code": "VALIDATION_ERROR"
+             Y "fields" identifica deductiblePercentage como inválido
+```
+
+**Error Path — coinsurancePercentage fuera de rango**
+```gherkin
+CRITERIO-2.6: Porcentaje de coaseguro fuera de rango [0,100]
+  Dado que:  el request incluye una cobertura con coinsurancePercentage: -5.0
+  Cuando:    se realiza PUT /v1/quotes/FOL-2026-00042/coverage-options
+  Entonces:  la respuesta tiene HTTP 422
+             Y el body contiene "code": "VALIDATION_ERROR"
+             Y "fields" identifica coinsurancePercentage como inválido
+```
+
+**Error Path — folio inexistente**
+```gherkin
+CRITERIO-2.7: Folio inexistente en PUT
+  Dado que:  el folio "FOL-9999-00001" no existe
+  Cuando:    se realiza PUT /v1/quotes/FOL-9999-00001/coverage-options con cualquier body válido
+  Entonces:  la respuesta tiene HTTP 404
+             Y el body contiene "code": "FOLIO_NOT_FOUND"
+```
+
+### Reglas de Negocio
+
+1. **Catálogo del core obligatorio:** antes de persistir, el backend debe consultar `GET /v1/catalogs/guarantees` al core service (puerto 8081) y validar que cada `code` en el request exista en el catálogo retornado.
+2. **Solo códigos del catálogo:** si algún `code` del request no existe en el catálogo, la operación es rechazada con HTTP 422 `VALIDATION_ERROR`. El catálogo es la fuente de verdad.
+3. **Rango de deductiblePercentage:** valor decimal `>= 0.0` y `<= 100.0`. Validación a nivel de Bean Validation (`@DecimalMin("0.0")` / `@DecimalMax("100.0")`).
+4. **Rango de coinsurancePercentage:** valor decimal `>= 0.0` y `<= 100.0`. Misma validación que `deductiblePercentage`.
+5. **Versionado optimista:** el campo `version` del request debe coincidir con el valor almacenado en `QuoteJpa`. Si difiere → HTTP 409 `VERSION_CONFLICT`. El versionado se gestiona en `QuoteJpa` (aggregate raíz), no en `CoverageOptionJpa`.
+6. **Reemplazo completo:** el PUT reemplaza la lista completa de opciones de cobertura para el folio (delete all + insert all en la misma transacción).
+7. **`description` enriquecida:** al persistir, la `description` se toma del catálogo del core (no del request). El request solo envía `code`, `selected`, `deductiblePercentage` y `coinsurancePercentage`.
+8. **Actualización de `updatedAt`:** toda escritura exitosa actualiza `updatedAt` en `QuoteJpa` vía `@UpdateTimestamp`.
+9. **Folio debe existir:** tanto GET como PUT validan la existencia del folio; si no existe → HTTP 404 `FOLIO_NOT_FOUND`.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Almacén | Cambios | Descripción |
+|---------|---------|---------|-------------|
+| `CoverageOptionJpa` | tabla `coverage_options` | **nueva** | Opción de cobertura con FK a `quotes` |
+| `QuoteJpa` | tabla `quotes` | sin cambios estructurales | `@Version` gestiona el optimistic lock |
+
+#### Tabla `coverage_options` (migración V7 — nueva)
+
+| Columna | Tipo SQL | Obligatorio | Constraint | Descripción |
+|---------|----------|-------------|------------|-------------|
+| `id` | `BIGSERIAL` | sí | PK | Identificador interno |
+| `quote_id` | `BIGINT` | sí | FK → `quotes.id` ON DELETE CASCADE | Cotización propietaria |
+| `code` | `VARCHAR(50)` | sí | NOT NULL | Código de cobertura del catálogo (ej. GUA-FIRE) |
+| `description` | `VARCHAR(255)` | no | — | Descripción enriquecida desde el catálogo del core |
+| `selected` | `BOOLEAN` | sí | NOT NULL DEFAULT FALSE | ¿Cobertura seleccionada? |
+| `deductible_percentage` | `DECIMAL(5,2)` | no | CHECK >= 0 AND <= 100 | % deducible |
+| `coinsurance_percentage` | `DECIMAL(5,2)` | no | CHECK >= 0 AND <= 100 | % coaseguro |
+
+#### Índices / Constraints
+
+- `pk_coverage_options` — PRIMARY KEY en `id`
+- `fk_coverage_options_quote_id` — FK a `quotes.id` ON DELETE CASCADE
+- `uk_coverage_options_quote_code` — UNIQUE `(quote_id, code)` — un folio no repite el mismo code
+- `idx_coverage_options_quote_id` — índice en `quote_id` para consultas por folio
+
+#### Migración Flyway
+
+```sql
+-- V7__create_coverage_options_table.sql
+CREATE TABLE IF NOT EXISTS coverage_options (
+    id                     BIGSERIAL PRIMARY KEY,
+    quote_id               BIGINT         NOT NULL
+        REFERENCES quotes(id) ON DELETE CASCADE,
+    code                   VARCHAR(50)    NOT NULL,
+    description            VARCHAR(255),
+    selected               BOOLEAN        NOT NULL DEFAULT FALSE,
+    deductible_percentage  DECIMAL(5,2)
+        CONSTRAINT chk_deductible_pct CHECK (deductible_percentage >= 0 AND deductible_percentage <= 100),
+    coinsurance_percentage DECIMAL(5,2)
+        CONSTRAINT chk_coinsurance_pct CHECK (coinsurance_percentage >= 0 AND coinsurance_percentage <= 100),
+    CONSTRAINT uk_coverage_options_quote_code UNIQUE (quote_id, code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_coverage_options_quote_id ON coverage_options (quote_id);
+```
+
+#### Domain Model
+
+```java
+// coverage/domain/model/CoverageOption.java
+public record CoverageOption(
+    String code,
+    String description,
+    boolean selected,
+    BigDecimal deductiblePercentage,
+    BigDecimal coinsurancePercentage
+) {}
+```
+
+### API Endpoints
+
+#### GET /v1/quotes/{folio}/coverage-options
+
+- **Descripción:** Retorna todas las opciones de cobertura persistidas para la cotización
+- **Auth requerida:** no
+- **Path param:** `folio` — número de folio (ej. `FOL-2026-00042`)
+- **Response 200:**
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "coverageOptions": [
+      {
+        "code": "GUA-FIRE",
+        "description": "Incendio edificios",
+        "selected": true,
+        "deductiblePercentage": 2.0,
+        "coinsurancePercentage": 80.0
+      },
+      {
+        "code": "GUA-THEFT",
+        "description": "Robo",
+        "selected": false,
+        "deductiblePercentage": 5.0,
+        "coinsurancePercentage": 100.0
+      }
+    ],
+    "version": 6
+  }
+  ```
+- **Response 404:** `{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}`
+
+---
+
+#### PUT /v1/quotes/{folio}/coverage-options
+
+- **Descripción:** Reemplaza la lista completa de opciones de cobertura; valida contra catálogo del core
+- **Auth requerida:** no
+- **Path param:** `folio` — número de folio
+- **Request Body:**
+  ```json
+  {
+    "coverageOptions": [
+      {
+        "code": "GUA-FIRE",
+        "selected": true,
+        "deductiblePercentage": 2.0,
+        "coinsurancePercentage": 80.0
+      },
+      {
+        "code": "GUA-THEFT",
+        "selected": true,
+        "deductiblePercentage": 5.0,
+        "coinsurancePercentage": 100.0
+      }
+    ],
+    "version": 6
+  }
+  ```
+- **Response 200:**
+  ```json
+  {
+    "folioNumber": "FOL-2026-00042",
+    "coverageOptions": [
+      {
+        "code": "GUA-FIRE",
+        "description": "Incendio edificios",
+        "selected": true,
+        "deductiblePercentage": 2.0,
+        "coinsurancePercentage": 80.0
+      },
+      {
+        "code": "GUA-THEFT",
+        "description": "Robo",
+        "selected": true,
+        "deductiblePercentage": 5.0,
+        "coinsurancePercentage": 100.0
+      }
+    ],
+    "updatedAt": "2026-04-22T15:45:00Z",
+    "version": 7
+  }
+  ```
+- **Response 404:** `{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}`
+- **Response 409:** `{"error": "Optimistic lock conflict", "code": "VERSION_CONFLICT"}`
+- **Response 422 — code inválido:** `{"error": "Validation failed", "code": "VALIDATION_ERROR", "fields": [{"field": "coverageOptions[0].code", "message": "Code not found in catalog"}]}`
+- **Response 422 — porcentaje inválido:** `{"error": "Validation failed", "code": "VALIDATION_ERROR", "fields": [{"field": "coverageOptions[0].deductiblePercentage", "message": "must be between 0.0 and 100.0"}]}`
+
+---
+
+### Arquitectura Hexagonal — Descomposición de Componentes
+
+#### Bounded context: `coverage`
+
+```
+com.sofka.insurancequoter.back.coverage/
+├── domain/
+│   ├── model/
+│   │   └── CoverageOption.java                            ← Record (code, description, selected, deductiblePercentage, coinsurancePercentage)
+│   └── port/
+│       ├── in/
+│       │   ├── GetCoverageOptionsUseCase.java             ← Input Port: CoverageOptionsResponse getCoverageOptions(String folioNumber)
+│       │   └── SaveCoverageOptionsUseCase.java            ← Input Port: CoverageOptionsResponse saveCoverageOptions(SaveCoverageOptionsCommand)
+│       └── out/
+│           ├── CoverageOptionRepository.java             ← Output Port: findByFolioNumber / replaceAll
+│           ├── QuoteLookupPort.java                      ← Output Port: verifica existencia y versión del folio
+│           └── GuaranteeCatalogClient.java               ← Output Port: List<GuaranteeDto> fetchGuarantees()
+├── application/
+│   └── usecase/
+│       ├── GetCoverageOptionsUseCaseImpl.java            ← Orquesta: lookup folio → buscar opciones → retornar
+│       ├── SaveCoverageOptionsUseCaseImpl.java           ← Orquesta: lookup folio → validar versión → validar codes → enriquecer → persistir
+│       ├── command/
+│       │   └── SaveCoverageOptionsCommand.java           ← Record: folioNumber, coverageOptions, version
+│       ├── dto/
+│       │   └── CoverageOptionsResponse.java             ← Record: folioNumber, coverageOptions, updatedAt, version
+│       └── exception/
+│           └── InvalidCoverageCodeException.java         ← Error de dominio: code no existe en catálogo
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/
+    │   │   └── rest/
+    │   │       ├── CoverageController.java               ← implementa CoverageApi; inyecta use cases y mapper
+    │   │       ├── swaggerdocs/
+    │   │       │   └── CoverageApi.java                  ← @Tag "Coverage Options"; @Operation GET y PUT
+    │   │       ├── dto/
+    │   │       │   ├── request/
+    │   │       │   │   ├── SaveCoverageOptionsRequest.java    ← { coverageOptions: [...], version }
+    │   │       │   │   └── CoverageOptionItemRequest.java     ← { code, selected, deductiblePercentage, coinsurancePercentage }
+    │   │       │   └── response/
+    │   │       │       ├── CoverageOptionsListResponse.java   ← { folioNumber, coverageOptions, updatedAt, version }
+    │   │       │       └── CoverageOptionItemResponse.java    ← { code, description, selected, deductiblePercentage, coinsurancePercentage }
+    │   │       └── mapper/
+    │   │           └── CoverageRestMapper.java
+    │   └── out/
+    │       ├── persistence/
+    │       │   ├── adapter/
+    │       │   │   └── CoverageOptionJpaAdapter.java      ← implementa CoverageOptionRepository + QuoteLookupPort
+    │       │   ├── repositories/
+    │       │   │   ├── CoverageOptionJpaRepository.java   ← extiende JpaRepository<CoverageOptionJpa, Long>
+    │       │   │   └── QuoteJpaRepository.java            ← existente de SPEC-002 — reutilizar para lookup por folioNumber
+    │       │   ├── entities/
+    │       │   │   └── CoverageOptionJpa.java             ← @Entity tabla coverage_options; @ManyToOne QuoteJpa
+    │       │   └── mappers/
+    │       │       └── CoverageOptionPersistenceMapper.java
+    │       └── http/
+    │           ├── adapter/
+    │           │   └── GuaranteeCatalogClientAdapter.java ← implementa GuaranteeCatalogClient; llama GET /v1/catalogs/guarantees al core
+    │           └── dto/
+    │               ├── GuaranteeCatalogResponse.java      ← { guarantees: [...] }
+    │               └── GuaranteeDto.java                  ← { code, description, tarifable }
+    └── config/
+        └── CoverageConfig.java                           ← @Bean wiring de use cases + RestClient para core
+```
+
+#### Contratos de interfaces clave
+
+```java
+// domain/port/in/GetCoverageOptionsUseCase.java
+public interface GetCoverageOptionsUseCase {
+    CoverageOptionsResponse getCoverageOptions(String folioNumber);
+}
+
+// domain/port/in/SaveCoverageOptionsUseCase.java
+public interface SaveCoverageOptionsUseCase {
+    CoverageOptionsResponse saveCoverageOptions(SaveCoverageOptionsCommand command);
+}
+
+// domain/port/out/CoverageOptionRepository.java
+public interface CoverageOptionRepository {
+    List<CoverageOption> findByFolioNumber(String folioNumber);
+    List<CoverageOption> replaceAll(String folioNumber, List<CoverageOption> options);
+}
+
+// domain/port/out/QuoteLookupPort.java
+public interface QuoteLookupPort {
+    void assertFolioExists(String folioNumber);      // lanza FolioNotFoundException si no existe
+    long getCurrentVersion(String folioNumber);       // retorna version actual
+    void assertVersionMatches(String folioNumber, long expectedVersion); // lanza VersionConflictException si difiere
+}
+
+// domain/port/out/GuaranteeCatalogClient.java
+public interface GuaranteeCatalogClient {
+    List<GuaranteeDto> fetchGuarantees();  // llama GET /v1/catalogs/guarantees al core
+}
+```
+
+#### Flujo de llamada — PUT (reemplazo)
+
+```
+CoverageController.saveCoverageOptions(folio, request)
+  → SaveCoverageOptionsUseCase.saveCoverageOptions(command)
+      1. QuoteLookupPort.assertFolioExists(folio)            ← 404 si no existe
+      2. QuoteLookupPort.assertVersionMatches(folio, version) ← 409 si conflict
+      3. GuaranteeCatalogClient.fetchGuarantees()            ← obtiene catálogo del core
+      4. Para cada opción en command.coverageOptions:
+         a. Validar que code existe en el catálogo            ← InvalidCoverageCodeException si no
+         b. Enriquecer description desde el catálogo
+      5. CoverageOptionRepository.replaceAll(folio, enrichedOptions) ← delete + insert en una tx
+      6. return CoverageOptionsResponse (con version incrementada por @Version de QuoteJpa)
+  ← ResponseEntity<CoverageOptionsListResponse>(200)
+```
+
+#### Manejo de excepciones
+
+| Excepción de dominio | HTTP | Código |
+|---------------------|------|--------|
+| `FolioNotFoundException` | 404 | `FOLIO_NOT_FOUND` |
+| `VersionConflictException` | 409 | `VERSION_CONFLICT` |
+| `InvalidCoverageCodeException` | 422 | `VALIDATION_ERROR` |
+| `MethodArgumentNotValidException` | 422 | `VALIDATION_ERROR` |
+
+> `GlobalExceptionHandler` (existente de SPEC-002) debe agregar handler para `InvalidCoverageCodeException` → 422 `VALIDATION_ERROR`.
+
+### Notas de Implementación
+
+- **Reutilizar `FolioNotFoundException` y `VersionConflictException`:** estas excepciones ya existen en `location/application/usecase/`. Mover a un paquete compartido (ej. `com.sofka.insurancequoter.back.shared.exception`) o reusar desde `location`. Verificar que `GlobalExceptionHandler` ya las registra.
+- **`QuoteLookupPort` — `QuoteJpa` y `@Version`:** el incremento de `version` es automático vía Hibernate cuando `QuoteJpa` se guarda. La implementación de `replaceAll` debe realizar un `save(quoteJpa)` con un cambio de campo (ej. `updatedAt`) para que `@Version` incremente. Alternativa: usar `@Query` con `UPDATE ... SET version = version + 1`.
+- **`CoverageOptionJpaAdapter.replaceAll`:** debe implementarse como una transacción atómica: (1) `deleteByQuoteId(quote.id)` + (2) `saveAll(newOptions)`. Marcar con `@Transactional`.
+- **`GuaranteeCatalogClientAdapter`:** utilizar el `RestClient` configurado en `CoverageConfig` apuntando al core service (puerto 8081). En caso de error del core → lanzar `CoreServiceException` (ya existente). Para tests, usar WireMock.
+- **Validación de rangos con Bean Validation:** `CoverageOptionItemRequest` debe usar `@DecimalMin("0.0")` y `@DecimalMax("100.0")` en `deductiblePercentage` y `coinsurancePercentage`. La validación de `code` contra catálogo es lógica de negocio → se hace en el use case (no con anotaciones).
+- **`QuoteJpaRepository` reutilizado:** el repositorio JPA de `quotes` ya existe en el contexto `folio`. `CoverageOptionJpaAdapter` puede inyectarlo directamente o exponerlo vía un nuevo output port `QuoteLookupPort` implementado por un adapter en `coverage/infrastructure/adapter/out/persistence/`.
+- **Orden de DELETE + INSERT:** al reemplazar, siempre hacer `deleteAllByQuoteId` antes del `saveAll` dentro de la misma transacción para respetar el constraint `UNIQUE (quote_id, code)`.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable. Marcar cada ítem (`[x]`) al completarlo.
+
+### Backend
+
+#### Base de Datos
+- [ ] Crear migración `V7__create_coverage_options_table.sql` — tabla `coverage_options` con columnas, FK a `quotes`, constraint UNIQUE `(quote_id, code)`, CHECK constraints para porcentajes, índice `idx_coverage_options_quote_id`
+
+#### Dominio
+- [ ] Crear record `CoverageOption` en `coverage/domain/model/` — campos: `code`, `description`, `selected`, `deductiblePercentage`, `coinsurancePercentage`
+- [ ] Crear Input Port `GetCoverageOptionsUseCase` en `coverage/domain/port/in/`
+- [ ] Crear Input Port `SaveCoverageOptionsUseCase` en `coverage/domain/port/in/`
+- [ ] Crear Output Port `CoverageOptionRepository` en `coverage/domain/port/out/` — métodos: `findByFolioNumber`, `replaceAll`
+- [ ] Crear Output Port `QuoteLookupPort` en `coverage/domain/port/out/` — métodos: `assertFolioExists`, `getCurrentVersion`, `assertVersionMatches`
+- [ ] Crear Output Port `GuaranteeCatalogClient` en `coverage/domain/port/out/` — método: `fetchGuarantees`
+
+#### Aplicación
+- [ ] Crear record `SaveCoverageOptionsCommand` en `coverage/application/usecase/command/` — campos: `folioNumber`, `coverageOptions`, `version`
+- [ ] Crear record `CoverageOptionsResponse` en `coverage/application/usecase/dto/` — campos: `folioNumber`, `coverageOptions`, `updatedAt`, `version`
+- [ ] Crear `InvalidCoverageCodeException` en `coverage/application/usecase/exception/`
+- [ ] Crear `GetCoverageOptionsUseCaseImpl` en `coverage/application/usecase/` — orquesta lookup + buscar opciones + retornar
+- [ ] Crear `SaveCoverageOptionsUseCaseImpl` en `coverage/application/usecase/` — orquesta validación de versión + validación de codes + enriquecimiento + persistencia
+
+#### Infraestructura — Persistencia
+- [ ] Crear `CoverageOptionJpa` en `coverage/infrastructure/adapter/out/persistence/entities/` — `@Entity`, `@ManyToOne` a `QuoteJpa`, columnas según diseño
+- [ ] Crear `CoverageOptionJpaRepository` en `coverage/infrastructure/adapter/out/persistence/repositories/` — extiende `JpaRepository<CoverageOptionJpa, Long>`; método `findByQuoteId` y `deleteAllByQuoteId`
+- [ ] Crear `CoverageOptionPersistenceMapper` en `coverage/infrastructure/adapter/out/persistence/mappers/` — `CoverageOption ↔ CoverageOptionJpa`
+- [ ] Crear `CoverageOptionJpaAdapter` en `coverage/infrastructure/adapter/out/persistence/adapter/` — implementa `CoverageOptionRepository` y `QuoteLookupPort`; método `replaceAll` con `@Transactional`
+
+#### Infraestructura — HTTP Client
+- [ ] Crear `GuaranteeDto` y `GuaranteeCatalogResponse` en `coverage/infrastructure/adapter/out/http/dto/`
+- [ ] Crear `GuaranteeCatalogClientAdapter` en `coverage/infrastructure/adapter/out/http/adapter/` — implementa `GuaranteeCatalogClient`; llama `GET /v1/catalogs/guarantees` al core
+
+#### Infraestructura — REST
+- [ ] Crear `CoverageOptionItemRequest` en `coverage/infrastructure/adapter/in/rest/dto/request/` — `@DecimalMin`/`@DecimalMax` en porcentajes
+- [ ] Crear `SaveCoverageOptionsRequest` en `coverage/infrastructure/adapter/in/rest/dto/request/` — `@Valid @NotNull` en `coverageOptions`; `@NotNull` en `version`
+- [ ] Crear `CoverageOptionItemResponse` en `coverage/infrastructure/adapter/in/rest/dto/response/`
+- [ ] Crear `CoverageOptionsListResponse` en `coverage/infrastructure/adapter/in/rest/dto/response/`
+- [ ] Crear `CoverageRestMapper` en `coverage/infrastructure/adapter/in/rest/mapper/`
+- [ ] Crear Swagger interface `CoverageApi` en `coverage/infrastructure/adapter/in/rest/swaggerdocs/` — `@Tag "Coverage Options"`, `@Operation` para GET y PUT
+- [ ] Crear `CoverageController` en `coverage/infrastructure/adapter/in/rest/` — implementa `CoverageApi`; inyecta use cases vía constructor
+- [ ] Actualizar `GlobalExceptionHandler` — agregar handler para `InvalidCoverageCodeException` → 422 `VALIDATION_ERROR` con `fields`
+
+#### Configuración
+- [ ] Crear `CoverageConfig` en `coverage/infrastructure/config/` — `@Bean` wiring de `GetCoverageOptionsUseCaseImpl`, `SaveCoverageOptionsUseCaseImpl`, `CoverageOptionJpaAdapter`, `GuaranteeCatalogClientAdapter`
+
+#### Tests Backend (TDD — escribir el test ANTES de la implementación)
+
+**GetCoverageOptionsUseCaseImpl**
+- [ ] `GetCoverageOptionsUseCaseImplTest` — folio existente con opciones → retorna lista con todos los campos
+- [ ] `GetCoverageOptionsUseCaseImplTest` — folio existente sin opciones → retorna lista vacía
+- [ ] `GetCoverageOptionsUseCaseImplTest` — folio inexistente → lanza FolioNotFoundException
+
+**SaveCoverageOptionsUseCaseImpl**
+- [ ] `SaveCoverageOptionsUseCaseImplTest` — version conflict → lanza VersionConflictException sin persistir
+- [ ] `SaveCoverageOptionsUseCaseImplTest` — folio inexistente → lanza FolioNotFoundException
+- [ ] `SaveCoverageOptionsUseCaseImplTest` — code no existe en catálogo → lanza InvalidCoverageCodeException
+- [ ] `SaveCoverageOptionsUseCaseImplTest` — guardado exitoso: retorna opciones con descripción enriquecida desde catálogo y version incrementada
+- [ ] `SaveCoverageOptionsUseCaseImplTest` — mix de selected true/false: persiste correctamente ambos estados
+
+**CoverageOptionJpaAdapter**
+- [ ] `CoverageOptionJpaAdapterTest` — findByFolioNumber retorna lista vacía si no hay opciones
+- [ ] `CoverageOptionJpaAdapterTest` — replaceAll elimina existentes y persiste nuevas en la misma transacción
+- [ ] `CoverageOptionJpaAdapterTest` — assertFolioExists lanza FolioNotFoundException si el folio no existe
+- [ ] `CoverageOptionJpaAdapterTest` — assertVersionMatches lanza VersionConflictException si version difiere
+
+**GuaranteeCatalogClientAdapter**
+- [ ] `GuaranteeCatalogClientAdapterTest` — respuesta exitosa del core → retorna lista de GuaranteeDto (WireMock)
+- [ ] `GuaranteeCatalogClientAdapterTest` — error del core (5xx) → lanza CoreServiceException (WireMock)
+
+**CoverageController**
+- [ ] `CoverageControllerTest` — GET /v1/quotes/{folio}/coverage-options → HTTP 200 con lista de opciones
+- [ ] `CoverageControllerTest` — GET con folio inexistente → HTTP 404 FOLIO_NOT_FOUND
+- [ ] `CoverageControllerTest` — PUT exitoso → HTTP 200 con versión incrementada
+- [ ] `CoverageControllerTest` — PUT con version conflict → HTTP 409 VERSION_CONFLICT
+- [ ] `CoverageControllerTest` — PUT con code inválido → HTTP 422 VALIDATION_ERROR
+- [ ] `CoverageControllerTest` — PUT con deductiblePercentage > 100 → HTTP 422 VALIDATION_ERROR
+- [ ] `CoverageControllerTest` — PUT con coinsurancePercentage < 0 → HTTP 422 VALIDATION_ERROR
+
+**Tests de integración**
+- [ ] `CoverageOptionsIntegrationTest` — `@SpringBootTest` + Testcontainers PostgreSQL + WireMock para core: PUT luego GET retorna datos persistidos con descripción del catálogo
+- [ ] `CoverageOptionsIntegrationTest` — PUT con version conflict: HTTP 409 y datos sin modificar
+- [ ] `CoverageOptionsIntegrationTest` — PUT con code inválido (WireMock retorna catálogo sin ese code): HTTP 422
+- [ ] `CoverageOptionsIntegrationTest` — GET folio sin opciones: HTTP 200 con array vacío
+
+### QA
+- [ ] Ejecutar skill `/gherkin-case-generator` → escenarios para CRITERIO-1.1…2.7
+- [ ] Ejecutar skill `/risk-identifier` → clasificación ASD (concurrencia en version, core unavailable, constraint UNIQUE)
+- [ ] Validar manualmente con Bruno/Postman: GET y PUT
+- [ ] Verificar que `description` en la respuesta proviene del catálogo del core, no del request
+- [ ] Verificar que DELETE + INSERT son atómicos (rollback si falla el INSERT)
+- [ ] Verificar comportamiento cuando el core service no está disponible
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/.claude/specs/coverage-options.spec.md
+++ b/.claude/specs/coverage-options.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-006
-status: DRAFT
+status: IMPLEMENTED
 feature: coverage-options
 created: 2026-04-22
 updated: 2026-04-22

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ out/
 .env
 *.env
 !.env.example
+
+### Claude agent internal state ###
+.claude/agent-memory/
+.claude/scheduled_tasks.lock

--- a/docs/output/qa/coverage-options-gherkin.md
+++ b/docs/output/qa/coverage-options-gherkin.md
@@ -1,0 +1,235 @@
+# Escenarios Gherkin — Opciones de Cobertura de Cotización (SPEC-006)
+
+> Generado desde los criterios de aceptación CRITERIO-1.1…2.7
+> Feature: `coverage-options` | Spec: `SPEC-006`
+
+---
+
+```gherkin
+#language: es
+Característica: Gestión de opciones de cobertura de cotización
+  Como agente de seguros
+  Quiero gestionar las opciones de cobertura de una cotización
+  Para registrar qué coberturas aplican con sus parámetros de deducible y coaseguro
+
+  Antecedentes:
+    Dado que el sistema tiene un folio activo "FOL-2026-00042" con versión 6
+    Y el core service responde en "http://localhost:8081"
+    Y el core service expone el catálogo de garantías con los codes "GUA-FIRE" y "GUA-THEFT"
+
+  # ─────────────────────────────────────────────
+  # HU-01: Consultar opciones de cobertura
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @HU-01 @CRITERIO-1.1
+  Escenario: Consulta exitosa de opciones de cobertura configuradas
+    Dado que el folio "FOL-2026-00042" tiene dos opciones de cobertura persistidas
+      | code      | description      | selected | deductiblePercentage | coinsurancePercentage |
+      | GUA-FIRE  | Incendio edificios | true   | 2.0                  | 80.0                  |
+      | GUA-THEFT | Robo             | false    | 5.0                  | 100.0                 |
+    Cuando se consultan las opciones de cobertura del folio "FOL-2026-00042"
+    Entonces la respuesta es HTTP 200
+    Y el cuerpo contiene "folioNumber": "FOL-2026-00042"
+    Y "coverageOptions" es un arreglo con 2 elementos
+    Y cada opción incluye los campos: code, description, selected, deductiblePercentage, coinsurancePercentage
+    Y "version" es 6
+
+  @edge-case @HU-01 @CRITERIO-1.2
+  Escenario: Consulta de cotización sin opciones de cobertura retorna lista vacía
+    Dado que el folio "FOL-2026-00042" existe pero no tiene opciones de cobertura registradas
+    Cuando se consultan las opciones de cobertura del folio "FOL-2026-00042"
+    Entonces la respuesta es HTTP 200
+    Y "coverageOptions" es un arreglo vacío
+    Y "version" es 6
+
+  @error-path @HU-01 @CRITERIO-1.3
+  Escenario: Consulta de opciones de cobertura con folio inexistente retorna 404
+    Dado que el folio "FOL-9999-00001" no existe en el sistema
+    Cuando se consultan las opciones de cobertura del folio "FOL-9999-00001"
+    Entonces la respuesta es HTTP 404
+    Y el cuerpo contiene '{"error": "Folio not found", "code": "FOLIO_NOT_FOUND"}'
+
+  # ─────────────────────────────────────────────
+  # HU-02: Configurar opciones de cobertura
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @HU-02 @CRITERIO-2.1
+  Escenario: Configuración exitosa de coberturas con codes válidos del catálogo
+    Dado que el folio "FOL-2026-00042" tiene versión 6
+    Y el core service retorna el catálogo con "GUA-FIRE" (Incendio edificios) y "GUA-THEFT" (Robo)
+    Cuando se configuran las opciones de cobertura del folio "FOL-2026-00042" con versión 6
+      | code      | selected | deductiblePercentage | coinsurancePercentage |
+      | GUA-FIRE  | true     | 2.0                  | 80.0                  |
+      | GUA-THEFT | true     | 5.0                  | 100.0                 |
+    Entonces la respuesta es HTTP 200
+    Y "coverageOptions" refleja las dos coberturas enviadas con sus parámetros
+    Y "version" es 7
+    Y "updatedAt" tiene formato ISO-8601 UTC
+
+  @happy-path @HU-02 @CRITERIO-2.2
+  Escenario: Configuración con mix de coberturas seleccionadas y no seleccionadas
+    Dado que el folio "FOL-2026-00042" tiene versión 6
+    Y el catálogo del core contiene "GUA-FIRE" y "GUA-THEFT"
+    Cuando se configuran las opciones con "GUA-FIRE" seleccionada y "GUA-THEFT" no seleccionada con versión 6
+    Entonces la respuesta es HTTP 200
+    Y "coverageOptions[0].selected" es verdadero para GUA-FIRE
+    Y "coverageOptions[1].selected" es falso para GUA-THEFT
+    Y "version" es 7
+
+  @error-path @HU-02 @CRITERIO-2.3
+  Escenario: Conflicto de versión optimista retorna 409
+    Dado que el folio "FOL-2026-00042" tiene versión actual 7
+    Cuando se configuran las opciones de cobertura del folio "FOL-2026-00042" con versión 6 (desactualizada)
+    Entonces la respuesta es HTTP 409
+    Y el cuerpo contiene '{"error": "Optimistic lock conflict", "code": "VERSION_CONFLICT"}'
+    Y los datos de cobertura no se modifican
+
+  @error-path @HU-02 @CRITERIO-2.4
+  Escenario: Configuración rechazada por code de cobertura no existente en catálogo
+    Dado que el catálogo del core NO contiene el code "COV-INVALID"
+    Y el folio "FOL-2026-00042" tiene versión 6
+    Cuando se configuran las opciones con una cobertura cuyo code es "COV-INVALID" y versión 6
+    Entonces la respuesta es HTTP 422
+    Y el cuerpo contiene "code": "VALIDATION_ERROR"
+    Y "fields" identifica el code inválido
+
+  @error-path @HU-02 @CRITERIO-2.5
+  Escenario: Configuración rechazada por deductiblePercentage fuera de rango
+    Dado que el folio "FOL-2026-00042" tiene versión 6
+    Cuando se configuran las opciones con una cobertura que tiene deductiblePercentage 150.0 y versión 6
+    Entonces la respuesta es HTTP 422
+    Y el cuerpo contiene "code": "VALIDATION_ERROR"
+    Y "fields" identifica deductiblePercentage como inválido
+
+  @error-path @HU-02 @CRITERIO-2.6
+  Escenario: Configuración rechazada por coinsurancePercentage fuera de rango
+    Dado que el folio "FOL-2026-00042" tiene versión 6
+    Cuando se configuran las opciones con una cobertura que tiene coinsurancePercentage -5.0 y versión 6
+    Entonces la respuesta es HTTP 422
+    Y el cuerpo contiene "code": "VALIDATION_ERROR"
+    Y "fields" identifica coinsurancePercentage como inválido
+
+  @error-path @HU-02 @CRITERIO-2.7
+  Escenario: Configuración de coberturas con folio inexistente retorna 404
+    Dado que el folio "FOL-9999-00001" no existe en el sistema
+    Cuando se configuran las opciones de cobertura del folio "FOL-9999-00001" con cualquier body válido
+    Entonces la respuesta es HTTP 404
+    Y el cuerpo contiene "code": "FOLIO_NOT_FOUND"
+
+  # ─────────────────────────────────────────────
+  # Reglas de negocio transversales
+  # ─────────────────────────────────────────────
+
+  @edge-case @regla-negocio
+  Escenario: La description en la respuesta proviene del catálogo del core, no del request
+    Dado que el catálogo del core retorna "GUA-FIRE" con description "Incendio edificios"
+    Y el folio "FOL-2026-00042" tiene versión 6
+    Cuando se configuran opciones enviando solo code, selected y porcentajes (sin description) con versión 6
+    Entonces la respuesta es HTTP 200
+    Y "coverageOptions[0].description" es "Incendio edificios" (enriquecida desde el catálogo)
+
+  @edge-case @regla-negocio
+  Escenario: El PUT reemplaza la lista completa de coberturas
+    Dado que el folio "FOL-2026-00042" tiene dos opciones de cobertura persistidas: "GUA-FIRE" y "GUA-THEFT"
+    Y tiene versión 6
+    Cuando se configura solo la cobertura "GUA-FIRE" con versión 6
+    Entonces la respuesta es HTTP 200
+    Y "coverageOptions" contiene únicamente "GUA-FIRE"
+    Y "GUA-THEFT" ya no aparece en la respuesta
+    Y "version" es 7
+
+  @edge-case @regla-negocio
+  Escenario: Valores límite válidos para porcentajes (0.0 y 100.0)
+    Dado que el folio "FOL-2026-00042" tiene versión 6
+    Y el catálogo contiene "GUA-FIRE"
+    Cuando se configura "GUA-FIRE" con deductiblePercentage 0.0 y coinsurancePercentage 100.0 y versión 6
+    Entonces la respuesta es HTTP 200
+    Y "coverageOptions[0].deductiblePercentage" es 0.0
+    Y "coverageOptions[0].coinsurancePercentage" es 100.0
+
+  @edge-case @regla-negocio
+  Escenario: Valores justo fuera de rango rechazados con 422
+    Dado que el folio "FOL-2026-00042" tiene versión 6
+    Cuando se configura una cobertura con deductiblePercentage 100.01 y versión 6
+    Entonces la respuesta es HTTP 422
+    Y el cuerpo contiene "code": "VALIDATION_ERROR"
+
+  @edge-case @regla-negocio
+  Esquema del escenario: Validar rangos de porcentajes
+    Dado que el folio "FOL-2026-00042" tiene versión 6
+    Cuando se configura una cobertura con <campo> igual a <valor>
+    Entonces la respuesta es HTTP <http_status>
+    Ejemplos:
+      | campo                  | valor  | http_status |
+      | deductiblePercentage   | -0.01  | 422         |
+      | deductiblePercentage   | 0.0    | 200         |
+      | deductiblePercentage   | 50.0   | 200         |
+      | deductiblePercentage   | 100.0  | 200         |
+      | deductiblePercentage   | 100.01 | 422         |
+      | coinsurancePercentage  | -5.0   | 422         |
+      | coinsurancePercentage  | 0.0    | 200         |
+      | coinsurancePercentage  | 100.0  | 200         |
+      | coinsurancePercentage  | 150.0  | 422         |
+```
+
+---
+
+## Datos de Prueba Sintéticos
+
+| Escenario | Campo | Valor válido | Valor inválido | Borde |
+|-----------|-------|-------------|----------------|-------|
+| Código de cobertura | `code` | `"GUA-FIRE"`, `"GUA-THEFT"` | `"COV-INVALID"` | `""` (vacío) |
+| Versión optimista | `version` | versión actual del folio | versión anterior (stale) | `0` |
+| Porcentaje deducible | `deductiblePercentage` | `2.0`, `50.0` | `-0.01`, `150.0` | `0.0`, `100.0` |
+| Porcentaje coaseguro | `coinsurancePercentage` | `80.0`, `100.0` | `-5.0`, `200.0` | `0.0`, `100.0` |
+| Selección cobertura | `selected` | `true`, `false` | — | ambas en mismo request |
+
+### Folios de prueba
+
+| Folio | Estado | Versión inicial | Uso |
+|-------|--------|-----------------|-----|
+| `FOL-2026-00042` | CREATED | 6 | Happy paths HU-01..02 |
+| `FOL-2026-00099` | CREATED | 7 | Escenarios con version conflict |
+| `FOL-9999-00001` | (inexistente) | — | Error paths 404 |
+
+### Respuestas WireMock para core service
+
+```json
+// GET /v1/catalogs/guarantees → 200 (catálogo estándar)
+{
+  "guarantees": [
+    { "code": "GUA-FIRE",  "description": "Incendio edificios" },
+    { "code": "GUA-THEFT", "description": "Robo" }
+  ]
+}
+
+// GET /v1/catalogs/guarantees → 200 (catálogo reducido — solo GUA-FIRE)
+{
+  "guarantees": [
+    { "code": "GUA-FIRE", "description": "Incendio edificios" }
+  ]
+}
+
+// GET /v1/catalogs/guarantees → 503 (core no disponible)
+HTTP 503 Service Unavailable
+```
+
+---
+
+## Cobertura por criterio
+
+| Criterio | Escenario Gherkin | Etiquetas |
+|----------|-------------------|-----------|
+| CRITERIO-1.1 | Consulta exitosa con dos coberturas configuradas | `@smoke @critico @HU-01` |
+| CRITERIO-1.2 | GET sin opciones configuradas → array vacío | `@edge-case @HU-01` |
+| CRITERIO-1.3 | Folio inexistente en GET → 404 | `@error-path @HU-01` |
+| CRITERIO-2.1 | PUT exitoso con codes válidos → 200 y version +1 | `@smoke @critico @HU-02` |
+| CRITERIO-2.2 | PUT con mix selected true/false → persiste ambos | `@happy-path @HU-02` |
+| CRITERIO-2.3 | Version conflict PUT → 409 | `@error-path @HU-02` |
+| CRITERIO-2.4 | Code no existe en catálogo → 422 VALIDATION_ERROR | `@error-path @HU-02` |
+| CRITERIO-2.5 | deductiblePercentage > 100 → 422 VALIDATION_ERROR | `@error-path @HU-02` |
+| CRITERIO-2.6 | coinsurancePercentage < 0 → 422 VALIDATION_ERROR | `@error-path @HU-02` |
+| CRITERIO-2.7 | Folio inexistente en PUT → 404 | `@error-path @HU-02` |
+| Regla 6 | PUT reemplaza lista completa (no merge) | `@edge-case @regla-negocio` |
+| Regla 7 | description enriquecida desde catálogo, no del request | `@edge-case @regla-negocio` |
+| Borde | Valores límite 0.0 y 100.0 son válidos | `@edge-case @regla-negocio` |

--- a/docs/output/qa/coverage-options-risks.md
+++ b/docs/output/qa/coverage-options-risks.md
@@ -1,0 +1,117 @@
+# Matriz de Riesgos — Opciones de Cobertura de Cotización (SPEC-006)
+
+> Generado por `/risk-identifier` | Feature: `coverage-options`
+> Spec: `SPEC-006` | Fecha: 2026-04-22
+
+---
+
+## Resumen
+
+Total: 9 | Alto (A): 4 | Medio (S): 3 | Bajo (D): 2
+
+---
+
+## Detalle
+
+| ID    | HU           | Descripción del Riesgo                                                                                                                      | Factores                                                         | Nivel | Testing     |
+|-------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|-------|-------------|
+| R-001 | HU-02        | Operación `replaceAll` ejecuta DELETE masivo + INSERT en la misma TX; si la TX no está delimitada con `@Transactional`, un fallo entre DELETE e INSERT deja la cotización sin coberturas — dato irrecuperable sin respaldo | Operación destructiva, integridad transaccional, código nuevo    | **A** | Obligatorio |
+| R-002 | HU-02        | Condición de carrera en versionado optimista manual: la verificación `version == command.version` corre antes de persistir; dos threads concurrentes pueden pasar la validación simultáneamente y el segundo sobrescribir al primero sin 409 | Concurrencia, integridad de datos, SLA                           | **A** | Obligatorio |
+| R-003 | HU-02        | Integración con core service inestable: si `GET /v1/catalogs/guarantees` falla (timeout, 5xx), el flujo debe propagar `CoreServiceException` → 502; un manejo incorrecto puede propagar 500 o validar incorrectamente codes ausentes | Integración con sistema externo, datos sensibles del catálogo     | **A** | Obligatorio |
+| R-004 | HU-02        | Constraint `UNIQUE (quote_id, code)` en la tabla: si el request contiene el mismo `code` dos veces, el `saveAll` lanza `DataIntegrityViolationException` no manejada, retornando 500 en lugar de 422 | Flujo crítico sin validación explícita en el use case            | **A** | Obligatorio |
+| R-005 | HU-02        | La `description` debe enriquecerse desde el catálogo del core, no del request. Si el mapper toma la descripción del request en lugar del catálogo, el constraint de dominio se viola silenciosamente sin error visible | Lógica de enriquecimiento, fuente de verdad del catálogo         | **S** | Recomendado |
+| R-006 | HU-02        | El catálogo del core puede cambiar entre la llamada `fetchGuarantees()` y la validación de codes: un code válido al momento de la solicitud puede desaparecer entre peticiones concurrentes, provocando un rechazo inesperado | Consistencia eventual, integración con sistema externo           | **S** | Recomendado |
+| R-007 | HU-01/HU-02  | El campo `version` en el response GET no refleja la versión post-PUT si la caché de Hibernate no se invalida correctamente; un `EntityManager` con snapshot desactualizado puede retornar `version` anterior | Comportamiento ORM, versionado Hibernate                         | **S** | Recomendado |
+| R-008 | HU-01        | Serialización de `BigDecimal` para `deductiblePercentage` y `coinsurancePercentage`: Jackson puede serializar como número con escala variable (`2.0` vs `2.00`); puede romper el contrato con el frontend si espera un formato fijo | Ajuste de serialización, contrato de API                         | **D** | Opcional    |
+| R-009 | HU-02        | El body `PUT` permite enviar `coverageOptions: []` (lista vacía); el comportamiento esperado es que se eliminen todas las coberturas previas sin error; sin test explícito puede no estar cubierto | Edge case no cubierto explícitamente en criterios de aceptación  | **D** | Opcional    |
+
+---
+
+## Plan de Mitigación — Riesgos ALTO
+
+---
+
+### R-001: Operación replaceAll destructiva sin atomicidad garantizada
+
+**Descripción:** `CoverageOptionJpaAdapter.replaceAll` ejecuta `deleteAllByQuote_Id(quoteId)` seguido de `saveAll(newOptions)`. Si la transacción no está correctamente delimitada con `@Transactional`, un fallo en el INSERT (ej. violación de constraint) después del DELETE deja el folio sin coberturas — estado inconsistente irrecuperable sin snapshot previo.
+
+**Mitigación:**
+- Verificar que `replaceAll` en `CoverageOptionJpaAdapter` tiene `@Transactional`.
+- El test de integración `CoverageOptionsIntegrationTest` ya cubre PUT+GET; agregar verificación explícita de rollback forzando fallo en INSERT.
+- No ejecutar DELETE y INSERT como llamadas separadas fuera de un bloque `@Transactional`.
+
+**Tests obligatorios:**
+- `CoverageOptionsIntegrationTest` — PUT exitoso → GET posterior retorna datos consistentes.
+- `CoverageOptionJpaAdapterTest` — `replaceAll` ejecuta ambas operaciones en la misma transacción.
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+### R-002: Condición de carrera en versionado optimista manual
+
+**Descripción:** `SaveCoverageOptionsUseCaseImpl` llama `quoteLookupPort.assertVersionMatches(folio, command.version())` antes de persistir. Si dos threads concurrentes superan la validación simultáneamente (ambos leen version=6, ambos validan OK), el segundo save puede sobrescribir al primero sin disparar 409. La guarda final la provee `@Version` de Hibernate en `QuoteJpa`, que lanza `ObjectOptimisticLockingFailureException` — debe estar correctamente manejada en `GlobalExceptionHandler`.
+
+**Mitigación:**
+- Verificar que `GlobalExceptionHandler` captura `ObjectOptimisticLockingFailureException` → 409 (ya existe en el handler).
+- El `replaceAll` debe incluir un `save(quoteJpa)` que dispare el incremento de `@Version` en Hibernate.
+- Test de integración con dos requests concurrentes sobre el mismo folio.
+
+**Tests obligatorios:**
+- `SaveCoverageOptionsUseCaseImplTest` — version conflict en check manual → `VersionConflictException`.
+- `CoverageOptionsIntegrationTest` — PUT con versión desactualizada → 409.
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+### R-003: Integración con core service inestable (catálogo de garantías)
+
+**Descripción:** `GuaranteeCatalogClientAdapter` llama `GET /v1/catalogs/guarantees` en cada PUT. Si el core no responde (timeout, 503) el adapter lanza `CoreServiceException` → `GlobalExceptionHandler` devuelve 502. Un manejo incorrecto puede: (a) propagar excepción de red como 500, (b) retornar lista vacía del catálogo y rechazar todos los codes como inválidos con 422.
+
+**Mitigación:**
+- `GuaranteeCatalogClientAdapter` usa `onStatus(HttpStatusCode::isError, ...)` para lanzar `CoreServiceException` — nunca retorna lista vacía ante error.
+- WireMock en tests de integración simula: (a) 200 con catálogo, (b) 503 del core.
+- Documentar en `CoverageConfig` el timeout del `RestClient` para el core.
+
+**Tests obligatorios:**
+- `GuaranteeCatalogClientAdapterTest` — 503 del core → `CoreServiceException` (no lista vacía).
+- `CoverageOptionsIntegrationTest` — WireMock 503 → response 502 CORE_SERVICE_ERROR.
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+### R-004: Constraint UNIQUE (quote_id, code) sin validación previa de duplicados
+
+**Descripción:** El use case no valida que el mismo `code` no aparezca dos veces en el request. Si el request envía `[{code: "GUA-FIRE"}, {code: "GUA-FIRE"}]`, el `saveAll` lanza `DataIntegrityViolationException` (violación de UNIQUE constraint) que no está manejada en `GlobalExceptionHandler`, retornando HTTP 500 en lugar de 422.
+
+**Mitigación:**
+- Agregar validación en `SaveCoverageOptionsUseCaseImpl` que detecte codes duplicados en el request antes de llamar a `replaceAll`.
+- O agregar handler para `DataIntegrityViolationException` en `GlobalExceptionHandler` → 422 VALIDATION_ERROR.
+- Test unitario en `SaveCoverageOptionsUseCaseImplTest` con request que contiene codes duplicados.
+
+**Tests obligatorios:**
+- `SaveCoverageOptionsUseCaseImplTest` — request con codes duplicados → excepción controlada (no 500).
+- `CoverageOptionsIntegrationTest` — PUT con codes duplicados → 422 o 409 (no 500).
+
+**Bloqueante para release:** ✅ Sí
+
+---
+
+## Riesgos MEDIO — Acciones Recomendadas
+
+| ID    | Acción recomendada |
+|-------|--------------------|
+| R-005 | En `CoverageOptionsIntegrationTest`, verificar explícitamente que la `description` del response es la del catálogo WireMock, no `null` ni la del request. Agregar assertion `"coverageOptions[0].description" == "Incendio edificios"`. |
+| R-006 | Documentar que el catálogo se consulta en tiempo real en cada PUT (sin caché). Si se implementa caché en el futuro, agregar test de invalidación. Por ahora, aceptar como riesgo de baja probabilidad. |
+| R-007 | En `CoverageOptionsIntegrationTest`, tras un PUT exitoso, verificar que el GET retorna `version` incrementada (version original + 1). Confirma que Hibernate invalida el snapshot tras la transacción. |
+
+---
+
+## Riesgos BAJO — Backlog
+
+| ID    | Acción sugerida |
+|-------|-----------------|
+| R-008 | Verificar en `CoverageControllerTest` que `deductiblePercentage` y `coinsurancePercentage` serializan como número JSON (`2.0`) y no como string. Agregar `JsonPath` assertion sobre el tipo del campo. |
+| R-009 | Agregar test explícito para PUT con `coverageOptions: []` — verificar que retorna 200 y que el GET posterior retorna lista vacía (reemplazo total hacia vacío). |

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImpl.java
@@ -1,0 +1,31 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.GetCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+
+import java.util.List;
+
+// Orchestrates: assert folio exists → fetch options → fetch version → return response
+public class GetCoverageOptionsUseCaseImpl implements GetCoverageOptionsUseCase {
+
+    private final QuoteLookupPort quoteLookupPort;
+    private final CoverageOptionRepository coverageOptionRepository;
+
+    public GetCoverageOptionsUseCaseImpl(QuoteLookupPort quoteLookupPort,
+                                         CoverageOptionRepository coverageOptionRepository) {
+        this.quoteLookupPort = quoteLookupPort;
+        this.coverageOptionRepository = coverageOptionRepository;
+    }
+
+    @Override
+    public CoverageOptionsResponse getCoverageOptions(String folioNumber) {
+        quoteLookupPort.assertFolioExists(folioNumber);
+        List<CoverageOption> options = coverageOptionRepository.findByFolioNumber(folioNumber);
+        long version = quoteLookupPort.getCurrentVersion(folioNumber);
+        java.time.Instant updatedAt = quoteLookupPort.getUpdatedAt(folioNumber);
+        return new CoverageOptionsResponse(folioNumber, options, updatedAt, version);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImpl.java
@@ -1,0 +1,72 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
+import com.sofka.insurancequoter.back.coverage.application.usecase.exception.InvalidCoverageCodeException;
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.SaveCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// Orchestrates: assert folio → check version → validate codes → enrich descriptions → persist → return
+public class SaveCoverageOptionsUseCaseImpl implements SaveCoverageOptionsUseCase {
+
+    private final QuoteLookupPort quoteLookupPort;
+    private final CoverageOptionRepository coverageOptionRepository;
+    private final GuaranteeCatalogClient guaranteeCatalogClient;
+
+    public SaveCoverageOptionsUseCaseImpl(QuoteLookupPort quoteLookupPort,
+                                          CoverageOptionRepository coverageOptionRepository,
+                                          GuaranteeCatalogClient guaranteeCatalogClient) {
+        this.quoteLookupPort = quoteLookupPort;
+        this.coverageOptionRepository = coverageOptionRepository;
+        this.guaranteeCatalogClient = guaranteeCatalogClient;
+    }
+
+    @Override
+    public CoverageOptionsResponse saveCoverageOptions(SaveCoverageOptionsCommand command) {
+        quoteLookupPort.assertFolioExists(command.folioNumber());
+        quoteLookupPort.assertVersionMatches(command.folioNumber(), command.version());
+
+        Set<String> seenCodes = new HashSet<>();
+        for (CoverageOption option : command.coverageOptions()) {
+            if (!seenCodes.add(option.code())) {
+                throw new InvalidCoverageCodeException(option.code());
+            }
+        }
+
+        List<GuaranteeDto> catalog = guaranteeCatalogClient.fetchGuarantees();
+        Map<String, String> catalogByCode = catalog.stream()
+                .collect(Collectors.toMap(GuaranteeDto::code, GuaranteeDto::description));
+
+        // Validate all codes and enrich descriptions from catalog
+        List<CoverageOption> enriched = command.coverageOptions().stream()
+                .map(option -> {
+                    if (!catalogByCode.containsKey(option.code())) {
+                        throw new InvalidCoverageCodeException(option.code());
+                    }
+                    return new CoverageOption(
+                            option.code(),
+                            catalogByCode.get(option.code()),
+                            option.selected(),
+                            option.deductiblePercentage(),
+                            option.coinsurancePercentage()
+                    );
+                })
+                .toList();
+
+        List<CoverageOption> saved = coverageOptionRepository.replaceAll(command.folioNumber(), enriched);
+        long newVersion = quoteLookupPort.getCurrentVersion(command.folioNumber());
+        java.time.Instant updatedAt = quoteLookupPort.getUpdatedAt(command.folioNumber());
+
+        return new CoverageOptionsResponse(command.folioNumber(), saved, updatedAt, newVersion);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/command/SaveCoverageOptionsCommand.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/command/SaveCoverageOptionsCommand.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase.command;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+
+import java.util.List;
+
+// Command carrying the data required to replace coverage options on a quote
+public record SaveCoverageOptionsCommand(
+        String folioNumber,
+        List<CoverageOption> coverageOptions,
+        long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/dto/CoverageOptionsResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/dto/CoverageOptionsResponse.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase.dto;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+
+import java.time.Instant;
+import java.util.List;
+
+// Application-layer response DTO for coverage options queries and writes
+public record CoverageOptionsResponse(
+        String folioNumber,
+        List<CoverageOption> coverageOptions,
+        Instant updatedAt,
+        long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/dto/GuaranteeDto.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/dto/GuaranteeDto.java
@@ -1,0 +1,4 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase.dto;
+
+// DTO for guarantee catalog entries fetched from the core service
+public record GuaranteeDto(String code, String description) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/exception/InvalidCoverageCodeException.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/exception/InvalidCoverageCodeException.java
@@ -1,0 +1,16 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase.exception;
+
+// Thrown when a coverage code submitted in the request is not present in the guarantee catalog
+public class InvalidCoverageCodeException extends RuntimeException {
+
+    private final String invalidCode;
+
+    public InvalidCoverageCodeException(String code) {
+        super("Coverage code not found in catalog: " + code);
+        this.invalidCode = code;
+    }
+
+    public String getInvalidCode() {
+        return invalidCode;
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/model/CoverageOption.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/model/CoverageOption.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.coverage.domain.model;
+
+import java.math.BigDecimal;
+
+// Domain value object — no JPA or Spring annotations
+public record CoverageOption(
+        String code,
+        String description,
+        boolean selected,
+        BigDecimal deductiblePercentage,
+        BigDecimal coinsurancePercentage
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/in/GetCoverageOptionsUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/in/GetCoverageOptionsUseCase.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.coverage.domain.port.in;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+
+// Input port: retrieves coverage options persisted for a given quote folio
+public interface GetCoverageOptionsUseCase {
+
+    CoverageOptionsResponse getCoverageOptions(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/in/SaveCoverageOptionsUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/in/SaveCoverageOptionsUseCase.java
@@ -1,0 +1,10 @@
+package com.sofka.insurancequoter.back.coverage.domain.port.in;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+
+// Input port: replaces the full list of coverage options for a quote
+public interface SaveCoverageOptionsUseCase {
+
+    CoverageOptionsResponse saveCoverageOptions(SaveCoverageOptionsCommand command);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/CoverageOptionRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/CoverageOptionRepository.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.coverage.domain.port.out;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+
+import java.util.List;
+
+// Output port: persistence operations for coverage options
+public interface CoverageOptionRepository {
+
+    List<CoverageOption> findByFolioNumber(String folioNumber);
+
+    List<CoverageOption> replaceAll(String folioNumber, List<CoverageOption> options);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/GuaranteeCatalogClient.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/GuaranteeCatalogClient.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.coverage.domain.port.out;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
+
+import java.util.List;
+
+// Output port: fetches the guarantee catalog from the core service
+public interface GuaranteeCatalogClient {
+
+    List<GuaranteeDto> fetchGuarantees();
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/QuoteLookupPort.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/QuoteLookupPort.java
@@ -1,0 +1,19 @@
+package com.sofka.insurancequoter.back.coverage.domain.port.out;
+
+import java.time.Instant;
+
+// Output port: verifies quote existence and manages optimistic locking version checks
+public interface QuoteLookupPort {
+
+    // Throws FolioNotFoundException if the folio does not exist
+    void assertFolioExists(String folioNumber);
+
+    // Returns the current optimistic-lock version of the quote
+    long getCurrentVersion(String folioNumber);
+
+    // Returns the last-updated timestamp of the quote
+    Instant getUpdatedAt(String folioNumber);
+
+    // Throws VersionConflictException if the stored version differs from expectedVersion
+    void assertVersionMatches(String folioNumber, long expectedVersion);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/CoverageController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/CoverageController.java
@@ -1,0 +1,43 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.GetCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.SaveCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.request.SaveCoverageOptionsRequest;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.response.CoverageOptionsListResponse;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.mapper.CoverageRestMapper;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.swaggerdocs.CoverageApi;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+// REST controller for coverage options — delegates all logic to use cases
+@RestController
+public class CoverageController implements CoverageApi {
+
+    private final GetCoverageOptionsUseCase getCoverageOptionsUseCase;
+    private final SaveCoverageOptionsUseCase saveCoverageOptionsUseCase;
+    private final CoverageRestMapper mapper;
+
+    public CoverageController(GetCoverageOptionsUseCase getCoverageOptionsUseCase,
+                               SaveCoverageOptionsUseCase saveCoverageOptionsUseCase,
+                               CoverageRestMapper mapper) {
+        this.getCoverageOptionsUseCase = getCoverageOptionsUseCase;
+        this.saveCoverageOptionsUseCase = saveCoverageOptionsUseCase;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public ResponseEntity<CoverageOptionsListResponse> getCoverageOptions(String folio) {
+        CoverageOptionsResponse response = getCoverageOptionsUseCase.getCoverageOptions(folio);
+        return ResponseEntity.ok(mapper.toListResponse(response));
+    }
+
+    @Override
+    public ResponseEntity<CoverageOptionsListResponse> saveCoverageOptions(
+            String folio, SaveCoverageOptionsRequest request) {
+        SaveCoverageOptionsCommand command = mapper.toCommand(folio, request);
+        CoverageOptionsResponse response = saveCoverageOptionsUseCase.saveCoverageOptions(command);
+        return ResponseEntity.ok(mapper.toListResponse(response));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/request/CoverageOptionItemRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/request/CoverageOptionItemRequest.java
@@ -1,0 +1,15 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.request;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+
+// Request item for a single coverage option within SaveCoverageOptionsRequest
+public record CoverageOptionItemRequest(
+        @NotBlank String code,
+        boolean selected,
+        @DecimalMin("0.0") @DecimalMax("100.0") BigDecimal deductiblePercentage,
+        @DecimalMin("0.0") @DecimalMax("100.0") BigDecimal coinsurancePercentage
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/request/SaveCoverageOptionsRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/request/SaveCoverageOptionsRequest.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+// Request body for PUT /v1/quotes/{folio}/coverage-options
+public record SaveCoverageOptionsRequest(
+        @NotNull @Valid List<CoverageOptionItemRequest> coverageOptions,
+        @NotNull Long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/response/CoverageOptionItemResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/response/CoverageOptionItemResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.response;
+
+import java.math.BigDecimal;
+
+// Response item for a single coverage option in CoverageOptionsListResponse
+public record CoverageOptionItemResponse(
+        String code,
+        String description,
+        boolean selected,
+        BigDecimal deductiblePercentage,
+        BigDecimal coinsurancePercentage
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/response/CoverageOptionsListResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/dto/response/CoverageOptionsListResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+// HTTP response body for GET and PUT /v1/quotes/{folio}/coverage-options
+public record CoverageOptionsListResponse(
+        String folioNumber,
+        List<CoverageOptionItemResponse> coverageOptions,
+        Instant updatedAt,
+        long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/mapper/CoverageRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/mapper/CoverageRestMapper.java
@@ -1,0 +1,41 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.request.CoverageOptionItemRequest;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.request.SaveCoverageOptionsRequest;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.response.CoverageOptionItemResponse;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.response.CoverageOptionsListResponse;
+
+import java.util.List;
+
+// Maps between REST DTOs and application layer types (commands/responses)
+public class CoverageRestMapper {
+
+    public SaveCoverageOptionsCommand toCommand(String folioNumber, SaveCoverageOptionsRequest request) {
+        List<CoverageOption> options = request.coverageOptions().stream()
+                .map(this::toDomain)
+                .toList();
+        return new SaveCoverageOptionsCommand(folioNumber, options, request.version());
+    }
+
+    private CoverageOption toDomain(CoverageOptionItemRequest req) {
+        return new CoverageOption(req.code(), null, req.selected(),
+                req.deductiblePercentage(), req.coinsurancePercentage());
+    }
+
+    public CoverageOptionsListResponse toListResponse(CoverageOptionsResponse response) {
+        List<CoverageOptionItemResponse> items = response.coverageOptions().stream()
+                .map(this::toItemResponse)
+                .toList();
+        return new CoverageOptionsListResponse(
+                response.folioNumber(), items, response.updatedAt(), response.version());
+    }
+
+    private CoverageOptionItemResponse toItemResponse(CoverageOption option) {
+        return new CoverageOptionItemResponse(
+                option.code(), option.description(), option.selected(),
+                option.deductiblePercentage(), option.coinsurancePercentage());
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/swaggerdocs/CoverageApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/swaggerdocs/CoverageApi.java
@@ -1,0 +1,41 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.request.SaveCoverageOptionsRequest;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.response.CoverageOptionsListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+// Swagger/OpenAPI interface for coverage options endpoints — keeps controllers clean
+@Tag(name = "Coverage Options", description = "Gestión de opciones de cobertura de cotización")
+@RequestMapping("/v1/quotes/{folio}/coverage-options")
+public interface CoverageApi {
+
+    @Operation(summary = "Consultar opciones de cobertura")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Opciones de cobertura retornadas"),
+            @ApiResponse(responseCode = "404", description = "Folio no encontrado")
+    })
+    @GetMapping
+    ResponseEntity<CoverageOptionsListResponse> getCoverageOptions(@PathVariable String folio);
+
+    @Operation(summary = "Configurar opciones de cobertura")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Opciones de cobertura guardadas"),
+            @ApiResponse(responseCode = "404", description = "Folio no encontrado"),
+            @ApiResponse(responseCode = "409", description = "Conflicto de versión optimista"),
+            @ApiResponse(responseCode = "422", description = "Error de validación")
+    })
+    @PutMapping
+    ResponseEntity<CoverageOptionsListResponse> saveCoverageOptions(
+            @PathVariable String folio,
+            @Valid @RequestBody SaveCoverageOptionsRequest request);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/adapter/GuaranteeCatalogClientAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/adapter/GuaranteeCatalogClientAdapter.java
@@ -1,0 +1,42 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.http.adapter;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.http.dto.GuaranteeCatalogResponse;
+import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+// Calls core service GET /v1/catalogs/guarantees and returns the guarantee catalog
+public class GuaranteeCatalogClientAdapter implements GuaranteeCatalogClient {
+
+    private final RestClient restClient;
+
+    public GuaranteeCatalogClientAdapter(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @Override
+    public List<GuaranteeDto> fetchGuarantees() {
+        try {
+            GuaranteeCatalogResponse response = restClient.get()
+                    .uri("/v1/catalogs/guarantees")
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        throw new CoreServiceException(
+                                "Core service error fetching guarantees: HTTP " + res.getStatusCode().value());
+                    })
+                    .body(GuaranteeCatalogResponse.class);
+            if (response == null || response.guarantees() == null) {
+                return List.of();
+            }
+            return response.guarantees();
+        } catch (CoreServiceException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CoreServiceException("Core service unavailable: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/dto/GuaranteeCatalogResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/dto/GuaranteeCatalogResponse.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.http.dto;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
+
+import java.util.List;
+
+// HTTP response DTO from core service GET /v1/catalogs/guarantees
+public record GuaranteeCatalogResponse(List<GuaranteeDto> guarantees) {}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/adapter/CoverageOptionJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/adapter/CoverageOptionJpaAdapter.java
@@ -1,0 +1,85 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.entities.CoverageOptionJpa;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.mappers.CoverageOptionPersistenceMapper;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+// Implements CoverageOptionRepository and QuoteLookupPort using JPA
+public class CoverageOptionJpaAdapter implements CoverageOptionRepository, QuoteLookupPort {
+
+    private final CoverageOptionJpaRepository coverageOptionJpaRepository;
+    private final QuoteJpaRepository quoteJpaRepository;
+    private final CoverageOptionPersistenceMapper mapper;
+
+    public CoverageOptionJpaAdapter(CoverageOptionJpaRepository coverageOptionJpaRepository,
+                                     QuoteJpaRepository quoteJpaRepository,
+                                     CoverageOptionPersistenceMapper mapper) {
+        this.coverageOptionJpaRepository = coverageOptionJpaRepository;
+        this.quoteJpaRepository = quoteJpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<CoverageOption> findByFolioNumber(String folioNumber) {
+        QuoteJpa quote = getQuoteOrThrow(folioNumber);
+        List<CoverageOptionJpa> jpaList = coverageOptionJpaRepository.findAllByQuote_Id(quote.getId());
+        return mapper.toDomainList(jpaList);
+    }
+
+    @Override
+    @Transactional
+    public List<CoverageOption> replaceAll(String folioNumber, List<CoverageOption> options) {
+        QuoteJpa quote = getQuoteOrThrow(folioNumber);
+        // Bulk DELETE + immediate flush before INSERT to respect UNIQUE(quote_id, code) constraint
+        coverageOptionJpaRepository.deleteAllByQuote_Id(quote.getId());
+        coverageOptionJpaRepository.flush();
+        // Save new options
+        List<CoverageOptionJpa> jpaList = mapper.toJpaList(options, quote);
+        List<CoverageOptionJpa> savedList = coverageOptionJpaRepository.saveAll(jpaList);
+        // Touch the quote to trigger @UpdateTimestamp and force version increment via @Version
+        quote.setUpdatedAt(Instant.now());
+        quoteJpaRepository.save(quote);
+        return mapper.toDomainList(savedList);
+    }
+
+    @Override
+    public void assertFolioExists(String folioNumber) {
+        quoteJpaRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
+    }
+
+    @Override
+    public long getCurrentVersion(String folioNumber) {
+        QuoteJpa quote = getQuoteOrThrow(folioNumber);
+        return quote.getVersion();
+    }
+
+    @Override
+    public Instant getUpdatedAt(String folioNumber) {
+        return getQuoteOrThrow(folioNumber).getUpdatedAt();
+    }
+
+    @Override
+    public void assertVersionMatches(String folioNumber, long expectedVersion) {
+        QuoteJpa quote = getQuoteOrThrow(folioNumber);
+        if (quote.getVersion() != expectedVersion) {
+            throw new VersionConflictException(folioNumber, expectedVersion, quote.getVersion());
+        }
+    }
+
+    private QuoteJpa getQuoteOrThrow(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/entities/CoverageOptionJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/entities/CoverageOptionJpa.java
@@ -1,0 +1,42 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.entities;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "coverage_options")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoverageOptionJpa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quote_id", nullable = false)
+    private QuoteJpa quote;
+
+    @Column(name = "code", nullable = false, length = 50)
+    private String code;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @Column(name = "selected", nullable = false)
+    private boolean selected;
+
+    @Column(name = "deductible_percentage", precision = 5, scale = 2)
+    private BigDecimal deductiblePercentage;
+
+    @Column(name = "coinsurance_percentage", precision = 5, scale = 2)
+    private BigDecimal coinsurancePercentage;
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/mappers/CoverageOptionPersistenceMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/mappers/CoverageOptionPersistenceMapper.java
@@ -1,0 +1,40 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.mappers;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.entities.CoverageOptionJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+
+import java.util.List;
+
+// Bidirectional mapper between CoverageOption (domain) and CoverageOptionJpa (persistence)
+public class CoverageOptionPersistenceMapper {
+
+    public CoverageOption toDomain(CoverageOptionJpa jpa) {
+        return new CoverageOption(
+                jpa.getCode(),
+                jpa.getDescription(),
+                jpa.isSelected(),
+                jpa.getDeductiblePercentage(),
+                jpa.getCoinsurancePercentage()
+        );
+    }
+
+    public CoverageOptionJpa toJpa(CoverageOption domain, QuoteJpa quote) {
+        return CoverageOptionJpa.builder()
+                .quote(quote)
+                .code(domain.code())
+                .description(domain.description())
+                .selected(domain.selected())
+                .deductiblePercentage(domain.deductiblePercentage())
+                .coinsurancePercentage(domain.coinsurancePercentage())
+                .build();
+    }
+
+    public List<CoverageOption> toDomainList(List<CoverageOptionJpa> jpaList) {
+        return jpaList.stream().map(this::toDomain).toList();
+    }
+
+    public List<CoverageOptionJpa> toJpaList(List<CoverageOption> domainList, QuoteJpa quote) {
+        return domainList.stream().map(d -> toJpa(d, quote)).toList();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/repositories/CoverageOptionJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/repositories/CoverageOptionJpaRepository.java
@@ -1,0 +1,20 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories;
+
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.entities.CoverageOptionJpa;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+// Spring Data repository for coverage_options table
+public interface CoverageOptionJpaRepository extends JpaRepository<CoverageOptionJpa, Long> {
+
+    List<CoverageOptionJpa> findAllByQuote_Id(Long quoteId);
+
+    // Bulk DELETE to guarantee SQL execution order before saveAll within the same TX
+    @Modifying
+    @Query("DELETE FROM CoverageOptionJpa c WHERE c.quote.id = :quoteId")
+    void deleteAllByQuote_Id(@Param("quoteId") Long quoteId);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
@@ -1,0 +1,60 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.config;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.GetCoverageOptionsUseCaseImpl;
+import com.sofka.insurancequoter.back.coverage.application.usecase.SaveCoverageOptionsUseCaseImpl;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.GetCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.SaveCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.mapper.CoverageRestMapper;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.http.adapter.GuaranteeCatalogClientAdapter;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.adapter.CoverageOptionJpaAdapter;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.mappers.CoverageOptionPersistenceMapper;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+// Wires coverage bounded context: use cases, adapters, HTTP client
+@Configuration
+public class CoverageConfig {
+
+    @Bean
+    public GuaranteeCatalogClient guaranteeCatalogClient(
+            @Value("${core.service.base-url:http://localhost:8081}") String baseUrl) {
+        RestClient restClient = RestClient.builder().baseUrl(baseUrl).build();
+        return new GuaranteeCatalogClientAdapter(restClient);
+    }
+
+    @Bean
+    public CoverageOptionPersistenceMapper coverageOptionPersistenceMapper() {
+        return new CoverageOptionPersistenceMapper();
+    }
+
+    @Bean
+    public CoverageOptionJpaAdapter coverageOptionJpaAdapter(
+            CoverageOptionJpaRepository coverageOptionJpaRepository,
+            QuoteJpaRepository quoteJpaRepository,
+            CoverageOptionPersistenceMapper mapper) {
+        return new CoverageOptionJpaAdapter(coverageOptionJpaRepository, quoteJpaRepository, mapper);
+    }
+
+    @Bean
+    public GetCoverageOptionsUseCase getCoverageOptionsUseCase(
+            CoverageOptionJpaAdapter adapter) {
+        return new GetCoverageOptionsUseCaseImpl(adapter, adapter);
+    }
+
+    @Bean
+    public SaveCoverageOptionsUseCase saveCoverageOptionsUseCase(
+            CoverageOptionJpaAdapter adapter,
+            GuaranteeCatalogClient guaranteeCatalogClient) {
+        return new SaveCoverageOptionsUseCaseImpl(adapter, adapter, guaranteeCatalogClient);
+    }
+
+    @Bean
+    public CoverageRestMapper coverageRestMapper() {
+        return new CoverageRestMapper();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
 
+import com.sofka.insurancequoter.back.coverage.application.usecase.exception.InvalidCoverageCodeException;
 import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
 import com.sofka.insurancequoter.back.folio.application.usecase.InvalidReferenceException;
 import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
@@ -88,6 +89,19 @@ public class GlobalExceptionHandler {
                         "error", "Validation failed",
                         "code", "VALIDATION_ERROR",
                         "fields", List.of(ex.getMessage())
+                ));
+    }
+
+    @ExceptionHandler(InvalidCoverageCodeException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidCoverageCode(InvalidCoverageCodeException ex) {
+        return ResponseEntity.status(422)
+                .body(Map.of(
+                        "error", "Validation failed",
+                        "code", "VALIDATION_ERROR",
+                        "fields", List.of(Map.of(
+                                "field", "coverageOptions[].code",
+                                "message", ex.getMessage()
+                        ))
                 ));
     }
 

--- a/src/main/resources/db/migration/V7__create_coverage_options_table.sql
+++ b/src/main/resources/db/migration/V7__create_coverage_options_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS coverage_options (
+    id                     BIGSERIAL PRIMARY KEY,
+    quote_id               BIGINT         NOT NULL
+        REFERENCES quotes(id) ON DELETE CASCADE,
+    code                   VARCHAR(50)    NOT NULL,
+    description            VARCHAR(255),
+    selected               BOOLEAN        NOT NULL DEFAULT FALSE,
+    deductible_percentage  DECIMAL(5,2)
+        CONSTRAINT chk_deductible_pct CHECK (deductible_percentage >= 0 AND deductible_percentage <= 100),
+    coinsurance_percentage DECIMAL(5,2)
+        CONSTRAINT chk_coinsurance_pct CHECK (coinsurance_percentage >= 0 AND coinsurance_percentage <= 100),
+    CONSTRAINT uk_coverage_options_quote_code UNIQUE (quote_id, code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_coverage_options_quote_id ON coverage_options (quote_id);

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImplTest.java
@@ -1,0 +1,98 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+// Tests for GetCoverageOptionsUseCaseImpl — TDD RED phase
+@ExtendWith(MockitoExtension.class)
+class GetCoverageOptionsUseCaseImplTest {
+
+    @Mock
+    private CoverageOptionRepository coverageOptionRepository;
+
+    @Mock
+    private QuoteLookupPort quoteLookupPort;
+
+    @InjectMocks
+    private GetCoverageOptionsUseCaseImpl useCase;
+
+    // --- CRITERIO-1.1: folio exists with options → returns populated list ---
+
+    @Test
+    void shouldReturnOptions_whenFolioExistsWithCoverageOptions() {
+        // GIVEN
+        String folio = "FOL-2026-00042";
+        List<CoverageOption> options = List.of(
+                new CoverageOption("GUA-FIRE", "Incendio edificios", true,
+                        new BigDecimal("2.0"), new BigDecimal("80.0")),
+                new CoverageOption("GUA-THEFT", "Robo", false,
+                        new BigDecimal("5.0"), new BigDecimal("100.0"))
+        );
+        doNothing().when(quoteLookupPort).assertFolioExists(folio);
+        when(coverageOptionRepository.findByFolioNumber(folio)).thenReturn(options);
+        when(quoteLookupPort.getCurrentVersion(folio)).thenReturn(6L);
+
+        // WHEN
+        CoverageOptionsResponse response = useCase.getCoverageOptions(folio);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo(folio);
+        assertThat(response.coverageOptions()).hasSize(2);
+        assertThat(response.coverageOptions().get(0).code()).isEqualTo("GUA-FIRE");
+        assertThat(response.coverageOptions().get(0).selected()).isTrue();
+        assertThat(response.coverageOptions().get(1).code()).isEqualTo("GUA-THEFT");
+        assertThat(response.coverageOptions().get(1).selected()).isFalse();
+        assertThat(response.version()).isEqualTo(6L);
+        verify(quoteLookupPort).assertFolioExists(folio);
+        verify(coverageOptionRepository).findByFolioNumber(folio);
+        verify(quoteLookupPort).getCurrentVersion(folio);
+    }
+
+    // --- CRITERIO-1.2: folio exists without options → returns empty list ---
+
+    @Test
+    void shouldReturnEmptyList_whenFolioExistsWithNoCoverageOptions() {
+        // GIVEN
+        String folio = "FOL-2026-00042";
+        doNothing().when(quoteLookupPort).assertFolioExists(folio);
+        when(coverageOptionRepository.findByFolioNumber(folio)).thenReturn(List.of());
+        when(quoteLookupPort.getCurrentVersion(folio)).thenReturn(3L);
+
+        // WHEN
+        CoverageOptionsResponse response = useCase.getCoverageOptions(folio);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo(folio);
+        assertThat(response.coverageOptions()).isEmpty();
+        assertThat(response.version()).isEqualTo(3L);
+    }
+
+    // --- CRITERIO-1.3: folio does not exist → throws FolioNotFoundException ---
+
+    @Test
+    void shouldThrowFolioNotFoundException_whenFolioDoesNotExist() {
+        // GIVEN
+        String folio = "FOL-9999-00001";
+        doThrow(new FolioNotFoundException(folio)).when(quoteLookupPort).assertFolioExists(folio);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.getCoverageOptions(folio))
+                .isInstanceOf(FolioNotFoundException.class);
+        verify(coverageOptionRepository, never()).findByFolioNumber(any());
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImplTest.java
@@ -1,0 +1,196 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
+import com.sofka.insurancequoter.back.coverage.application.usecase.exception.InvalidCoverageCodeException;
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+// Tests for SaveCoverageOptionsUseCaseImpl — TDD RED phase
+@ExtendWith(MockitoExtension.class)
+class SaveCoverageOptionsUseCaseImplTest {
+
+    @Mock
+    private QuoteLookupPort quoteLookupPort;
+
+    @Mock
+    private CoverageOptionRepository coverageOptionRepository;
+
+    @Mock
+    private GuaranteeCatalogClient guaranteeCatalogClient;
+
+    @InjectMocks
+    private SaveCoverageOptionsUseCaseImpl useCase;
+
+    private static final String FOLIO = "FOL-2026-00042";
+
+    // --- CRITERIO-2.3: version conflict → throws VersionConflictException without persisting ---
+
+    @Test
+    void shouldThrowVersionConflictException_whenVersionDoesNotMatch() {
+        // GIVEN
+        doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
+        doThrow(new VersionConflictException(FOLIO, 6L, 7L))
+                .when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
+        SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, List.of(), 6L);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
+                .isInstanceOf(VersionConflictException.class);
+        verify(coverageOptionRepository, never()).replaceAll(any(), any());
+    }
+
+    // --- CRITERIO-2.7: folio does not exist → throws FolioNotFoundException ---
+
+    @Test
+    void shouldThrowFolioNotFoundException_whenFolioDoesNotExist() {
+        // GIVEN
+        doThrow(new FolioNotFoundException(FOLIO)).when(quoteLookupPort).assertFolioExists(FOLIO);
+        SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, List.of(), 1L);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
+                .isInstanceOf(FolioNotFoundException.class);
+        verify(coverageOptionRepository, never()).replaceAll(any(), any());
+    }
+
+    // --- CRITERIO-2.4: code not in catalog → throws InvalidCoverageCodeException ---
+
+    @Test
+    void shouldThrowInvalidCoverageCodeException_whenCodeNotInCatalog() {
+        // GIVEN
+        doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
+        doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 5L);
+        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(
+                List.of(new GuaranteeDto("GUA-FIRE", "Incendio edificios"))
+        );
+        CoverageOption invalid = new CoverageOption("COV-INVALID", null, true, BigDecimal.ZERO, BigDecimal.ZERO);
+        SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, List.of(invalid), 5L);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
+                .isInstanceOf(InvalidCoverageCodeException.class)
+                .hasMessageContaining("COV-INVALID");
+        verify(coverageOptionRepository, never()).replaceAll(any(), any());
+    }
+
+    // --- CRITERIO-2.1: successful save → returns enriched options with version+1 ---
+
+    @Test
+    void shouldReturnEnrichedOptions_whenSaveIsSuccessful() {
+        // GIVEN
+        doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
+        doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
+        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(List.of(
+                new GuaranteeDto("GUA-FIRE", "Incendio edificios"),
+                new GuaranteeDto("GUA-THEFT", "Robo")
+        ));
+        List<CoverageOption> input = List.of(
+                new CoverageOption("GUA-FIRE", null, true, new BigDecimal("2.0"), new BigDecimal("80.0")),
+                new CoverageOption("GUA-THEFT", null, true, new BigDecimal("5.0"), new BigDecimal("100.0"))
+        );
+        List<CoverageOption> persisted = List.of(
+                new CoverageOption("GUA-FIRE", "Incendio edificios", true, new BigDecimal("2.0"), new BigDecimal("80.0")),
+                new CoverageOption("GUA-THEFT", "Robo", true, new BigDecimal("5.0"), new BigDecimal("100.0"))
+        );
+        when(coverageOptionRepository.replaceAll(eq(FOLIO), any())).thenReturn(persisted);
+        when(quoteLookupPort.getCurrentVersion(FOLIO)).thenReturn(7L);
+
+        SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, input, 6L);
+
+        // WHEN
+        CoverageOptionsResponse response = useCase.saveCoverageOptions(command);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo(FOLIO);
+        assertThat(response.coverageOptions()).hasSize(2);
+        assertThat(response.coverageOptions().get(0).description()).isEqualTo("Incendio edificios");
+        assertThat(response.coverageOptions().get(1).description()).isEqualTo("Robo");
+        assertThat(response.version()).isEqualTo(7L);
+
+        // verify the enriched list was passed to replaceAll
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<CoverageOption>> captor = ArgumentCaptor.forClass(List.class);
+        verify(coverageOptionRepository).replaceAll(eq(FOLIO), captor.capture());
+        assertThat(captor.getValue().get(0).description()).isEqualTo("Incendio edificios");
+        assertThat(captor.getValue().get(1).description()).isEqualTo("Robo");
+    }
+
+    // --- R-004: duplicate codes in request → throws InvalidCoverageCodeException without persisting ---
+
+    @Test
+    void shouldThrowInvalidCoverageCodeException_whenRequestContainsDuplicateCodes() {
+        // GIVEN — duplicate check runs before catalog fetch, so no stub needed for fetchGuarantees
+        doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
+        doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
+        List<CoverageOption> input = List.of(
+                new CoverageOption("GUA-FIRE", null, true, BigDecimal.ZERO, BigDecimal.ZERO),
+                new CoverageOption("GUA-FIRE", null, false, BigDecimal.ZERO, BigDecimal.ZERO)
+        );
+        SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, input, 6L);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
+                .isInstanceOf(InvalidCoverageCodeException.class)
+                .hasMessageContaining("GUA-FIRE");
+        verify(coverageOptionRepository, never()).replaceAll(any(), any());
+        verify(guaranteeCatalogClient, never()).fetchGuarantees();
+    }
+
+    // --- CRITERIO-2.2: mix of selected true/false → both states persisted correctly ---
+
+    @Test
+    void shouldPersistBothSelectedStates_whenMixOfTrueAndFalse() {
+        // GIVEN
+        doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
+        doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
+        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(List.of(
+                new GuaranteeDto("GUA-FIRE", "Incendio edificios"),
+                new GuaranteeDto("GUA-THEFT", "Robo")
+        ));
+        List<CoverageOption> input = List.of(
+                new CoverageOption("GUA-FIRE", null, true, BigDecimal.ZERO, BigDecimal.ZERO),
+                new CoverageOption("GUA-THEFT", null, false, BigDecimal.ZERO, BigDecimal.ZERO)
+        );
+        List<CoverageOption> persisted = List.of(
+                new CoverageOption("GUA-FIRE", "Incendio edificios", true, BigDecimal.ZERO, BigDecimal.ZERO),
+                new CoverageOption("GUA-THEFT", "Robo", false, BigDecimal.ZERO, BigDecimal.ZERO)
+        );
+        when(coverageOptionRepository.replaceAll(eq(FOLIO), any())).thenReturn(persisted);
+        when(quoteLookupPort.getCurrentVersion(FOLIO)).thenReturn(7L);
+        SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, input, 6L);
+
+        // WHEN
+        CoverageOptionsResponse response = useCase.saveCoverageOptions(command);
+
+        // THEN
+        assertThat(response.coverageOptions().get(0).selected()).isTrue();
+        assertThat(response.coverageOptions().get(1).selected()).isFalse();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<CoverageOption>> captor = ArgumentCaptor.forClass(List.class);
+        verify(coverageOptionRepository).replaceAll(eq(FOLIO), captor.capture());
+        assertThat(captor.getValue().get(0).selected()).isTrue();
+        assertThat(captor.getValue().get(1).selected()).isFalse();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/CoverageControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/CoverageControllerTest.java
@@ -1,0 +1,210 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
+import com.sofka.insurancequoter.back.coverage.application.usecase.exception.InvalidCoverageCodeException;
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.GetCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.in.SaveCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.mapper.CoverageRestMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.GlobalExceptionHandler;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Controller tests using MockMvc standalone setup — TDD phase
+@ExtendWith(MockitoExtension.class)
+class CoverageControllerTest {
+
+    @Mock
+    private GetCoverageOptionsUseCase getCoverageOptionsUseCase;
+
+    @Mock
+    private SaveCoverageOptionsUseCase saveCoverageOptionsUseCase;
+
+    private MockMvc mockMvc;
+
+    private static final String FOLIO = "FOL-2026-00042";
+    private static final Instant UPDATED_AT = Instant.parse("2026-04-22T15:45:00Z");
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        CoverageController controller = new CoverageController(
+                getCoverageOptionsUseCase, saveCoverageOptionsUseCase, new CoverageRestMapper());
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    private CoverageOptionsResponse buildResponse(long version, Instant updatedAt) {
+        return new CoverageOptionsResponse(FOLIO, List.of(
+                new CoverageOption("GUA-FIRE", "Incendio edificios", true,
+                        new BigDecimal("2.0"), new BigDecimal("80.0"))
+        ), updatedAt, version);
+    }
+
+    // --- #190: GET 200 with options list ---
+
+    @Test
+    void shouldReturn200WithOptions_whenGetCoverageOptions() throws Exception {
+        // GIVEN
+        when(getCoverageOptionsUseCase.getCoverageOptions(FOLIO))
+                .thenReturn(buildResponse(6L, null));
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/{folio}/coverage-options", FOLIO))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value(FOLIO))
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("GUA-FIRE"))
+                .andExpect(jsonPath("$.coverageOptions[0].description").value("Incendio edificios"))
+                .andExpect(jsonPath("$.coverageOptions[0].selected").value(true))
+                .andExpect(jsonPath("$.version").value(6));
+    }
+
+    // --- #191: GET 404 when folio does not exist ---
+
+    @Test
+    void shouldReturn404_whenFolioNotFoundOnGet() throws Exception {
+        // GIVEN
+        when(getCoverageOptionsUseCase.getCoverageOptions(FOLIO))
+                .thenThrow(new FolioNotFoundException(FOLIO));
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/{folio}/coverage-options", FOLIO))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+    }
+
+    // --- #192: PUT 200 successful save ---
+
+    @Test
+    void shouldReturn200WithIncrementedVersion_whenSaveCoverageOptions() throws Exception {
+        // GIVEN
+        when(saveCoverageOptionsUseCase.saveCoverageOptions(any()))
+                .thenReturn(buildResponse(7L, UPDATED_AT));
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                  ],
+                                  "version": 6
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value(FOLIO))
+                .andExpect(jsonPath("$.version").value(7))
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("GUA-FIRE"));
+    }
+
+    // --- #193: PUT 409 version conflict ---
+
+    @Test
+    void shouldReturn409_whenVersionConflictOnPut() throws Exception {
+        // GIVEN
+        when(saveCoverageOptionsUseCase.saveCoverageOptions(any()))
+                .thenThrow(new VersionConflictException(FOLIO, 6L, 7L));
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                  ],
+                                  "version": 6
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("VERSION_CONFLICT"));
+    }
+
+    // --- #194: PUT 422 invalid coverage code ---
+
+    @Test
+    void shouldReturn422_whenInvalidCoverageCodeOnPut() throws Exception {
+        // GIVEN
+        when(saveCoverageOptionsUseCase.saveCoverageOptions(any()))
+                .thenThrow(new InvalidCoverageCodeException("COV-INVALID"));
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"COV-INVALID","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                  ],
+                                  "version": 6
+                                }
+                                """))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // --- #195: PUT 422 deductiblePercentage > 100 ---
+
+    @Test
+    void shouldReturn422_whenDeductiblePercentageExceedsMaximum() throws Exception {
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":150.0,"coinsurancePercentage":80.0}
+                                  ],
+                                  "version": 6
+                                }
+                                """))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // --- #196: PUT 422 coinsurancePercentage < 0 ---
+
+    @Test
+    void shouldReturn422_whenCoinsurancePercentageBelowMinimum() throws Exception {
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":-5.0}
+                                  ],
+                                  "version": 6
+                                }
+                                """))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/GuaranteeCatalogClientAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/GuaranteeCatalogClientAdapterTest.java
@@ -1,0 +1,87 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.http;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.http.adapter.GuaranteeCatalogClientAdapter;
+import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+// Tests for GuaranteeCatalogClientAdapter using WireMock — TDD RED phase
+class GuaranteeCatalogClientAdapterTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    private GuaranteeCatalogClientAdapter buildAdapter() {
+        String baseUrl = "http://localhost:" + wireMock.getPort();
+        RestClient restClient = RestClient.builder().baseUrl(baseUrl).build();
+        return new GuaranteeCatalogClientAdapter(restClient);
+    }
+
+    // --- #188: successful core response → returns list of GuaranteeDto ---
+
+    @Test
+    void shouldReturnGuaranteeDtoList_whenCoreRespondsSuccessfully() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/catalogs/guarantees"))
+                .willReturn(okJson("""
+                        {
+                          "guarantees": [
+                            {"code": "GUA-FIRE", "description": "Incendio edificios"},
+                            {"code": "GUA-THEFT", "description": "Robo"}
+                          ]
+                        }
+                        """)));
+
+        // WHEN
+        List<GuaranteeDto> result = buildAdapter().fetchGuarantees();
+
+        // THEN
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).code()).isEqualTo("GUA-FIRE");
+        assertThat(result.get(0).description()).isEqualTo("Incendio edificios");
+        assertThat(result.get(1).code()).isEqualTo("GUA-THEFT");
+        assertThat(result.get(1).description()).isEqualTo("Robo");
+    }
+
+    // --- #189: core returns 5xx → throws CoreServiceException ---
+
+    @Test
+    void shouldThrowCoreServiceException_whenCoreReturns5xxError() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/catalogs/guarantees"))
+                .willReturn(serverError()));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> buildAdapter().fetchGuarantees())
+                .isInstanceOf(CoreServiceException.class)
+                .hasMessageContaining("Core service error");
+    }
+
+    // --- R-003: network error (connection reset) → throws CoreServiceException, not 500 ---
+
+    @Test
+    void shouldThrowCoreServiceException_whenCoreConnectionIsReset() {
+        // GIVEN
+        wireMock.stubFor(get(urlEqualTo("/v1/catalogs/guarantees"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> buildAdapter().fetchGuarantees())
+                .isInstanceOf(CoreServiceException.class)
+                .hasMessageContaining("Core service unavailable");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/CoverageOptionJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/CoverageOptionJpaAdapterTest.java
@@ -1,0 +1,136 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.adapter.CoverageOptionJpaAdapter;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.entities.CoverageOptionJpa;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.mappers.CoverageOptionPersistenceMapper;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+// Unit tests for CoverageOptionJpaAdapter using Mockito — TDD RED phase
+@ExtendWith(MockitoExtension.class)
+class CoverageOptionJpaAdapterTest {
+
+    @Mock
+    private CoverageOptionJpaRepository coverageOptionJpaRepository;
+
+    @Mock
+    private QuoteJpaRepository quoteJpaRepository;
+
+    private CoverageOptionJpaAdapter adapter;
+
+    private static final String FOLIO = "FOL-2026-00042";
+
+    @BeforeEach
+    void setUp() {
+        adapter = new CoverageOptionJpaAdapter(coverageOptionJpaRepository, quoteJpaRepository,
+                new CoverageOptionPersistenceMapper());
+    }
+
+    private QuoteJpa buildQuote(long id, long version) {
+        return QuoteJpa.builder()
+                .id(id)
+                .folioNumber(FOLIO)
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .version(version)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    // --- #184: findByFolioNumber returns empty list when no options exist ---
+
+    @Test
+    void shouldReturnEmptyList_whenNoOptionsExistForFolio() {
+        // GIVEN
+        QuoteJpa quote = buildQuote(1L, 3L);
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quote));
+        when(coverageOptionJpaRepository.findAllByQuote_Id(1L)).thenReturn(List.of());
+
+        // WHEN
+        List<CoverageOption> result = adapter.findByFolioNumber(FOLIO);
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    // --- #185: replaceAll deletes existing and saves new options ---
+
+    @Test
+    void shouldDeleteExistingAndSaveNew_whenReplaceAllIsCalled() {
+        // GIVEN
+        QuoteJpa quote = buildQuote(1L, 3L);
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quote));
+        doNothing().when(coverageOptionJpaRepository).deleteAllByQuote_Id(1L);
+
+        CoverageOption option = new CoverageOption("GUA-FIRE", "Incendio edificios", true,
+                new BigDecimal("2.0"), new BigDecimal("80.0"));
+        CoverageOptionJpa savedJpa = CoverageOptionJpa.builder()
+                .id(10L)
+                .quote(quote)
+                .code("GUA-FIRE")
+                .description("Incendio edificios")
+                .selected(true)
+                .deductiblePercentage(new BigDecimal("2.0"))
+                .coinsurancePercentage(new BigDecimal("80.0"))
+                .build();
+        when(coverageOptionJpaRepository.saveAll(any())).thenReturn(List.of(savedJpa));
+        when(quoteJpaRepository.save(any())).thenReturn(quote);
+
+        // WHEN
+        List<CoverageOption> result = adapter.replaceAll(FOLIO, List.of(option));
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).code()).isEqualTo("GUA-FIRE");
+        assertThat(result.get(0).description()).isEqualTo("Incendio edificios");
+        verify(coverageOptionJpaRepository).deleteAllByQuote_Id(1L);
+        verify(coverageOptionJpaRepository).saveAll(any());
+        verify(quoteJpaRepository).save(any());
+    }
+
+    // --- #186: assertFolioExists throws FolioNotFoundException when folio missing ---
+
+    @Test
+    void shouldThrowFolioNotFoundException_whenFolioNotFound() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> adapter.assertFolioExists(FOLIO))
+                .isInstanceOf(FolioNotFoundException.class);
+    }
+
+    // --- #187: assertVersionMatches throws VersionConflictException when version differs ---
+
+    @Test
+    void shouldThrowVersionConflictException_whenVersionDoesNotMatch() {
+        // GIVEN
+        QuoteJpa quote = buildQuote(1L, 7L);
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quote));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> adapter.assertVersionMatches(FOLIO, 6L))
+                .isInstanceOf(VersionConflictException.class);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/integration/CoverageOptionsIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/integration/CoverageOptionsIntegrationTest.java
@@ -1,0 +1,247 @@
+package com.sofka.insurancequoter.back.coverage.integration;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.sofka.insurancequoter.InsuranceQuoterApplication;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Integration tests for coverage options — no @Transactional so @Version increments commit correctly
+@SpringBootTest(classes = InsuranceQuoterApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Testcontainers
+class CoverageOptionsIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:16-alpine");
+
+    static WireMockServer wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private QuoteJpaRepository quoteJpaRepository;
+
+    @Autowired
+    private CoverageOptionJpaRepository coverageOptionJpaRepository;
+
+    private MockMvc mockMvc;
+
+    private static final String FOLIO = "FOL-2026-IT-COV";
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMock.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMock.stop();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("core.service.base-url", () -> "http://localhost:" + wireMock.port());
+    }
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        wireMock.resetAll();
+
+        // Clean state — coverage_options has FK cascade, delete explicitly for isolation
+        coverageOptionJpaRepository.deleteAll();
+        quoteJpaRepository.deleteAll();
+
+        QuoteJpa quote = QuoteJpa.builder()
+                .folioNumber(FOLIO)
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .build();
+        quoteJpaRepository.save(quote);
+    }
+
+    private void stubGuaranteeCatalog() {
+        wireMock.stubFor(get(urlEqualTo("/v1/catalogs/guarantees"))
+                .willReturn(okJson("""
+                        {"guarantees":[
+                          {"code":"GUA-FIRE","description":"Incendio edificios"},
+                          {"code":"GUA-THEFT","description":"Robo"}
+                        ]}
+                        """)));
+    }
+
+    // --- #197: PUT then GET returns persisted data with catalog description ---
+
+    @Test
+    void shouldPersistAndRetrieveCoverageOptions_whenPutFollowedByGet() throws Exception {
+        stubGuaranteeCatalog();
+        long version = quoteJpaRepository.findByFolioNumber(FOLIO).orElseThrow().getVersion();
+
+        // PUT to save coverage options
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0},
+                                    {"code":"GUA-THEFT","selected":false,"deductiblePercentage":5.0,"coinsurancePercentage":100.0}
+                                  ],
+                                  "version": %d
+                                }
+                                """.formatted(version)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value(FOLIO))
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("GUA-FIRE"))
+                .andExpect(jsonPath("$.coverageOptions[0].description").value("Incendio edificios"))
+                .andExpect(jsonPath("$.coverageOptions[0].selected").value(true))
+                .andExpect(jsonPath("$.coverageOptions[1].code").value("GUA-THEFT"))
+                .andExpect(jsonPath("$.coverageOptions[1].selected").value(false));
+
+        // GET returns same persisted data
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/v1/quotes/{folio}/coverage-options", FOLIO))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value(FOLIO))
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("GUA-FIRE"))
+                .andExpect(jsonPath("$.coverageOptions[0].description").value("Incendio edificios"))
+                .andExpect(jsonPath("$.coverageOptions[1].code").value("GUA-THEFT"));
+    }
+
+    // --- #198: PUT with stale version returns 409 and does not modify data ---
+
+    @Test
+    void shouldReturn409AndNotModifyData_whenVersionConflictOnPut() throws Exception {
+        stubGuaranteeCatalog();
+        long version = quoteJpaRepository.findByFolioNumber(FOLIO).orElseThrow().getVersion();
+
+        // First PUT advances the version
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                  ],
+                                  "version": %d
+                                }
+                                """.formatted(version)))
+                .andExpect(status().isOk());
+
+        // Second PUT with stale version → 409
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-THEFT","selected":true,"deductiblePercentage":5.0,"coinsurancePercentage":100.0}
+                                  ],
+                                  "version": %d
+                                }
+                                """.formatted(version)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("VERSION_CONFLICT"));
+    }
+
+    // --- #199: PUT with code not in catalog returns 422 ---
+
+    @Test
+    void shouldReturn422_whenCoverageCodeNotInCatalog() throws Exception {
+        stubGuaranteeCatalog();
+        long version = quoteJpaRepository.findByFolioNumber(FOLIO).orElseThrow().getVersion();
+
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"COV-INVALID","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                  ],
+                                  "version": %d
+                                }
+                                """.formatted(version)))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // --- #200: GET on folio with no coverage options returns 200 with empty array ---
+
+    @Test
+    void shouldReturn200WithEmptyArray_whenFolioHasNoCoverageOptions() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/v1/quotes/{folio}/coverage-options", FOLIO))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value(FOLIO))
+                .andExpect(jsonPath("$.coverageOptions").isArray())
+                .andExpect(jsonPath("$.coverageOptions").isEmpty());
+    }
+
+    // --- R-009: PUT with empty list deletes all existing options and returns empty array ---
+
+    @Test
+    void shouldReturnEmptyArray_whenPutWithEmptyCoverageOptionsList() throws Exception {
+        stubGuaranteeCatalog();
+        long version = quoteJpaRepository.findByFolioNumber(FOLIO).orElseThrow().getVersion();
+
+        // First PUT: persist two options
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [
+                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                  ],
+                                  "version": %d
+                                }
+                                """.formatted(version)))
+                .andExpect(status().isOk());
+
+        long versionAfterFirstPut = quoteJpaRepository.findByFolioNumber(FOLIO).orElseThrow().getVersion();
+
+        // Second PUT: replace with empty list — all previous options should be deleted
+        mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "coverageOptions": [],
+                                  "version": %d
+                                }
+                                """.formatted(versionAfterFirstPut)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.coverageOptions").isArray())
+                .andExpect(jsonPath("$.coverageOptions").isEmpty());
+
+        // GET confirms no options remain
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/v1/quotes/{folio}/coverage-options", FOLIO))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.coverageOptions").isEmpty());
+    }
+}


### PR DESCRIPTION
## Descripción
Implementación completa del feature SPEC-006: opciones de cobertura (GET/PUT).

## Cambios

### DB
- `V7__create_coverage_options_table.sql`: tabla `coverage_options` con FK a `quotes`, UNIQUE(quote_id, code), CHECK en porcentajes

### Domain / Application
- `CoverageOption` record (puro, sin JPA/Spring)
- Ports: `GetCoverageOptionsUseCase`, `SaveCoverageOptionsUseCase`, `CoverageOptionRepository`, `QuoteLookupPort`, `GuaranteeCatalogClient`
- Use cases con validación: existencia de folio → versión → dedup de códigos → catálogo → enriquecimiento → persistencia

### Infrastructure
- `CoverageOptionJpaAdapter`: bulk DELETE + `flush()` + `saveAll()` para respetar UNIQUE constraint en mismo TX
- `GuaranteeCatalogClientAdapter`: llama `GET /v1/catalogs/guarantees` en core service; envuelve errores de red como `CoreServiceException`
- `CoverageController`: `GET` y `PUT /v1/quotes/{folio}/coverage-options`
- `CoverageConfig`: wiring de beans y `RestClient` para core service

### Fixes QA
- **R-001**: flush() tras DELETE masivo evita violación UNIQUE en replaceAll
- **R-003**: errores de conexión capturados como CoreServiceException → 502
- **R-004**: validación de códigos duplicados con HashSet ANTES de llamar al catálogo
- **updatedAt**: corregido en respuestas (era null); se añadió `getUpdatedAt()` al QuoteLookupPort

## Tests
- 5 clases de tests unitarios (use cases, controller, JPA adapter, HTTP adapter)
- 1 test de integración con Testcontainers + WireMock (5 escenarios)
- Validación manual curl: 11 criterios verificados

## Issues cerrados
#197 #198 #199 #200 #201 #202 #203 #204 #205 #206

## QA
- Gherkin: `docs/output/qa/coverage-options-gherkin.md`
- Riesgos: `docs/output/qa/coverage-options-risks.md`