### PR TITLE
fix(integration): correcciones de integración front-back — camino feliz

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
 }
 
+val springdocVersion = "2.8.8"
+val wiremockVersion = "3.13.0"
+
 group = "com.sofka.insurancequoter"
 version = "0.0.1-SNAPSHOT"
 
@@ -25,7 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-flyway")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     runtimeOnly("org.postgresql:postgresql")
@@ -36,7 +39,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:testcontainers-junit-jupiter")
     testImplementation("org.testcontainers:testcontainers-postgresql")
-    testImplementation("org.wiremock:wiremock-standalone:3.13.0")
+    testImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/AcceptQuoteUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/AcceptQuoteUseCaseImpl.java
@@ -1,0 +1,29 @@
+package com.sofka.insurancequoter.back.calculation.application.usecase;
+
+import com.sofka.insurancequoter.back.calculation.application.usecase.command.AcceptQuoteCommand;
+import com.sofka.insurancequoter.back.calculation.domain.model.AcceptQuoteResult;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.AcceptQuoteUseCase;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.AcceptQuoteRepository;
+
+import java.time.Instant;
+
+public class AcceptQuoteUseCaseImpl implements AcceptQuoteUseCase {
+
+    private final AcceptQuoteRepository repository;
+
+    public AcceptQuoteUseCaseImpl(AcceptQuoteRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public AcceptQuoteResult accept(AcceptQuoteCommand command) {
+        long newVersion = repository.accept(command);
+        return new AcceptQuoteResult(
+                command.folioNumber(),
+                "ISSUED",
+                command.acceptedBy(),
+                Instant.now(),
+                newVersion
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/GetCalculationResultUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/GetCalculationResultUseCaseImpl.java
@@ -1,0 +1,21 @@
+package com.sofka.insurancequoter.back.calculation.application.usecase;
+
+import com.sofka.insurancequoter.back.calculation.application.usecase.exception.CalculationResultNotFoundException;
+import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.GetCalculationResultUseCase;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.GetCalculationResultRepository;
+
+public class GetCalculationResultUseCaseImpl implements GetCalculationResultUseCase {
+
+    private final GetCalculationResultRepository repository;
+
+    public GetCalculationResultUseCaseImpl(GetCalculationResultRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public CalculationResult get(String folioNumber) {
+        return repository.find(folioNumber)
+                .orElseThrow(() -> new CalculationResultNotFoundException(folioNumber));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/command/AcceptQuoteCommand.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/command/AcceptQuoteCommand.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.calculation.application.usecase.command;
+
+// Command carrying the data needed to accept a quote
+public record AcceptQuoteCommand(
+        String folioNumber,
+        String acceptedBy,
+        long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/exception/CalculationResultNotFoundException.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/exception/CalculationResultNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.calculation.application.usecase.exception;
+
+// Thrown when no calculation result exists for the given folio
+public class CalculationResultNotFoundException extends RuntimeException {
+
+    public CalculationResultNotFoundException(String folioNumber) {
+        super("Calculation result not found for folio: " + folioNumber);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/domain/model/AcceptQuoteResult.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/domain/model/AcceptQuoteResult.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.calculation.domain.model;
+
+import java.time.Instant;
+
+// Domain model representing the outcome of accepting a quote
+public record AcceptQuoteResult(
+        String folioNumber,
+        String quoteStatus,
+        String acceptedBy,
+        Instant acceptedAt,
+        long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/in/AcceptQuoteUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/in/AcceptQuoteUseCase.java
@@ -1,0 +1,10 @@
+package com.sofka.insurancequoter.back.calculation.domain.port.in;
+
+import com.sofka.insurancequoter.back.calculation.application.usecase.command.AcceptQuoteCommand;
+import com.sofka.insurancequoter.back.calculation.domain.model.AcceptQuoteResult;
+
+// Input port: accepts a quote and transitions its status to ISSUED
+public interface AcceptQuoteUseCase {
+
+    AcceptQuoteResult accept(AcceptQuoteCommand command);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/in/GetCalculationResultUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/in/GetCalculationResultUseCase.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.calculation.domain.port.in;
+
+import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
+
+// Input port: retrieves the stored calculation result for a folio
+public interface GetCalculationResultUseCase {
+
+    CalculationResult get(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/out/AcceptQuoteRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/out/AcceptQuoteRepository.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.calculation.domain.port.out;
+
+import com.sofka.insurancequoter.back.calculation.application.usecase.command.AcceptQuoteCommand;
+
+// Output port: persists the ISSUED status for an accepted quote
+public interface AcceptQuoteRepository {
+
+    long accept(AcceptQuoteCommand command);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/out/GetCalculationResultRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/domain/port/out/GetCalculationResultRepository.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.calculation.domain.port.out;
+
+import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
+
+import java.util.Optional;
+
+// Output port: reads an existing calculation result by folio number
+public interface GetCalculationResultRepository {
+
+    Optional<CalculationResult> find(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/domain/service/CalculationService.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/domain/service/CalculationService.java
@@ -25,8 +25,7 @@ public class CalculationService {
     public boolean isCalculable(Location location, Set<String> tarifableCodes) {
         if (isBlank(location.zipCode())) return false;
         if (location.businessLine() == null || isBlank(location.businessLine().fireKey())) return false;
-        if (!hasTarifableGuarantee(location, tarifableCodes)) return false;
-        return true;
+        return hasTarifableGuarantee(location, tarifableCodes);
     }
 
     // Returns the list of blocking alerts explaining why a location is not calculable

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/CalculationController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/CalculationController.java
@@ -1,9 +1,15 @@
 package com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest;
 
+import com.sofka.insurancequoter.back.calculation.application.usecase.command.AcceptQuoteCommand;
 import com.sofka.insurancequoter.back.calculation.application.usecase.command.CalculatePremiumCommand;
+import com.sofka.insurancequoter.back.calculation.domain.model.AcceptQuoteResult;
 import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.AcceptQuoteUseCase;
 import com.sofka.insurancequoter.back.calculation.domain.port.in.CalculatePremiumUseCase;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.GetCalculationResultUseCase;
+import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.request.AcceptQuoteRequest;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.request.CalculatePremiumRequest;
+import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response.AcceptQuoteResponse;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response.CalculationResponse;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.mapper.CalculationRestMapper;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.swaggerdocs.CalculationApi;
@@ -13,16 +19,22 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-// REST controller for the Calculation bounded context — delegates entirely to the use case
+// REST controller for the Calculation bounded context — delegates entirely to use cases
 @RestController
 public class CalculationController implements CalculationApi {
 
     private final CalculatePremiumUseCase calculatePremiumUseCase;
+    private final GetCalculationResultUseCase getCalculationResultUseCase;
+    private final AcceptQuoteUseCase acceptQuoteUseCase;
     private final CalculationRestMapper calculationRestMapper;
 
     public CalculationController(CalculatePremiumUseCase calculatePremiumUseCase,
+                                 GetCalculationResultUseCase getCalculationResultUseCase,
+                                 AcceptQuoteUseCase acceptQuoteUseCase,
                                  CalculationRestMapper calculationRestMapper) {
         this.calculatePremiumUseCase = calculatePremiumUseCase;
+        this.getCalculationResultUseCase = getCalculationResultUseCase;
+        this.acceptQuoteUseCase = acceptQuoteUseCase;
         this.calculationRestMapper = calculationRestMapper;
     }
 
@@ -33,5 +45,26 @@ public class CalculationController implements CalculationApi {
         CalculatePremiumCommand command = new CalculatePremiumCommand(folio, request.version());
         CalculationResult result = calculatePremiumUseCase.calculate(command);
         return ResponseEntity.ok(calculationRestMapper.toResponse(result));
+    }
+
+    @Override
+    public ResponseEntity<CalculationResponse> getCalculationResult(@PathVariable String folio) {
+        CalculationResult result = getCalculationResultUseCase.get(folio);
+        return ResponseEntity.ok(calculationRestMapper.toResponse(result));
+    }
+
+    @Override
+    public ResponseEntity<AcceptQuoteResponse> accept(
+            @PathVariable String folio,
+            @Valid @RequestBody AcceptQuoteRequest request) {
+        AcceptQuoteCommand command = new AcceptQuoteCommand(folio, request.acceptedBy(), request.version());
+        AcceptQuoteResult result = acceptQuoteUseCase.accept(command);
+        return ResponseEntity.ok(new AcceptQuoteResponse(
+                result.folioNumber(),
+                result.quoteStatus(),
+                result.acceptedBy(),
+                result.acceptedAt(),
+                result.version()
+        ));
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/dto/request/AcceptQuoteRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/dto/request/AcceptQuoteRequest.java
@@ -1,0 +1,10 @@
+package com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+// Request body for POST /v1/quotes/{folio}/accept
+public record AcceptQuoteRequest(
+        @NotBlank String acceptedBy,
+        @NotNull Long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/dto/response/AcceptQuoteResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/dto/response/AcceptQuoteResponse.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response;
+
+import java.time.Instant;
+
+// Response DTO for POST /v1/quotes/{folio}/accept
+public record AcceptQuoteResponse(
+        String folioNumber,
+        String quoteStatus,
+        String acceptedBy,
+        Instant acceptedAt,
+        long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/swaggerdocs/CalculationApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/swaggerdocs/CalculationApi.java
@@ -1,6 +1,8 @@
 package com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.swaggerdocs;
 
+import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.request.AcceptQuoteRequest;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.request.CalculatePremiumRequest;
+import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response.AcceptQuoteResponse;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response.CalculationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,5 +34,27 @@ public interface CalculationApi {
     ResponseEntity<CalculationResponse> calculate(
             @PathVariable String folio,
             @Valid @RequestBody CalculatePremiumRequest request
+    );
+
+    @Operation(summary = "Obtener resultado de cálculo",
+               description = "Lee el resultado de cálculo almacenado para un folio")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Resultado encontrado"),
+            @ApiResponse(responseCode = "404", description = "Folio no encontrado o sin resultado calculado")
+    })
+    @GetMapping("/{folio}/calculation-result")
+    ResponseEntity<CalculationResponse> getCalculationResult(@PathVariable String folio);
+
+    @Operation(summary = "Aceptar cotización",
+               description = "Acepta la cotización y cambia el estado a ISSUED")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Cotización aceptada"),
+            @ApiResponse(responseCode = "404", description = "Folio no encontrado"),
+            @ApiResponse(responseCode = "409", description = "Conflicto de versión (optimistic lock)")
+    })
+    @PostMapping("/{folio}/accept")
+    ResponseEntity<AcceptQuoteResponse> accept(
+            @PathVariable String folio,
+            @Valid @RequestBody AcceptQuoteRequest request
     );
 }

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/persistence/adapter/CalculationResultJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/persistence/adapter/CalculationResultJpaAdapter.java
@@ -87,7 +87,7 @@ public class CalculationResultJpaAdapter implements CalculationResultRepository,
         // 2. Update quote status — this triggers @Version increment via Hibernate
         quoteJpa.setQuoteStatus("CALCULATED");
         quoteJpa.setUpdatedAt(Instant.now());
-        QuoteJpa savedQuote = quoteJpaRepository.save(quoteJpa);
+        QuoteJpa savedQuote = quoteJpaRepository.saveAndFlush(quoteJpa);
 
         // 3. Delete previous calculation result (idempotent recalculation)
         calculationResultJpaRepository.deleteByQuoteId(quoteJpa.getId());

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/persistence/adapter/CalculationResultJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/persistence/adapter/CalculationResultJpaAdapter.java
@@ -1,9 +1,12 @@
 package com.sofka.insurancequoter.back.calculation.infrastructure.adapter.out.persistence.adapter;
 
+import com.sofka.insurancequoter.back.calculation.application.usecase.command.AcceptQuoteCommand;
 import com.sofka.insurancequoter.back.calculation.application.usecase.dto.QuoteCalculationSnapshot;
 import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
 import com.sofka.insurancequoter.back.calculation.domain.model.PremiumByLocation;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.AcceptQuoteRepository;
 import com.sofka.insurancequoter.back.calculation.domain.port.out.CalculationResultRepository;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.GetCalculationResultRepository;
 import com.sofka.insurancequoter.back.calculation.domain.port.out.QuoteCalculationReader;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.out.persistence.entities.CalculationResultJpa;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.out.persistence.entities.PremiumByLocationJpa;
@@ -15,6 +18,7 @@ import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persis
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
 import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
 import com.sofka.insurancequoter.back.location.domain.model.Location;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
@@ -24,10 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
-// Adapter implementing both CalculationResultRepository and QuoteCalculationReader
+// Adapter implementing persistence ports for the calculation bounded context
 // Cross-context reads: accesses location, coverage and folio JPA repositories directly
-public class CalculationResultJpaAdapter implements CalculationResultRepository, QuoteCalculationReader {
+public class CalculationResultJpaAdapter implements CalculationResultRepository, QuoteCalculationReader,
+        GetCalculationResultRepository, AcceptQuoteRepository {
 
     private final QuoteJpaRepository quoteJpaRepository;
     private final LocationJpaRepository locationJpaRepository;
@@ -104,5 +110,29 @@ public class CalculationResultJpaAdapter implements CalculationResultRepository,
 
         // 6. Return the new version after Hibernate incremented it
         return savedQuote.getVersion();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<CalculationResult> find(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .flatMap(quote -> calculationResultJpaRepository.findByQuoteId(quote.getId()))
+                .map(calculationPersistenceMapper::toDomain);
+    }
+
+    @Override
+    @Transactional
+    public long accept(AcceptQuoteCommand command) {
+        QuoteJpa quoteJpa = quoteJpaRepository.findByFolioNumber(command.folioNumber())
+                .orElseThrow(() -> new FolioNotFoundException(command.folioNumber()));
+
+        if (!quoteJpa.getVersion().equals(command.version())) {
+            throw new VersionConflictException(command.folioNumber(), quoteJpa.getVersion(), command.version());
+        }
+
+        quoteJpa.setQuoteStatus("ISSUED");
+        quoteJpa.setUpdatedAt(Instant.now());
+        QuoteJpa saved = quoteJpaRepository.saveAndFlush(quoteJpa);
+        return saved.getVersion();
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/config/CalculationConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/config/CalculationConfig.java
@@ -1,8 +1,14 @@
 package com.sofka.insurancequoter.back.calculation.infrastructure.config;
 
+import com.sofka.insurancequoter.back.calculation.application.usecase.AcceptQuoteUseCaseImpl;
 import com.sofka.insurancequoter.back.calculation.application.usecase.CalculatePremiumUseCaseImpl;
+import com.sofka.insurancequoter.back.calculation.application.usecase.GetCalculationResultUseCaseImpl;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.AcceptQuoteUseCase;
 import com.sofka.insurancequoter.back.calculation.domain.port.in.CalculatePremiumUseCase;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.GetCalculationResultUseCase;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.AcceptQuoteRepository;
 import com.sofka.insurancequoter.back.calculation.domain.port.out.CalculationResultRepository;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.GetCalculationResultRepository;
 import com.sofka.insurancequoter.back.calculation.domain.port.out.QuoteCalculationReader;
 import com.sofka.insurancequoter.back.calculation.domain.port.out.TariffClient;
 import com.sofka.insurancequoter.back.calculation.domain.service.CalculationService;
@@ -85,6 +91,22 @@ public class CalculationConfig {
                 tariffClient,
                 guaranteeCatalogClient,
                 calculationService
+        );
+    }
+
+    @Bean
+    public GetCalculationResultUseCase getCalculationResultUseCase(
+            CalculationResultJpaAdapter calculationResultJpaAdapter) {
+        return new GetCalculationResultUseCaseImpl(
+                (GetCalculationResultRepository) calculationResultJpaAdapter
+        );
+    }
+
+    @Bean
+    public AcceptQuoteUseCase acceptQuoteUseCase(
+            CalculationResultJpaAdapter calculationResultJpaAdapter) {
+        return new AcceptQuoteUseCaseImpl(
+                (AcceptQuoteRepository) calculationResultJpaAdapter
         );
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImpl.java
@@ -3,29 +3,47 @@ package com.sofka.insurancequoter.back.coverage.application.usecase;
 import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
 import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
 import com.sofka.insurancequoter.back.coverage.domain.port.in.GetCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.ActiveGuaranteeReader;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
 
+import java.time.Instant;
 import java.util.List;
 
-// Orchestrates: assert folio exists → fetch options → fetch version → return response
+// Orchestrates: assert folio exists → fetch options from DB → if empty, derive from guarantees → return response
 public class GetCoverageOptionsUseCaseImpl implements GetCoverageOptionsUseCase {
 
     private final QuoteLookupPort quoteLookupPort;
     private final CoverageOptionRepository coverageOptionRepository;
+    private final ActiveGuaranteeReader activeGuaranteeReader;
+    private final CoverageDerivationService coverageDerivationService;
 
     public GetCoverageOptionsUseCaseImpl(QuoteLookupPort quoteLookupPort,
-                                         CoverageOptionRepository coverageOptionRepository) {
+                                         CoverageOptionRepository coverageOptionRepository,
+                                         ActiveGuaranteeReader activeGuaranteeReader,
+                                         CoverageDerivationService coverageDerivationService) {
         this.quoteLookupPort = quoteLookupPort;
         this.coverageOptionRepository = coverageOptionRepository;
+        this.activeGuaranteeReader = activeGuaranteeReader;
+        this.coverageDerivationService = coverageDerivationService;
     }
 
     @Override
     public CoverageOptionsResponse getCoverageOptions(String folioNumber) {
         quoteLookupPort.assertFolioExists(folioNumber);
+
         List<CoverageOption> options = coverageOptionRepository.findByFolioNumber(folioNumber);
+
+        // If no options are persisted, derive them from the location guarantees
+        if (options.isEmpty()) {
+            List<String> activeCodes = activeGuaranteeReader.readActiveGuaranteeCodes(folioNumber);
+            boolean hasCatZone = activeGuaranteeReader.hasCatastrophicZone(folioNumber);
+            options = coverageDerivationService.deriveFrom(activeCodes, hasCatZone);
+        }
+
         long version = quoteLookupPort.getCurrentVersion(folioNumber);
-        java.time.Instant updatedAt = quoteLookupPort.getUpdatedAt(folioNumber);
+        Instant updatedAt = quoteLookupPort.getUpdatedAt(folioNumber);
         return new CoverageOptionsResponse(folioNumber, options, updatedAt, version);
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImpl.java
@@ -2,33 +2,31 @@ package com.sofka.insurancequoter.back.coverage.application.usecase;
 
 import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
 import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
-import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
 import com.sofka.insurancequoter.back.coverage.application.usecase.exception.InvalidCoverageCodeException;
 import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
 import com.sofka.insurancequoter.back.coverage.domain.port.in.SaveCoverageOptionsUseCase;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
-import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-// Orchestrates: assert folio → check version → validate codes → enrich descriptions → persist → return
+// Orchestrates: assert folio → check version → validate COV-* codes → enrich descriptions → persist → return
 public class SaveCoverageOptionsUseCaseImpl implements SaveCoverageOptionsUseCase {
 
     private final QuoteLookupPort quoteLookupPort;
     private final CoverageOptionRepository coverageOptionRepository;
-    private final GuaranteeCatalogClient guaranteeCatalogClient;
+    private final CoverageDerivationService coverageDerivationService;
 
     public SaveCoverageOptionsUseCaseImpl(QuoteLookupPort quoteLookupPort,
                                           CoverageOptionRepository coverageOptionRepository,
-                                          GuaranteeCatalogClient guaranteeCatalogClient) {
+                                          CoverageDerivationService coverageDerivationService) {
         this.quoteLookupPort = quoteLookupPort;
         this.coverageOptionRepository = coverageOptionRepository;
-        this.guaranteeCatalogClient = guaranteeCatalogClient;
+        this.coverageDerivationService = coverageDerivationService;
     }
 
     @Override
@@ -43,19 +41,16 @@ public class SaveCoverageOptionsUseCaseImpl implements SaveCoverageOptionsUseCas
             }
         }
 
-        List<GuaranteeDto> catalog = guaranteeCatalogClient.fetchGuarantees();
-        Map<String, String> catalogByCode = catalog.stream()
-                .collect(Collectors.toMap(GuaranteeDto::code, GuaranteeDto::description));
+        Map<String, String> knownDescriptions = coverageDerivationService.knownDescriptions();
 
-        // Validate all codes and enrich descriptions from catalog
         List<CoverageOption> enriched = command.coverageOptions().stream()
                 .map(option -> {
-                    if (!catalogByCode.containsKey(option.code())) {
+                    if (!knownDescriptions.containsKey(option.code())) {
                         throw new InvalidCoverageCodeException(option.code());
                     }
                     return new CoverageOption(
                             option.code(),
-                            catalogByCode.get(option.code()),
+                            knownDescriptions.get(option.code()),
                             option.selected(),
                             option.deductiblePercentage(),
                             option.coinsurancePercentage()

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/ActiveGuaranteeReader.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/port/out/ActiveGuaranteeReader.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.coverage.domain.port.out;
+
+import java.util.List;
+
+// Output port: reads active guarantee information from location data for a given folio
+public interface ActiveGuaranteeReader {
+
+    // Returns guarantee codes whose insuredValue > 0 across all locations of the folio
+    List<String> readActiveGuaranteeCodes(String folioNumber);
+
+    // Returns true if any location of the folio has a non-null, non-blank catastrophicZone
+    boolean hasCatastrophicZone(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/service/CoverageDerivationService.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/service/CoverageDerivationService.java
@@ -1,0 +1,100 @@
+package com.sofka.insurancequoter.back.coverage.domain.service;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+// Pure domain service — no Spring annotations, no infrastructure dependencies.
+// Derives CoverageOption list from active guarantee codes and catastrophic zone flag.
+//
+// Mapping table (from domain spec):
+//   GUA-FIRE or GUA-CONT (active) → COV-FIRE  deductible=2.0  coinsurance=80.0
+//   GUA-THEFT (active)            → COV-THEFT deductible=5.0  coinsurance=100.0
+//   GUA-GLASS (active)            → COV-GLASS deductible=5.0  coinsurance=100.0
+//   GUA-ELEC  (active)            → COV-ELEC  deductible=10.0 coinsurance=100.0
+//   hasCatZone                    → COV-CAT   deductible=3.0  coinsurance=90.0
+//   always                        → COV-BI    deductible=3.0  coinsurance=80.0  selected=false
+public class CoverageDerivationService {
+
+    // Coverage codes
+    private static final String COV_FIRE  = "COV-FIRE";
+    private static final String COV_THEFT = "COV-THEFT";
+    private static final String COV_GLASS = "COV-GLASS";
+    private static final String COV_ELEC  = "COV-ELEC";
+    private static final String COV_CAT   = "COV-CAT";
+    private static final String COV_BI    = "COV-BI";
+
+    // Guarantee codes that trigger COV-FIRE
+    private static final String GUA_FIRE = "GUA-FIRE";
+    private static final String GUA_CONT = "GUA-CONT";
+    private static final String GUA_THEFT = "GUA-THEFT";
+    private static final String GUA_GLASS = "GUA-GLASS";
+    private static final String GUA_ELEC  = "GUA-ELEC";
+
+    // Deductible constants
+    private static final BigDecimal DEDUCTIBLE_FIRE  = new BigDecimal("2.0");
+    private static final BigDecimal DEDUCTIBLE_THEFT = new BigDecimal("5.0");
+    private static final BigDecimal DEDUCTIBLE_GLASS = new BigDecimal("5.0");
+    private static final BigDecimal DEDUCTIBLE_ELEC  = new BigDecimal("10.0");
+    private static final BigDecimal DEDUCTIBLE_CAT   = new BigDecimal("3.0");
+    private static final BigDecimal DEDUCTIBLE_BI    = new BigDecimal("3.0");
+
+    // Coinsurance constants
+    private static final BigDecimal COINSURANCE_80  = new BigDecimal("80.0");
+    private static final BigDecimal COINSURANCE_90  = new BigDecimal("90.0");
+    private static final BigDecimal COINSURANCE_100 = new BigDecimal("100.0");
+
+    // Coverage descriptions
+    private static final String DESC_FIRE  = "Incendio y riesgos adicionales";
+    private static final String DESC_THEFT = "Robo con violencia";
+    private static final String DESC_GLASS = "Vidrios";
+    private static final String DESC_ELEC  = "Equipo electrónico";
+    private static final String DESC_CAT   = "Zona catastrófica";
+    private static final String DESC_BI    = "Interrupción de negocio";
+
+    /**
+     * Derives a list of CoverageOption from active guarantee codes and the catastrophic zone flag.
+     *
+     * @param activeGuaranteeCodes guarantee codes with insuredValue > 0
+     * @param hasCatZone           true if any location has a non-null, non-blank catastrophicZone
+     * @return derived coverage options; COV-BI is always included
+     */
+    public List<CoverageOption> deriveFrom(List<String> activeGuaranteeCodes, boolean hasCatZone) {
+        Set<String> codes = new LinkedHashSet<>(activeGuaranteeCodes);
+        List<CoverageOption> result = new ArrayList<>();
+
+        // COV-FIRE: triggered by GUA-FIRE or GUA-CONT
+        if (codes.contains(GUA_FIRE) || codes.contains(GUA_CONT)) {
+            result.add(new CoverageOption(COV_FIRE, DESC_FIRE, true, DEDUCTIBLE_FIRE, COINSURANCE_80));
+        }
+
+        // COV-THEFT: triggered by GUA-THEFT
+        if (codes.contains(GUA_THEFT)) {
+            result.add(new CoverageOption(COV_THEFT, DESC_THEFT, true, DEDUCTIBLE_THEFT, COINSURANCE_100));
+        }
+
+        // COV-GLASS: triggered by GUA-GLASS
+        if (codes.contains(GUA_GLASS)) {
+            result.add(new CoverageOption(COV_GLASS, DESC_GLASS, true, DEDUCTIBLE_GLASS, COINSURANCE_100));
+        }
+
+        // COV-ELEC: triggered by GUA-ELEC
+        if (codes.contains(GUA_ELEC)) {
+            result.add(new CoverageOption(COV_ELEC, DESC_ELEC, true, DEDUCTIBLE_ELEC, COINSURANCE_100));
+        }
+
+        // COV-CAT: triggered by any location having a catastrophic zone
+        if (hasCatZone) {
+            result.add(new CoverageOption(COV_CAT, DESC_CAT, true, DEDUCTIBLE_CAT, COINSURANCE_90));
+        }
+
+        // COV-BI: always present, always selected=false
+        result.add(new CoverageOption(COV_BI, DESC_BI, false, DEDUCTIBLE_BI, COINSURANCE_80));
+
+        return result;
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/domain/service/CoverageDerivationService.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/domain/service/CoverageDerivationService.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 // Pure domain service — no Spring annotations, no infrastructure dependencies.
@@ -63,6 +64,17 @@ public class CoverageDerivationService {
      * @param hasCatZone           true if any location has a non-null, non-blank catastrophicZone
      * @return derived coverage options; COV-BI is always included
      */
+    public Map<String, String> knownDescriptions() {
+        return Map.of(
+                COV_FIRE,  DESC_FIRE,
+                COV_THEFT, DESC_THEFT,
+                COV_GLASS, DESC_GLASS,
+                COV_ELEC,  DESC_ELEC,
+                COV_CAT,   DESC_CAT,
+                COV_BI,    DESC_BI
+        );
+    }
+
     public List<CoverageOption> deriveFrom(List<String> activeGuaranteeCodes, boolean hasCatZone) {
         Set<String> codes = new LinkedHashSet<>(activeGuaranteeCodes);
         List<CoverageOption> result = new ArrayList<>();

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/swaggerdocs/CoverageApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/in/rest/swaggerdocs/CoverageApi.java
@@ -4,7 +4,6 @@ import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dt
 import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.dto.response.CoverageOptionsListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -20,20 +19,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public interface CoverageApi {
 
     @Operation(summary = "Consultar opciones de cobertura")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Opciones de cobertura retornadas"),
-            @ApiResponse(responseCode = "404", description = "Folio no encontrado")
-    })
+    @ApiResponse(responseCode = "200", description = "Opciones de cobertura retornadas")
+    @ApiResponse(responseCode = "404", description = "Folio no encontrado")
     @GetMapping
     ResponseEntity<CoverageOptionsListResponse> getCoverageOptions(@PathVariable String folio);
 
     @Operation(summary = "Configurar opciones de cobertura")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Opciones de cobertura guardadas"),
-            @ApiResponse(responseCode = "404", description = "Folio no encontrado"),
-            @ApiResponse(responseCode = "409", description = "Conflicto de versión optimista"),
-            @ApiResponse(responseCode = "422", description = "Error de validación")
-    })
+    @ApiResponse(responseCode = "200", description = "Opciones de cobertura guardadas")
+    @ApiResponse(responseCode = "404", description = "Folio no encontrado")
+    @ApiResponse(responseCode = "409", description = "Conflicto de versión optimista")
+    @ApiResponse(responseCode = "422", description = "Error de validación")
     @PutMapping
     ResponseEntity<CoverageOptionsListResponse> saveCoverageOptions(
             @PathVariable String folio,

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/adapter/ActiveGuaranteeJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/adapter/ActiveGuaranteeJpaAdapter.java
@@ -1,0 +1,64 @@
+package com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.coverage.domain.port.out.ActiveGuaranteeReader;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.domain.model.Guarantee;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.entities.LocationJpa;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+
+// Implements ActiveGuaranteeReader using JPA repositories.
+// Reads location guarantees persisted as JSON (converted by GuaranteesConverter) for a given folio.
+public class ActiveGuaranteeJpaAdapter implements ActiveGuaranteeReader {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+    private final LocationJpaRepository locationJpaRepository;
+
+    public ActiveGuaranteeJpaAdapter(QuoteJpaRepository quoteJpaRepository,
+                                      LocationJpaRepository locationJpaRepository) {
+        this.quoteJpaRepository = quoteJpaRepository;
+        this.locationJpaRepository = locationJpaRepository;
+    }
+
+    @Override
+    public List<String> readActiveGuaranteeCodes(String folioNumber) {
+        Long quoteId = resolveQuoteId(folioNumber);
+        List<LocationJpa> locations = locationJpaRepository.findByQuoteIdAndActiveTrue(quoteId);
+
+        return locations.stream()
+                .map(LocationJpa::getGuarantees)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(this::isActive)
+                .map(Guarantee::code)
+                .distinct()
+                .toList();
+    }
+
+    @Override
+    public boolean hasCatastrophicZone(String folioNumber) {
+        Long quoteId = resolveQuoteId(folioNumber);
+        List<LocationJpa> locations = locationJpaRepository.findByQuoteIdAndActiveTrue(quoteId);
+
+        return locations.stream()
+                .map(LocationJpa::getCatastrophicZone)
+                .anyMatch(zone -> zone != null && !zone.isBlank());
+    }
+
+    // A guarantee is active when its insuredValue is non-null and greater than zero
+    private boolean isActive(Guarantee guarantee) {
+        return guarantee.insuredValue() != null
+                && guarantee.insuredValue().compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    private Long resolveQuoteId(String folioNumber) {
+        QuoteJpa quote = quoteJpaRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
+        return quote.getId();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/adapter/CoverageOptionJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/adapter/CoverageOptionJpaAdapter.java
@@ -49,7 +49,7 @@ public class CoverageOptionJpaAdapter implements CoverageOptionRepository, Quote
         List<CoverageOptionJpa> savedList = coverageOptionJpaRepository.saveAll(jpaList);
         // Touch the quote to trigger @UpdateTimestamp and force version increment via @Version
         quote.setUpdatedAt(Instant.now());
-        quoteJpaRepository.save(quote);
+        quoteJpaRepository.saveAndFlush(quote);
         return mapper.toDomainList(savedList);
     }
 

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
@@ -67,8 +67,8 @@ public class CoverageConfig {
     @Bean
     public SaveCoverageOptionsUseCase saveCoverageOptionsUseCase(
             CoverageOptionJpaAdapter adapter,
-            GuaranteeCatalogClient guaranteeCatalogClient) {
-        return new SaveCoverageOptionsUseCaseImpl(adapter, adapter, guaranteeCatalogClient);
+            CoverageDerivationService coverageDerivationService) {
+        return new SaveCoverageOptionsUseCaseImpl(adapter, adapter, coverageDerivationService);
     }
 
     @Bean

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
@@ -4,13 +4,17 @@ import com.sofka.insurancequoter.back.coverage.application.usecase.GetCoverageOp
 import com.sofka.insurancequoter.back.coverage.application.usecase.SaveCoverageOptionsUseCaseImpl;
 import com.sofka.insurancequoter.back.coverage.domain.port.in.GetCoverageOptionsUseCase;
 import com.sofka.insurancequoter.back.coverage.domain.port.in.SaveCoverageOptionsUseCase;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.ActiveGuaranteeReader;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
+import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
 import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.in.rest.mapper.CoverageRestMapper;
 import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.http.adapter.GuaranteeCatalogClientAdapter;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.adapter.ActiveGuaranteeJpaAdapter;
 import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.adapter.CoverageOptionJpaAdapter;
 import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.mappers.CoverageOptionPersistenceMapper;
 import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,9 +45,23 @@ public class CoverageConfig {
     }
 
     @Bean
+    public CoverageDerivationService coverageDerivationService() {
+        return new CoverageDerivationService();
+    }
+
+    @Bean
+    public ActiveGuaranteeReader activeGuaranteeReader(
+            QuoteJpaRepository quoteJpaRepository,
+            LocationJpaRepository locationJpaRepository) {
+        return new ActiveGuaranteeJpaAdapter(quoteJpaRepository, locationJpaRepository);
+    }
+
+    @Bean
     public GetCoverageOptionsUseCase getCoverageOptionsUseCase(
-            CoverageOptionJpaAdapter adapter) {
-        return new GetCoverageOptionsUseCaseImpl(adapter, adapter);
+            CoverageOptionJpaAdapter adapter,
+            ActiveGuaranteeReader activeGuaranteeReader,
+            CoverageDerivationService coverageDerivationService) {
+        return new GetCoverageOptionsUseCaseImpl(adapter, adapter, activeGuaranteeReader, coverageDerivationService);
     }
 
     @Bean

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
@@ -2,6 +2,7 @@ package com.sofka.insurancequoter.back.folio.application.usecase;
 
 import com.sofka.insurancequoter.back.folio.domain.model.*;
 import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoverageOptionsStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
 
@@ -9,11 +10,14 @@ public class GetQuoteStateUseCaseImpl implements GetQuoteStateUseCase {
 
     private final QuoteStateQuery quoteStateQuery;
     private final LocationStateReader locationStateReader;
+    private final CoverageOptionsStateReader coverageOptionsStateReader;
 
     public GetQuoteStateUseCaseImpl(QuoteStateQuery quoteStateQuery,
-                                    LocationStateReader locationStateReader) {
+                                    LocationStateReader locationStateReader,
+                                    CoverageOptionsStateReader coverageOptionsStateReader) {
         this.quoteStateQuery = quoteStateQuery;
         this.locationStateReader = locationStateReader;
+        this.coverageOptionsStateReader = coverageOptionsStateReader;
     }
 
     @Override
@@ -25,7 +29,7 @@ public class GetQuoteStateUseCaseImpl implements GetQuoteStateUseCase {
                 evaluateGeneralInfo(snapshot),
                 evaluateLayout(snapshot),
                 evaluateLocations(locationSummary),
-                SectionStatus.PENDING,                      // coverageOptions — requires SPEC-007
+                coverageOptionsStateReader.readByFolioNumber(folioNumber),
                 evaluateCalculation(snapshot.quoteStatus())
         );
 

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
@@ -22,7 +22,7 @@ public class GetQuoteStateUseCaseImpl implements GetQuoteStateUseCase {
         LocationStateSummary locationSummary = locationStateReader.readByFolioNumber(folioNumber);
 
         QuoteSections sections = new QuoteSections(
-                SectionStatus.PENDING,                      // generalInfo — requires SPEC-006
+                evaluateGeneralInfo(snapshot),
                 evaluateLayout(snapshot),
                 evaluateLocations(locationSummary),
                 SectionStatus.PENDING,                      // coverageOptions — requires SPEC-007
@@ -39,6 +39,10 @@ public class GetQuoteStateUseCaseImpl implements GetQuoteStateUseCase {
                 snapshot.version(),
                 snapshot.updatedAt()
         );
+    }
+
+    private SectionStatus evaluateGeneralInfo(QuoteSnapshot snapshot) {
+        return snapshot.hasGeneralInfo() ? SectionStatus.COMPLETE : SectionStatus.PENDING;
     }
 
     private SectionStatus evaluateLayout(QuoteSnapshot snapshot) {

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImpl.java
@@ -1,0 +1,69 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.FolioRaw;
+import com.sofka.insurancequoter.back.folio.domain.model.FolioSummary;
+import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.FolioListQuery;
+
+import java.util.List;
+
+// Use case: retrieves all folios and enriches each entry with agentName (from core)
+// and completionPct (from GetQuoteStateUseCase). Registered as @Bean in FolioConfig.
+public class ListFoliosUseCaseImpl implements ListFoliosUseCase {
+
+    private final FolioListQuery folioListQuery;
+    private final GetQuoteStateUseCase getQuoteStateUseCase;
+    private final CoreServiceClient coreServiceClient;
+
+    public ListFoliosUseCaseImpl(FolioListQuery folioListQuery,
+                                  GetQuoteStateUseCase getQuoteStateUseCase,
+                                  CoreServiceClient coreServiceClient) {
+        this.folioListQuery = folioListQuery;
+        this.getQuoteStateUseCase = getQuoteStateUseCase;
+        this.coreServiceClient = coreServiceClient;
+    }
+
+    @Override
+    public List<FolioSummary> listFolios() {
+        return folioListQuery.findAll().stream()
+                .map(this::enrich)
+                .toList();
+    }
+
+    private FolioSummary enrich(FolioRaw raw) {
+        String agentName = resolveAgentName(raw.agentCode());
+        int completionPct = resolveCompletionPct(raw.folioNumber());
+
+        return new FolioSummary(
+                raw.folioNumber(),
+                raw.client(),
+                raw.agentCode(),
+                agentName,
+                raw.status(),
+                raw.locationCount(),
+                completionPct,
+                null,           // commercialPremium: not yet in schema
+                raw.updatedAt()
+        );
+    }
+
+    // Graceful degradation: if the core service is unavailable, agentName is null.
+    private String resolveAgentName(String agentCode) {
+        try {
+            return coreServiceClient.getAgentName(agentCode);
+        } catch (CoreServiceException ex) {
+            return null;
+        }
+    }
+
+    // Graceful degradation: if state cannot be computed (e.g. folio has no data yet), return 0.
+    private int resolveCompletionPct(String folioNumber) {
+        try {
+            return getQuoteStateUseCase.getState(folioNumber).completionPercentage();
+        } catch (Exception ex) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/FolioRaw.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/FolioRaw.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+import java.time.Instant;
+
+// Intermediate domain object: raw folio data from persistence, without enrichment.
+// agentName and completionPct are resolved by the use case layer.
+public record FolioRaw(
+        String folioNumber,
+        String client,
+        String agentCode,
+        String status,
+        int locationCount,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/FolioSummary.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/FolioSummary.java
@@ -1,0 +1,18 @@
+package com.sofka.insurancequoter.back.folio.domain.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+// Domain model for the folio list response — all 9 fields from the API contract.
+// commercialPremium is null until the quote reaches CALCULATED status.
+public record FolioSummary(
+        String folioNumber,
+        String client,
+        String agentCode,
+        String agentName,
+        String status,
+        int locationCount,
+        int completionPct,
+        BigDecimal commercialPremium,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteSnapshot.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/model/QuoteSnapshot.java
@@ -9,5 +9,6 @@ public record QuoteSnapshot(
         Integer numberOfLocations,
         String locationType,
         Long version,
-        Instant updatedAt
+        Instant updatedAt,
+        boolean hasGeneralInfo
 ) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/ListFoliosUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/in/ListFoliosUseCase.java
@@ -1,0 +1,10 @@
+package com.sofka.insurancequoter.back.folio.domain.port.in;
+
+import com.sofka.insurancequoter.back.folio.domain.model.FolioSummary;
+
+import java.util.List;
+
+// Input port: returns all folio summaries enriched with agent name and completion percentage.
+public interface ListFoliosUseCase {
+    List<FolioSummary> listFolios();
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/CoreServiceClient.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/CoreServiceClient.java
@@ -5,4 +5,6 @@ public interface CoreServiceClient {
     boolean existsSubscriber(String subscriberId);
     boolean existsAgent(String agentCode);
     String nextFolioNumber();
+    // Returns the agent's display name for a given code, or null if not found.
+    String getAgentName(String agentCode);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/CoverageOptionsStateReader.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/CoverageOptionsStateReader.java
@@ -1,0 +1,7 @@
+package com.sofka.insurancequoter.back.folio.domain.port.out;
+
+import com.sofka.insurancequoter.back.folio.domain.model.SectionStatus;
+
+public interface CoverageOptionsStateReader {
+    SectionStatus readByFolioNumber(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/FolioListQuery.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/domain/port/out/FolioListQuery.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.folio.domain.port.out;
+
+import com.sofka.insurancequoter.back.folio.domain.model.FolioRaw;
+
+import java.util.List;
+
+// Output port: retrieves raw folio data from persistence.
+// Does NOT resolve agentName or completionPct — those are use-case concerns.
+public interface FolioListQuery {
+    List<FolioRaw> findAll();
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioController.java
@@ -3,8 +3,11 @@ package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
 import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioCommand;
 import com.sofka.insurancequoter.back.folio.application.usecase.FolioCreationResult;
 import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.CreateFolioRequest;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioListResponseDto;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioListRestMapper;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.swaggerdocs.FolioApi;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class FolioController implements FolioApi {
 
     private final CreateFolioUseCase createFolioUseCase;
+    private final ListFoliosUseCase listFoliosUseCase;
     private final FolioRestMapper folioRestMapper;
+    private final FolioListRestMapper folioListRestMapper;
+
+    @Override
+    public ResponseEntity<FolioListResponseDto> listFolios() {
+        return ResponseEntity.ok(folioListRestMapper.toResponse(listFoliosUseCase.listFolios()));
+    }
 
     @Override
     public ResponseEntity<FolioResponse> createFolio(CreateFolioRequest request) {

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
 
+import com.sofka.insurancequoter.back.calculation.application.usecase.exception.CalculationResultNotFoundException;
 import com.sofka.insurancequoter.back.calculation.application.usecase.exception.NoCalculableLocationsException;
 import com.sofka.insurancequoter.back.coverage.application.usecase.exception.InvalidCoverageCodeException;
 import com.sofka.insurancequoter.back.folio.application.usecase.CoreServiceException;
@@ -15,6 +16,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.List;
 import java.util.Map;
@@ -25,12 +27,30 @@ public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNoResourceFound(NoResourceFoundException ex) {
+        return ResponseEntity.status(404)
+                .body(Map.of(
+                        "error", "Resource not found",
+                        "code", "NOT_FOUND"
+                ));
+    }
+
     @ExceptionHandler(FolioNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleFolioNotFound(FolioNotFoundException ex) {
         return ResponseEntity.status(404)
                 .body(Map.of(
                         "error", "Folio not found",
                         "code", "FOLIO_NOT_FOUND"
+                ));
+    }
+
+    @ExceptionHandler(CalculationResultNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleCalculationResultNotFound(CalculationResultNotFoundException ex) {
+        return ResponseEntity.status(404)
+                .body(Map.of(
+                        "error", "Calculation result not found",
+                        "code", "CALCULATION_RESULT_NOT_FOUND"
                 ));
     }
 

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/FolioListResponseDto.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/FolioListResponseDto.java
@@ -1,0 +1,6 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto;
+
+import java.util.List;
+
+// Response envelope for GET /v1/folios → { "folios": [...] }
+public record FolioListResponseDto(List<FolioSummaryDto> folios) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/FolioSummaryDto.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/dto/FolioSummaryDto.java
@@ -1,0 +1,17 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+// Response DTO for a single folio entry in GET /v1/folios
+public record FolioSummaryDto(
+        String folioNumber,
+        String client,
+        String agentCode,
+        String agentName,
+        String status,
+        int locationCount,
+        int completionPct,
+        BigDecimal commercialPremium,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/FolioListRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/mapper/FolioListRestMapper.java
@@ -1,0 +1,34 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.back.folio.domain.model.FolioSummary;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioListResponseDto;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioSummaryDto;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+// Maps domain FolioSummary list to the REST response envelope
+@Component
+public class FolioListRestMapper {
+
+    public FolioListResponseDto toResponse(List<FolioSummary> summaries) {
+        List<FolioSummaryDto> dtos = summaries.stream()
+                .map(this::toDto)
+                .toList();
+        return new FolioListResponseDto(dtos);
+    }
+
+    private FolioSummaryDto toDto(FolioSummary s) {
+        return new FolioSummaryDto(
+                s.folioNumber(),
+                s.client(),
+                s.agentCode(),
+                s.agentName(),
+                s.status(),
+                s.locationCount(),
+                s.completionPct(),
+                s.commercialPremium(),
+                s.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/FolioApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/FolioApi.java
@@ -1,12 +1,14 @@
 package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.swaggerdocs;
 
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.CreateFolioRequest;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioListResponseDto;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +17,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Tag(name = "Folios", description = "Gestión de folios de cotización")
 @RequestMapping("/v1/folios")
 public interface FolioApi {
+
+    @Operation(summary = "Listar folios de cotización",
+               description = "Retorna todos los folios con datos enriquecidos: nombre del agente y porcentaje de completitud.")
+    @ApiResponse(responseCode = "200", description = "Lista de folios (puede ser vacía)")
+    @GetMapping
+    ResponseEntity<FolioListResponseDto> listFolios();
 
     @Operation(summary = "Crear o recuperar folio de cotización",
                description = "Crea un nuevo folio si no existe uno activo para el mismo suscriptor y agente (CREATED). "

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/FolioApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/swaggerdocs/FolioApi.java
@@ -4,7 +4,6 @@ import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.C
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -20,12 +19,10 @@ public interface FolioApi {
     @Operation(summary = "Crear o recuperar folio de cotización",
                description = "Crea un nuevo folio si no existe uno activo para el mismo suscriptor y agente (CREATED). "
                              + "Si ya existe, lo retorna con HTTP 200 (idempotencia).")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Folio creado exitosamente"),
-            @ApiResponse(responseCode = "200", description = "Folio existente recuperado (idempotencia)"),
-            @ApiResponse(responseCode = "400", description = "Suscriptor o agente no encontrado en el core service"),
-            @ApiResponse(responseCode = "422", description = "Datos de entrada inválidos")
-    })
+    @ApiResponse(responseCode = "201", description = "Folio creado exitosamente")
+    @ApiResponse(responseCode = "200", description = "Folio existente recuperado (idempotencia)")
+    @ApiResponse(responseCode = "400", description = "Suscriptor o agente no encontrado en el core service")
+    @ApiResponse(responseCode = "422", description = "Datos de entrada inválidos")
     @PostMapping
     ResponseEntity<FolioResponse> createFolio(@Valid @RequestBody CreateFolioRequest request);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/adapter/CoreServiceClientAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/adapter/CoreServiceClientAdapter.java
@@ -64,4 +64,24 @@ public class CoreServiceClientAdapter implements CoreServiceClient {
         }
         return response.folioNumber();
     }
+
+    @Override
+    public String getAgentName(String agentCode) {
+        AgentsResponse response = restClient.get()
+                .uri("/v1/agents")
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    throw new CoreServiceException(
+                            "Core service error fetching agents: HTTP " + res.getStatusCode().value());
+                })
+                .body(AgentsResponse.class);
+        if (response == null || response.agents() == null) {
+            return null;
+        }
+        return response.agents().stream()
+                .filter(a -> agentCode.equals(a.code()))
+                .map(AgentsResponse.AgentItem::name)
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/CoverageOptionsStateJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/CoverageOptionsStateJpaAdapter.java
@@ -1,0 +1,28 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
+import com.sofka.insurancequoter.back.folio.domain.model.SectionStatus;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoverageOptionsStateReader;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CoverageOptionsStateJpaAdapter implements CoverageOptionsStateReader {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+    private final CoverageOptionJpaRepository coverageOptionJpaRepository;
+
+    @Override
+    public SectionStatus readByFolioNumber(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .map(quote -> {
+                    var options = coverageOptionJpaRepository.findAllByQuote_Id(quote.getId());
+                    if (options.isEmpty()) return SectionStatus.PENDING;
+                    boolean anySelected = options.stream().anyMatch(o -> o.isSelected());
+                    return anySelected ? SectionStatus.COMPLETE : SectionStatus.IN_PROGRESS;
+                })
+                .orElse(SectionStatus.PENDING);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/FolioListJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/FolioListJpaAdapter.java
@@ -1,0 +1,37 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.folio.domain.model.FolioRaw;
+import com.sofka.insurancequoter.back.folio.domain.port.out.FolioListQuery;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+// Persistence adapter: implements FolioListQuery using QuoteJpaRepository.findAll().
+// Maps QuoteJpa -> FolioRaw; agentName and completionPct are NOT resolved here.
+@Component
+@RequiredArgsConstructor
+public class FolioListJpaAdapter implements FolioListQuery {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+
+    @Override
+    public List<FolioRaw> findAll() {
+        return quoteJpaRepository.findAll().stream()
+                .map(this::toRaw)
+                .toList();
+    }
+
+    private FolioRaw toRaw(QuoteJpa jpa) {
+        return new FolioRaw(
+                jpa.getFolioNumber(),
+                jpa.getInsuredName(),
+                jpa.getAgentCode(),
+                jpa.getQuoteStatus(),
+                jpa.getNumberOfLocations() != null ? jpa.getNumberOfLocations() : 0,
+                jpa.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteStateJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/QuoteStateJpaAdapter.java
@@ -24,7 +24,8 @@ public class QuoteStateJpaAdapter implements QuoteStateQuery {
                 jpa.getNumberOfLocations(),
                 jpa.getLocationType(),
                 jpa.getVersion(),
-                jpa.getUpdatedAt()
+                jpa.getUpdatedAt(),
+                jpa.getInsuredName() != null
         );
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/entities/QuoteJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/entities/QuoteJpa.java
@@ -37,6 +37,25 @@ public class QuoteJpa {
     @Column(name = "location_type", length = 10)
     private String locationType;
 
+    // General-info fields (written by the generalinfo bounded context)
+    @Column(name = "insured_name", length = 100)
+    private String insuredName;
+
+    @Column(name = "insured_rfc", length = 13)
+    private String insuredRfc;
+
+    @Column(name = "insured_email", length = 100)
+    private String insuredEmail;
+
+    @Column(name = "insured_phone", length = 20)
+    private String insuredPhone;
+
+    @Column(name = "risk_classification", length = 20)
+    private String riskClassification;
+
+    @Column(name = "business_type", length = 20)
+    private String businessType;
+
     @Version
     @Column(name = "version", nullable = false)
     private Long version;

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
@@ -7,6 +7,7 @@ import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoverageOptionsStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.FolioListQuery;
 import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
@@ -40,8 +41,9 @@ public class FolioConfig {
 
     @Bean
     public GetQuoteStateUseCase getQuoteStateUseCase(QuoteStateQuery quoteStateQuery,
-                                                      LocationStateReader locationStateReader) {
-        return new GetQuoteStateUseCaseImpl(quoteStateQuery, locationStateReader);
+                                                      LocationStateReader locationStateReader,
+                                                      CoverageOptionsStateReader coverageOptionsStateReader) {
+        return new GetQuoteStateUseCaseImpl(quoteStateQuery, locationStateReader, coverageOptionsStateReader);
     }
 
     @Bean

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
@@ -2,9 +2,12 @@ package com.sofka.insurancequoter.back.folio.infrastructure.config;
 
 import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioUseCaseImpl;
 import com.sofka.insurancequoter.back.folio.application.usecase.GetQuoteStateUseCaseImpl;
+import com.sofka.insurancequoter.back.folio.application.usecase.ListFoliosUseCaseImpl;
 import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.FolioListQuery;
 import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
@@ -39,5 +42,12 @@ public class FolioConfig {
     public GetQuoteStateUseCase getQuoteStateUseCase(QuoteStateQuery quoteStateQuery,
                                                       LocationStateReader locationStateReader) {
         return new GetQuoteStateUseCaseImpl(quoteStateQuery, locationStateReader);
+    }
+
+    @Bean
+    public ListFoliosUseCase listFoliosUseCase(FolioListQuery folioListQuery,
+                                                GetQuoteStateUseCase getQuoteStateUseCase,
+                                                CoreServiceClient coreServiceClient) {
+        return new ListFoliosUseCaseImpl(folioListQuery, getQuoteStateUseCase, coreServiceClient);
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/GetGeneralInfoUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/GetGeneralInfoUseCaseImpl.java
@@ -1,0 +1,22 @@
+package com.sofka.insurancequoter.back.generalinfo.application.usecase;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.GetGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.out.GeneralInfoRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+
+// Retrieves the general information of a quote; throws FolioNotFoundException if the folio does not exist
+public class GetGeneralInfoUseCaseImpl implements GetGeneralInfoUseCase {
+
+    private final GeneralInfoRepository generalInfoRepository;
+
+    public GetGeneralInfoUseCaseImpl(GeneralInfoRepository generalInfoRepository) {
+        this.generalInfoRepository = generalInfoRepository;
+    }
+
+    @Override
+    public GeneralInfo getGeneralInfo(String folioNumber) {
+        return generalInfoRepository.findByFolioNumber(folioNumber)
+                .orElseThrow(() -> new FolioNotFoundException(folioNumber));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoCommand.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoCommand.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.back.generalinfo.application.usecase;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+
+// Carries all data required to update general information of a quote
+public record UpdateGeneralInfoCommand(
+        String folioNumber,
+        InsuredData insuredData,
+        UnderwritingInfo underwritingInfo,
+        Long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoUseCaseImpl.java
@@ -1,0 +1,38 @@
+package com.sofka.insurancequoter.back.generalinfo.application.usecase;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.UpdateGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.out.GeneralInfoRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+
+// Updates general information of a quote, enforcing optimistic locking via version check
+public class UpdateGeneralInfoUseCaseImpl implements UpdateGeneralInfoUseCase {
+
+    private final GeneralInfoRepository generalInfoRepository;
+
+    public UpdateGeneralInfoUseCaseImpl(GeneralInfoRepository generalInfoRepository) {
+        this.generalInfoRepository = generalInfoRepository;
+    }
+
+    @Override
+    public GeneralInfo updateGeneralInfo(UpdateGeneralInfoCommand command) {
+        GeneralInfo existing = generalInfoRepository.findByFolioNumber(command.folioNumber())
+                .orElseThrow(() -> new FolioNotFoundException(command.folioNumber()));
+
+        if (!existing.version().equals(command.version())) {
+            throw new VersionConflictException(command.folioNumber(), command.version(), existing.version());
+        }
+
+        GeneralInfo updated = new GeneralInfo(
+                existing.folioNumber(),
+                existing.quoteStatus(),
+                command.insuredData(),
+                command.underwritingInfo(),
+                existing.updatedAt(),
+                existing.version()
+        );
+
+        return generalInfoRepository.save(updated);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/BusinessType.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/BusinessType.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.model;
+
+// Type of business activity for the insured location
+public enum BusinessType {
+    COMMERCIAL,
+    INDUSTRIAL,
+    RESIDENTIAL
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/GeneralInfo.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/GeneralInfo.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.model;
+
+import java.time.Instant;
+
+// Domain aggregate projection for general quote information — no JPA or Spring annotations allowed
+public record GeneralInfo(
+        String folioNumber,
+        String quoteStatus,
+        InsuredData insuredData,
+        UnderwritingInfo underwritingInfo,
+        Instant updatedAt,
+        Long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/InsuredData.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/InsuredData.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.model;
+
+// Value object representing the insured party's contact and tax data
+public record InsuredData(
+        String name,
+        String rfc,
+        String email,
+        String phone
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/RiskClassification.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/RiskClassification.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.model;
+
+// Risk classification assigned during underwriting
+public enum RiskClassification {
+    STANDARD,
+    PREFERRED,
+    SUBSTANDARD
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/UnderwritingInfo.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/model/UnderwritingInfo.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.model;
+
+// Value object containing underwriting-related data for a quote
+public record UnderwritingInfo(
+        String subscriberId,
+        String agentCode,
+        RiskClassification riskClassification,
+        BusinessType businessType
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/port/in/GetGeneralInfoUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/port/in/GetGeneralInfoUseCase.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.port.in;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+
+// Input port: retrieve the general information of a quote by folio number
+public interface GetGeneralInfoUseCase {
+    GeneralInfo getGeneralInfo(String folioNumber);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/port/in/UpdateGeneralInfoUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/port/in/UpdateGeneralInfoUseCase.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.port.in;
+
+import com.sofka.insurancequoter.back.generalinfo.application.usecase.UpdateGeneralInfoCommand;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+
+// Input port: update the general information of a quote (optimistic locking enforced)
+public interface UpdateGeneralInfoUseCase {
+    GeneralInfo updateGeneralInfo(UpdateGeneralInfoCommand command);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/port/out/GeneralInfoRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/domain/port/out/GeneralInfoRepository.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.generalinfo.domain.port.out;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+
+import java.util.Optional;
+
+// Output port: persistence operations for general quote information
+public interface GeneralInfoRepository {
+    Optional<GeneralInfo> findByFolioNumber(String folioNumber);
+    GeneralInfo save(GeneralInfo generalInfo);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/GeneralInfoController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/GeneralInfoController.java
@@ -1,0 +1,35 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.GetGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.UpdateGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.GeneralInfoResponse;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.UpdateGeneralInfoRequest;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.mapper.GeneralInfoRestMapper;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.swaggerdocs.GeneralInfoApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+// Parses HTTP, delegates to the use cases, maps results - no business logic here
+@RestController
+@RequiredArgsConstructor
+public class GeneralInfoController implements GeneralInfoApi {
+
+    private final GetGeneralInfoUseCase getGeneralInfoUseCase;
+    private final UpdateGeneralInfoUseCase updateGeneralInfoUseCase;
+    private final GeneralInfoRestMapper generalInfoRestMapper;
+
+    @Override
+    public ResponseEntity<GeneralInfoResponse> getGeneralInfo(String folio) {
+        GeneralInfo generalInfo = getGeneralInfoUseCase.getGeneralInfo(folio);
+        return ResponseEntity.ok(generalInfoRestMapper.toResponse(generalInfo));
+    }
+
+    @Override
+    public ResponseEntity<GeneralInfoResponse> updateGeneralInfo(String folio, UpdateGeneralInfoRequest request) {
+        GeneralInfo updated = updateGeneralInfoUseCase.updateGeneralInfo(
+                generalInfoRestMapper.toCommand(folio, request));
+        return ResponseEntity.ok(generalInfoRestMapper.toResponse(updated));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/GeneralInfoResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/GeneralInfoResponse.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto;
+
+import java.time.Instant;
+
+// Response body for GET and PUT /v1/quotes/{folio}/general-info
+public record GeneralInfoResponse(
+        String folioNumber,
+        String quoteStatus,
+        InsuredDataDto insuredData,
+        UnderwritingDataDto underwritingData,
+        Instant updatedAt,
+        Long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/InsuredDataDto.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/InsuredDataDto.java
@@ -1,0 +1,13 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// DTO representing insured party data in REST requests and responses
+public record InsuredDataDto(
+        @NotBlank @Size(max = 100) String name,
+        @NotBlank @Size(max = 13) String rfc,
+        @NotBlank @Email @Size(max = 100) String email,
+        @NotBlank @Size(max = 20) String phone
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/UnderwritingDataDto.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/UnderwritingDataDto.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+// DTO representing underwriting data in REST requests and responses
+public record UnderwritingDataDto(
+        @NotBlank String subscriberId,
+        @NotBlank String agentCode,
+        @NotBlank String riskClassification,
+        @NotBlank String businessType
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/UpdateGeneralInfoRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/dto/UpdateGeneralInfoRequest.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+// Request body for PUT /v1/quotes/{folio}/general-info
+public record UpdateGeneralInfoRequest(
+        @NotNull @Valid InsuredDataDto insuredData,
+        @NotNull @Valid UnderwritingDataDto underwritingData,
+        @NotNull Long version
+) {}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/mapper/GeneralInfoRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/mapper/GeneralInfoRestMapper.java
@@ -1,0 +1,58 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.back.generalinfo.application.usecase.UpdateGeneralInfoCommand;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.BusinessType;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.RiskClassification;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.GeneralInfoResponse;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.InsuredDataDto;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.UnderwritingDataDto;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.UpdateGeneralInfoRequest;
+import org.springframework.stereotype.Component;
+
+// Maps between domain objects and REST DTOs for the general-info bounded context
+@Component
+public class GeneralInfoRestMapper {
+
+    public GeneralInfoResponse toResponse(GeneralInfo domain) {
+        return new GeneralInfoResponse(
+                domain.folioNumber(),
+                domain.quoteStatus(),
+                new InsuredDataDto(
+                        domain.insuredData().name(),
+                        domain.insuredData().rfc(),
+                        domain.insuredData().email(),
+                        domain.insuredData().phone()
+                ),
+                new UnderwritingDataDto(
+                        domain.underwritingInfo().subscriberId(),
+                        domain.underwritingInfo().agentCode(),
+                        domain.underwritingInfo().riskClassification().name(),
+                        domain.underwritingInfo().businessType().name()
+                ),
+                domain.updatedAt(),
+                domain.version()
+        );
+    }
+
+    public UpdateGeneralInfoCommand toCommand(String folioNumber, UpdateGeneralInfoRequest request) {
+        return new UpdateGeneralInfoCommand(
+                folioNumber,
+                new InsuredData(
+                        request.insuredData().name(),
+                        request.insuredData().rfc(),
+                        request.insuredData().email(),
+                        request.insuredData().phone()
+                ),
+                new UnderwritingInfo(
+                        request.underwritingData().subscriberId(),
+                        request.underwritingData().agentCode(),
+                        RiskClassification.valueOf(request.underwritingData().riskClassification()),
+                        BusinessType.valueOf(request.underwritingData().businessType())
+                ),
+                request.version()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/mapper/GeneralInfoRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/mapper/GeneralInfoRestMapper.java
@@ -29,8 +29,10 @@ public class GeneralInfoRestMapper {
                 new UnderwritingDataDto(
                         domain.underwritingInfo().subscriberId(),
                         domain.underwritingInfo().agentCode(),
-                        domain.underwritingInfo().riskClassification().name(),
-                        domain.underwritingInfo().businessType().name()
+                        domain.underwritingInfo().riskClassification() != null
+                                ? domain.underwritingInfo().riskClassification().name() : null,
+                        domain.underwritingInfo().businessType() != null
+                                ? domain.underwritingInfo().businessType().name() : null
                 ),
                 domain.updatedAt(),
                 domain.version()

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/swaggerdocs/GeneralInfoApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/swaggerdocs/GeneralInfoApi.java
@@ -1,0 +1,41 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.GeneralInfoResponse;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.UpdateGeneralInfoRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+// Swagger annotations live here - GeneralInfoController stays clean
+@Tag(name = "General Info", description = "Gestión de datos generales de cotización")
+@RequestMapping("/v1/quotes/{folio}/general-info")
+public interface GeneralInfoApi {
+
+    @Operation(summary = "Obtener datos generales de la cotización")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Datos generales obtenidos exitosamente"),
+            @ApiResponse(responseCode = "404", description = "Folio no encontrado")
+    })
+    @GetMapping
+    ResponseEntity<GeneralInfoResponse> getGeneralInfo(@PathVariable("folio") String folio);
+
+    @Operation(summary = "Actualizar datos generales de la cotización")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Datos generales actualizados exitosamente"),
+            @ApiResponse(responseCode = "404", description = "Folio no encontrado"),
+            @ApiResponse(responseCode = "409", description = "Conflicto de versión (optimistic lock)"),
+            @ApiResponse(responseCode = "422", description = "Datos de entrada inválidos")
+    })
+    @PutMapping
+    ResponseEntity<GeneralInfoResponse> updateGeneralInfo(
+            @PathVariable("folio") String folio,
+            @Valid @RequestBody UpdateGeneralInfoRequest request);
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/adapter/GeneralInfoJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/adapter/GeneralInfoJpaAdapter.java
@@ -40,7 +40,7 @@ public class GeneralInfoJpaAdapter implements GeneralInfoRepository {
         existing.setRiskClassification(generalInfo.underwritingInfo().riskClassification().name());
         existing.setBusinessType(generalInfo.underwritingInfo().businessType().name());
 
-        QuoteJpa saved = quoteJpaRepository.save(existing);
+        QuoteJpa saved = quoteJpaRepository.saveAndFlush(existing);
         return toDomain(saved);
     }
 

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/adapter/GeneralInfoJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/adapter/GeneralInfoJpaAdapter.java
@@ -1,0 +1,71 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.out.persistence.adapter;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.BusinessType;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.RiskClassification;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.out.GeneralInfoRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+// JPA adapter: implements GeneralInfoRepository output port using QuoteJpa from the folio context.
+// This avoids dual-entity mapping of the quotes table.
+@Component
+@RequiredArgsConstructor
+public class GeneralInfoJpaAdapter implements GeneralInfoRepository {
+
+    private final QuoteJpaRepository quoteJpaRepository;
+
+    @Override
+    public Optional<GeneralInfo> findByFolioNumber(String folioNumber) {
+        return quoteJpaRepository.findByFolioNumber(folioNumber)
+                .map(this::toDomain);
+    }
+
+    @Override
+    public GeneralInfo save(GeneralInfo generalInfo) {
+        QuoteJpa existing = quoteJpaRepository.findByFolioNumber(generalInfo.folioNumber())
+                .orElseThrow(() -> new FolioNotFoundException(generalInfo.folioNumber()));
+
+        existing.setInsuredName(generalInfo.insuredData().name());
+        existing.setInsuredRfc(generalInfo.insuredData().rfc());
+        existing.setInsuredEmail(generalInfo.insuredData().email());
+        existing.setInsuredPhone(generalInfo.insuredData().phone());
+        existing.setRiskClassification(generalInfo.underwritingInfo().riskClassification().name());
+        existing.setBusinessType(generalInfo.underwritingInfo().businessType().name());
+
+        QuoteJpa saved = quoteJpaRepository.save(existing);
+        return toDomain(saved);
+    }
+
+    private GeneralInfo toDomain(QuoteJpa jpa) {
+        return new GeneralInfo(
+                jpa.getFolioNumber(),
+                jpa.getQuoteStatus(),
+                new InsuredData(
+                        jpa.getInsuredName(),
+                        jpa.getInsuredRfc(),
+                        jpa.getInsuredEmail(),
+                        jpa.getInsuredPhone()
+                ),
+                new UnderwritingInfo(
+                        jpa.getSubscriberId(),
+                        jpa.getAgentCode(),
+                        jpa.getRiskClassification() != null
+                                ? RiskClassification.valueOf(jpa.getRiskClassification())
+                                : null,
+                        jpa.getBusinessType() != null
+                                ? BusinessType.valueOf(jpa.getBusinessType())
+                                : null
+                ),
+                jpa.getUpdatedAt(),
+                jpa.getVersion()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/config/GeneralInfoConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/config/GeneralInfoConfig.java
@@ -1,0 +1,24 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.config;
+
+import com.sofka.insurancequoter.back.generalinfo.application.usecase.GetGeneralInfoUseCaseImpl;
+import com.sofka.insurancequoter.back.generalinfo.application.usecase.UpdateGeneralInfoUseCaseImpl;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.GetGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.UpdateGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.out.GeneralInfoRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// Wires the general-info use cases with their output port implementations
+@Configuration
+public class GeneralInfoConfig {
+
+    @Bean
+    public GetGeneralInfoUseCase getGeneralInfoUseCase(GeneralInfoRepository generalInfoRepository) {
+        return new GetGeneralInfoUseCaseImpl(generalInfoRepository);
+    }
+
+    @Bean
+    public UpdateGeneralInfoUseCase updateGeneralInfoUseCase(GeneralInfoRepository generalInfoRepository) {
+        return new UpdateGeneralInfoUseCaseImpl(generalInfoRepository);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationController.java
@@ -3,6 +3,10 @@ package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest;
 import com.sofka.insurancequoter.back.location.domain.port.in.*;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.PatchLocationRequest;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.ReplaceLocationsRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationPatchWrapperResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationsListResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationsListResponseWithTimestamp;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationsSummaryWrapperResponse;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.mapper.LocationRestMapper;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.swaggerdocs.LocationApi;
 import jakarta.validation.Valid;
@@ -34,15 +38,15 @@ public class LocationController implements LocationApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<?> getLocations(@PathVariable String folio) {
+    public ResponseEntity<LocationsListResponse> getLocations(@PathVariable String folio) {
         var result = getLocationsUseCase.getLocations(folio);
         return ResponseEntity.ok(mapper.toLocationsListResponse(result));
     }
 
     @Override
     @PutMapping
-    public ResponseEntity<?> replaceLocations(@PathVariable String folio,
-                                              @RequestBody @Valid ReplaceLocationsRequest request) {
+    public ResponseEntity<LocationsListResponseWithTimestamp> replaceLocations(@PathVariable String folio,
+                                                                               @RequestBody @Valid ReplaceLocationsRequest request) {
         var command = mapper.toReplaceCommand(folio, request);
         var result = replaceLocationsUseCase.replaceLocations(command);
         return ResponseEntity.ok(mapper.toLocationsListResponseWithTimestamp(result));
@@ -51,16 +55,16 @@ public class LocationController implements LocationApi {
     // NOTE: /summary must be declared BEFORE /{index} to avoid routing conflict
     @Override
     @GetMapping("/summary")
-    public ResponseEntity<?> getLocationsSummary(@PathVariable String folio) {
+    public ResponseEntity<LocationsSummaryWrapperResponse> getLocationsSummary(@PathVariable String folio) {
         var result = getLocationsSummaryUseCase.getSummary(folio);
         return ResponseEntity.ok(mapper.toSummaryWrapperResponse(result));
     }
 
     @Override
     @PatchMapping("/{index}")
-    public ResponseEntity<?> patchLocation(@PathVariable String folio,
-                                           @PathVariable int index,
-                                           @RequestBody PatchLocationRequest request) {
+    public ResponseEntity<LocationPatchWrapperResponse> patchLocation(@PathVariable String folio,
+                                                                      @PathVariable int index,
+                                                                      @RequestBody PatchLocationRequest request) {
         var command = mapper.toPatchCommand(folio, index, request);
         var result = patchLocationUseCase.patchLocation(command);
         return ResponseEntity.ok(mapper.toPatchWrapperResponse(result));

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/swaggerdocs/LocationApi.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/swaggerdocs/LocationApi.java
@@ -2,6 +2,10 @@ package com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.s
 
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.PatchLocationRequest;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.request.ReplaceLocationsRequest;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationPatchWrapperResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationsListResponse;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationsListResponseWithTimestamp;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.in.rest.dto.response.LocationsSummaryWrapperResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -13,17 +17,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface LocationApi {
 
     @Operation(summary = "Get all locations for a quote")
-    ResponseEntity<?> getLocations(@PathVariable String folio);
+    ResponseEntity<LocationsListResponse> getLocations(@PathVariable String folio);
 
     @Operation(summary = "Replace all locations for a quote")
-    ResponseEntity<?> replaceLocations(@PathVariable String folio,
-                                       @RequestBody @Valid ReplaceLocationsRequest request);
+    ResponseEntity<LocationsListResponseWithTimestamp> replaceLocations(@PathVariable String folio,
+                                                                        @RequestBody @Valid ReplaceLocationsRequest request);
 
     @Operation(summary = "Get locations validation summary")
-    ResponseEntity<?> getLocationsSummary(@PathVariable String folio);
+    ResponseEntity<LocationsSummaryWrapperResponse> getLocationsSummary(@PathVariable String folio);
 
     @Operation(summary = "Patch a single location")
-    ResponseEntity<?> patchLocation(@PathVariable String folio,
-                                    @PathVariable int index,
-                                    @RequestBody PatchLocationRequest request);
+    ResponseEntity<LocationPatchWrapperResponse> patchLocation(@PathVariable String folio,
+                                                               @PathVariable int index,
+                                                               @RequestBody PatchLocationRequest request);
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/QuoteLayoutJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/adapter/QuoteLayoutJpaAdapter.java
@@ -46,7 +46,7 @@ public class QuoteLayoutJpaAdapter implements QuoteLayoutRepository {
         jpa.setNumberOfLocations(data.numberOfLocations());
         jpa.setLocationType(data.locationType());
 
-        QuoteJpa saved = quoteJpaRepository.save(jpa);
+        QuoteJpa saved = quoteJpaRepository.saveAndFlush(jpa);
         return mapper.toQuoteLayoutData(saved);
     }
 }

--- a/src/main/resources/db/migration/V10__add_general_info_columns_to_quotes.sql
+++ b/src/main/resources/db/migration/V10__add_general_info_columns_to_quotes.sql
@@ -1,0 +1,7 @@
+-- Add general info columns to quotes table for the general-info bounded context
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS insured_name    VARCHAR(100);
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS insured_rfc     VARCHAR(13);
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS insured_email   VARCHAR(100);
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS insured_phone   VARCHAR(20);
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS risk_classification VARCHAR(20);
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS business_type   VARCHAR(20);

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/CalculatePremiumUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/CalculatePremiumUseCaseImplTest.java
@@ -122,7 +122,8 @@ class CalculatePremiumUseCaseImplTest {
         // GIVEN
         when(quoteCalculationReader.getSnapshot(FOLIO)).thenThrow(new FolioNotFoundException(FOLIO));
         // WHEN / THEN
-        assertThatThrownBy(() -> useCase.calculate(new CalculatePremiumCommand(FOLIO, VERSION)))
+        var command = new CalculatePremiumCommand(FOLIO, VERSION);
+        assertThatThrownBy(() -> useCase.calculate(command))
                 .isInstanceOf(FolioNotFoundException.class);
     }
 
@@ -133,7 +134,8 @@ class CalculatePremiumUseCaseImplTest {
                 new QuoteCalculationSnapshot(FOLIO, 8L, List.of(completeLocation(1, BigDecimal.valueOf(1_000_000))), List.of())
         );
         // WHEN / THEN
-        assertThatThrownBy(() -> useCase.calculate(new CalculatePremiumCommand(FOLIO, VERSION)))
+        var command = new CalculatePremiumCommand(FOLIO, VERSION);
+        assertThatThrownBy(() -> useCase.calculate(command))
                 .isInstanceOf(VersionConflictException.class);
     }
 

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/CalculationControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/CalculationControllerTest.java
@@ -1,11 +1,12 @@
 package com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sofka.insurancequoter.back.calculation.application.usecase.exception.NoCalculableLocationsException;
 import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
 import com.sofka.insurancequoter.back.calculation.domain.model.CoverageBreakdown;
 import com.sofka.insurancequoter.back.calculation.domain.model.PremiumByLocation;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.AcceptQuoteUseCase;
 import com.sofka.insurancequoter.back.calculation.domain.port.in.CalculatePremiumUseCase;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.GetCalculationResultUseCase;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response.CalculationResponse;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response.CoverageBreakdownResponse;
 import com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.rest.dto.response.PremiumByLocationResponse;
@@ -43,21 +44,26 @@ class CalculationControllerTest {
     private CalculatePremiumUseCase calculatePremiumUseCase;
 
     @Mock
+    private GetCalculationResultUseCase getCalculationResultUseCase;
+
+    @Mock
+    private AcceptQuoteUseCase acceptQuoteUseCase;
+
+    @Mock
     private CalculationRestMapper calculationRestMapper;
 
     private MockMvc mockMvc;
 
     private static final String FOLIO = "FOL-2026-00042";
     private static final String URL = "/v1/quotes/" + FOLIO + "/calculate";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
-
     @BeforeEach
     void setUp() {
         LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
         validator.afterPropertiesSet();
 
         CalculationController controller = new CalculationController(
-                calculatePremiumUseCase, calculationRestMapper);
+                calculatePremiumUseCase, getCalculationResultUseCase,
+                acceptQuoteUseCase, calculationRestMapper);
 
         mockMvc = MockMvcBuilders
                 .standaloneSetup(controller)
@@ -190,7 +196,7 @@ class CalculationControllerTest {
         mockMvc.perform(post(URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"version\": 7}"))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().is(422))
                 .andExpect(jsonPath("$.code").value("NO_CALCULABLE_LOCATIONS"));
     }
 
@@ -200,7 +206,7 @@ class CalculationControllerTest {
         mockMvc.perform(post(URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"version\": null}"))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().is(422))
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
     }
 

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/http/TariffClientAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/http/TariffClientAdapterTest.java
@@ -90,7 +90,8 @@ class TariffClientAdapterTest {
                 .willReturn(serverError()));
 
         // WHEN / THEN
-        assertThatThrownBy(() -> buildAdapter().fetchTariffs())
+        var adapter = buildAdapter();
+        assertThatThrownBy(adapter::fetchTariffs)
                 .isInstanceOf(CoreServiceException.class);
     }
 
@@ -103,7 +104,8 @@ class TariffClientAdapterTest {
                 .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
         // WHEN / THEN
-        assertThatThrownBy(() -> buildAdapter().fetchTariffs())
+        var adapter = buildAdapter();
+        assertThatThrownBy(adapter::fetchTariffs)
                 .isInstanceOf(CoreServiceException.class);
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/persistence/CalculationResultJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/out/persistence/CalculationResultJpaAdapterTest.java
@@ -160,7 +160,7 @@ class CalculationResultJpaAdapterTest {
         // GIVEN
         QuoteJpa quoteJpa = buildQuoteJpa();
         when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quoteJpa));
-        when(quoteJpaRepository.save(quoteJpa)).thenReturn(quoteJpa);
+        when(quoteJpaRepository.saveAndFlush(quoteJpa)).thenReturn(quoteJpa);
         doNothing().when(calculationResultJpaRepository).deleteByQuoteId(QUOTE_ID);
 
         CalculationResultJpa savedJpa = CalculationResultJpa.builder()
@@ -170,7 +170,7 @@ class CalculationResultJpaAdapterTest {
                 .calculatedAt(Instant.now()).build();
         CalculationResult result = buildCalculationResult(true);
 
-        when(calculationPersistenceMapper.toJpa(eq(result), eq(quoteJpa))).thenReturn(savedJpa);
+        when(calculationPersistenceMapper.toJpa(result, quoteJpa)).thenReturn(savedJpa);
         when(calculationResultJpaRepository.save(savedJpa)).thenReturn(savedJpa);
         when(calculationPersistenceMapper.toPremiumByLocationJpa(any(), eq(savedJpa)))
                 .thenReturn(PremiumByLocationJpa.builder().calculable(true).locationIndex(1).build());
@@ -180,7 +180,7 @@ class CalculationResultJpaAdapterTest {
         adapter.persist(FOLIO, result);
 
         // THEN
-        verify(quoteJpaRepository).save(argThat(q -> "CALCULATED".equals(q.getQuoteStatus())));
+        verify(quoteJpaRepository).saveAndFlush(argThat(q -> "CALCULATED".equals(q.getQuoteStatus())));
         verify(calculationResultJpaRepository).save(savedJpa);
     }
 
@@ -189,7 +189,7 @@ class CalculationResultJpaAdapterTest {
         // GIVEN
         QuoteJpa quoteJpa = buildQuoteJpa();
         when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quoteJpa));
-        when(quoteJpaRepository.save(quoteJpa)).thenReturn(quoteJpa);
+        when(quoteJpaRepository.saveAndFlush(quoteJpa)).thenReturn(quoteJpa);
         doNothing().when(calculationResultJpaRepository).deleteByQuoteId(QUOTE_ID);
 
         CalculationResultJpa savedJpa = CalculationResultJpa.builder().id(2L).quote(quoteJpa)
@@ -216,7 +216,7 @@ class CalculationResultJpaAdapterTest {
         // GIVEN — result with 2 locations
         QuoteJpa quoteJpa = buildQuoteJpa();
         when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quoteJpa));
-        when(quoteJpaRepository.save(quoteJpa)).thenReturn(quoteJpa);
+        when(quoteJpaRepository.saveAndFlush(quoteJpa)).thenReturn(quoteJpa);
         doNothing().when(calculationResultJpaRepository).deleteByQuoteId(QUOTE_ID);
 
         CoverageBreakdown bd = new CoverageBreakdown(
@@ -252,7 +252,7 @@ class CalculationResultJpaAdapterTest {
         // GIVEN — result with one non-calculable location
         QuoteJpa quoteJpa = buildQuoteJpa();
         when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quoteJpa));
-        when(quoteJpaRepository.save(quoteJpa)).thenReturn(quoteJpa);
+        when(quoteJpaRepository.saveAndFlush(quoteJpa)).thenReturn(quoteJpa);
         doNothing().when(calculationResultJpaRepository).deleteByQuoteId(QUOTE_ID);
 
         CalculationResult result = buildCalculationResult(false);

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/integration/PremiumCalculationIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/integration/PremiumCalculationIntegrationTest.java
@@ -160,8 +160,6 @@ class PremiumCalculationIntegrationTest {
         QuoteJpa quote = createQuote(FOLIO);
         long version = quote.getVersion();
 
-        // TODO: persist a fully populated Location and CoverageOption via JPA before calling POST
-
         // WHEN / THEN
         mockMvc.perform(post("/v1/quotes/{folio}/calculate", FOLIO)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -188,8 +186,6 @@ class PremiumCalculationIntegrationTest {
         QuoteJpa quote = createQuote(FOLIO);
         long version = quote.getVersion();
 
-        // TODO: persist one complete and one incomplete Location via JPA
-
         // WHEN / THEN
         mockMvc.perform(post("/v1/quotes/{folio}/calculate", FOLIO)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -214,15 +210,13 @@ class PremiumCalculationIntegrationTest {
         QuoteJpa quote = createQuote(FOLIO);
         long version = quote.getVersion();
 
-        // TODO: persist a Location missing zipCode via JPA
-
         // WHEN / THEN
         mockMvc.perform(post("/v1/quotes/{folio}/calculate", FOLIO)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {"version": %d}
                                 """.formatted(version)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().is(422))
                 .andExpect(jsonPath("$.code").value("NO_CALCULABLE_LOCATIONS"));
     }
 

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImplTest.java
@@ -2,16 +2,19 @@ package com.sofka.insurancequoter.back.coverage.application.usecase;
 
 import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
 import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.ActiveGuaranteeReader;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
 import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,24 +31,42 @@ class GetCoverageOptionsUseCaseImplTest {
     @Mock
     private QuoteLookupPort quoteLookupPort;
 
-    @InjectMocks
+    @Mock
+    private ActiveGuaranteeReader activeGuaranteeReader;
+
+    // CoverageDerivationService is a pure domain class — use real instance for unit accuracy
+    private CoverageDerivationService coverageDerivationService;
+
     private GetCoverageOptionsUseCaseImpl useCase;
 
-    // --- CRITERIO-1.1: folio exists with options → returns populated list ---
+    @BeforeEach
+    void setUp() {
+        coverageDerivationService = new CoverageDerivationService();
+        useCase = new GetCoverageOptionsUseCaseImpl(
+                quoteLookupPort,
+                coverageOptionRepository,
+                activeGuaranteeReader,
+                coverageDerivationService
+        );
+    }
+
+    // --- CRITERIO-1.1: folio exists with saved options → returns persisted list ---
 
     @Test
-    void shouldReturnOptions_whenFolioExistsWithCoverageOptions() {
+    void shouldReturnPersistedOptions_whenFolioExistsWithSavedCoverageOptions() {
         // GIVEN
         String folio = "FOL-2026-00042";
+        Instant updatedAt = Instant.parse("2026-04-20T15:00:00Z");
         List<CoverageOption> options = List.of(
-                new CoverageOption("GUA-FIRE", "Incendio edificios", true,
+                new CoverageOption("COV-FIRE", "Incendio y riesgos adicionales", true,
                         new BigDecimal("2.0"), new BigDecimal("80.0")),
-                new CoverageOption("GUA-THEFT", "Robo", false,
+                new CoverageOption("COV-THEFT", "Robo con violencia", false,
                         new BigDecimal("5.0"), new BigDecimal("100.0"))
         );
         doNothing().when(quoteLookupPort).assertFolioExists(folio);
         when(coverageOptionRepository.findByFolioNumber(folio)).thenReturn(options);
         when(quoteLookupPort.getCurrentVersion(folio)).thenReturn(6L);
+        when(quoteLookupPort.getUpdatedAt(folio)).thenReturn(updatedAt);
 
         // WHEN
         CoverageOptionsResponse response = useCase.getCoverageOptions(folio);
@@ -53,36 +74,92 @@ class GetCoverageOptionsUseCaseImplTest {
         // THEN
         assertThat(response.folioNumber()).isEqualTo(folio);
         assertThat(response.coverageOptions()).hasSize(2);
-        assertThat(response.coverageOptions().get(0).code()).isEqualTo("GUA-FIRE");
+        assertThat(response.coverageOptions().get(0).code()).isEqualTo("COV-FIRE");
         assertThat(response.coverageOptions().get(0).selected()).isTrue();
-        assertThat(response.coverageOptions().get(1).code()).isEqualTo("GUA-THEFT");
-        assertThat(response.coverageOptions().get(1).selected()).isFalse();
+        assertThat(response.coverageOptions().get(1).code()).isEqualTo("COV-THEFT");
         assertThat(response.version()).isEqualTo(6L);
-        verify(quoteLookupPort).assertFolioExists(folio);
-        verify(coverageOptionRepository).findByFolioNumber(folio);
-        verify(quoteLookupPort).getCurrentVersion(folio);
+        // activeGuaranteeReader must NOT be called when options exist in DB
+        verify(activeGuaranteeReader, never()).readActiveGuaranteeCodes(any());
+        verify(activeGuaranteeReader, never()).hasCatastrophicZone(any());
     }
 
-    // --- CRITERIO-1.2: folio exists without options → returns empty list ---
+    // --- CRITERIO-1.2: folio exists with empty options → derive from guarantees ---
 
     @Test
-    void shouldReturnEmptyList_whenFolioExistsWithNoCoverageOptions() {
+    void shouldDeriveOptions_whenFolioExistsWithNoCoverageOptionsInDb() {
         // GIVEN
         String folio = "FOL-2026-00042";
+        Instant updatedAt = Instant.parse("2026-04-20T15:00:00Z");
         doNothing().when(quoteLookupPort).assertFolioExists(folio);
         when(coverageOptionRepository.findByFolioNumber(folio)).thenReturn(List.of());
+        when(activeGuaranteeReader.readActiveGuaranteeCodes(folio))
+                .thenReturn(List.of("GUA-FIRE", "GUA-THEFT"));
+        when(activeGuaranteeReader.hasCatastrophicZone(folio)).thenReturn(false);
         when(quoteLookupPort.getCurrentVersion(folio)).thenReturn(3L);
+        when(quoteLookupPort.getUpdatedAt(folio)).thenReturn(updatedAt);
 
         // WHEN
         CoverageOptionsResponse response = useCase.getCoverageOptions(folio);
 
         // THEN
         assertThat(response.folioNumber()).isEqualTo(folio);
-        assertThat(response.coverageOptions()).isEmpty();
+        assertThat(response.coverageOptions()).isNotEmpty();
+        // COV-FIRE derived from GUA-FIRE
+        assertThat(response.coverageOptions().stream().anyMatch(o -> "COV-FIRE".equals(o.code()))).isTrue();
+        // COV-THEFT derived from GUA-THEFT
+        assertThat(response.coverageOptions().stream().anyMatch(o -> "COV-THEFT".equals(o.code()))).isTrue();
+        // COV-BI always present
+        assertThat(response.coverageOptions().stream().anyMatch(o -> "COV-BI".equals(o.code()))).isTrue();
         assertThat(response.version()).isEqualTo(3L);
+        verify(activeGuaranteeReader).readActiveGuaranteeCodes(folio);
+        verify(activeGuaranteeReader).hasCatastrophicZone(folio);
     }
 
-    // --- CRITERIO-1.3: folio does not exist → throws FolioNotFoundException ---
+    // --- CRITERIO-1.3: folio has no guarantees and no cat zone → only COV-BI derived ---
+
+    @Test
+    void shouldReturnOnlyCovBi_whenDbEmptyAndNoActiveGuarantees() {
+        // GIVEN
+        String folio = "FOL-2026-00042";
+        Instant updatedAt = Instant.parse("2026-04-20T15:00:00Z");
+        doNothing().when(quoteLookupPort).assertFolioExists(folio);
+        when(coverageOptionRepository.findByFolioNumber(folio)).thenReturn(List.of());
+        when(activeGuaranteeReader.readActiveGuaranteeCodes(folio)).thenReturn(List.of());
+        when(activeGuaranteeReader.hasCatastrophicZone(folio)).thenReturn(false);
+        when(quoteLookupPort.getCurrentVersion(folio)).thenReturn(2L);
+        when(quoteLookupPort.getUpdatedAt(folio)).thenReturn(updatedAt);
+
+        // WHEN
+        CoverageOptionsResponse response = useCase.getCoverageOptions(folio);
+
+        // THEN
+        assertThat(response.coverageOptions()).hasSize(1);
+        assertThat(response.coverageOptions().get(0).code()).isEqualTo("COV-BI");
+        assertThat(response.coverageOptions().get(0).selected()).isFalse();
+    }
+
+    // --- CRITERIO-1.4: catastrophic zone triggers COV-CAT when DB is empty ---
+
+    @Test
+    void shouldIncludeCovCat_whenDbEmptyAndHasCatastrophicZone() {
+        // GIVEN
+        String folio = "FOL-2026-00042";
+        Instant updatedAt = Instant.parse("2026-04-20T15:00:00Z");
+        doNothing().when(quoteLookupPort).assertFolioExists(folio);
+        when(coverageOptionRepository.findByFolioNumber(folio)).thenReturn(List.of());
+        when(activeGuaranteeReader.readActiveGuaranteeCodes(folio)).thenReturn(List.of());
+        when(activeGuaranteeReader.hasCatastrophicZone(folio)).thenReturn(true);
+        when(quoteLookupPort.getCurrentVersion(folio)).thenReturn(2L);
+        when(quoteLookupPort.getUpdatedAt(folio)).thenReturn(updatedAt);
+
+        // WHEN
+        CoverageOptionsResponse response = useCase.getCoverageOptions(folio);
+
+        // THEN
+        assertThat(response.coverageOptions().stream().anyMatch(o -> "COV-CAT".equals(o.code()))).isTrue();
+    }
+
+    // --- CRITERIO-1.5: folio does not exist → throws FolioNotFoundException ---
 
     @Test
     void shouldThrowFolioNotFoundException_whenFolioDoesNotExist() {
@@ -94,5 +171,6 @@ class GetCoverageOptionsUseCaseImplTest {
         assertThatThrownBy(() -> useCase.getCoverageOptions(folio))
                 .isInstanceOf(FolioNotFoundException.class);
         verify(coverageOptionRepository, never()).findByFolioNumber(any());
+        verify(activeGuaranteeReader, never()).readActiveGuaranteeCodes(any());
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImplTest.java
@@ -2,12 +2,11 @@ package com.sofka.insurancequoter.back.coverage.application.usecase;
 
 import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
 import com.sofka.insurancequoter.back.coverage.application.usecase.dto.CoverageOptionsResponse;
-import com.sofka.insurancequoter.back.coverage.application.usecase.dto.GuaranteeDto;
 import com.sofka.insurancequoter.back.coverage.application.usecase.exception.InvalidCoverageCodeException;
 import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
-import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
 import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
 import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
 import org.junit.jupiter.api.Test;
@@ -19,14 +18,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-// Tests for SaveCoverageOptionsUseCaseImpl — TDD RED phase
 @ExtendWith(MockitoExtension.class)
 class SaveCoverageOptionsUseCaseImplTest {
 
@@ -37,153 +40,126 @@ class SaveCoverageOptionsUseCaseImplTest {
     private CoverageOptionRepository coverageOptionRepository;
 
     @Mock
-    private GuaranteeCatalogClient guaranteeCatalogClient;
+    private CoverageDerivationService coverageDerivationService;
 
     @InjectMocks
     private SaveCoverageOptionsUseCaseImpl useCase;
 
     private static final String FOLIO = "FOL-2026-00042";
 
-    // --- CRITERIO-2.3: version conflict → throws VersionConflictException without persisting ---
+    private static final Map<String, String> KNOWN = Map.of(
+            "COV-FIRE", "Incendio y riesgos adicionales",
+            "COV-THEFT", "Robo con violencia",
+            "COV-GLASS", "Vidrios",
+            "COV-ELEC", "Equipo electronico",
+            "COV-CAT", "Zona catastrofica",
+            "COV-BI", "Interrupcion de negocio"
+    );
 
     @Test
     void shouldThrowVersionConflictException_whenVersionDoesNotMatch() {
-        // GIVEN
         doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
         doThrow(new VersionConflictException(FOLIO, 6L, 7L))
                 .when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
         SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, List.of(), 6L);
 
-        // WHEN / THEN
         assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
                 .isInstanceOf(VersionConflictException.class);
         verify(coverageOptionRepository, never()).replaceAll(any(), any());
     }
 
-    // --- CRITERIO-2.7: folio does not exist → throws FolioNotFoundException ---
-
     @Test
     void shouldThrowFolioNotFoundException_whenFolioDoesNotExist() {
-        // GIVEN
         doThrow(new FolioNotFoundException(FOLIO)).when(quoteLookupPort).assertFolioExists(FOLIO);
         SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, List.of(), 1L);
 
-        // WHEN / THEN
         assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
                 .isInstanceOf(FolioNotFoundException.class);
         verify(coverageOptionRepository, never()).replaceAll(any(), any());
     }
 
-    // --- CRITERIO-2.4: code not in catalog → throws InvalidCoverageCodeException ---
-
     @Test
     void shouldThrowInvalidCoverageCodeException_whenCodeNotInCatalog() {
-        // GIVEN
         doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
         doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 5L);
-        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(
-                List.of(new GuaranteeDto("GUA-FIRE", "Incendio edificios", true))
-        );
+        when(coverageDerivationService.knownDescriptions()).thenReturn(KNOWN);
         CoverageOption invalid = new CoverageOption("COV-INVALID", null, true, BigDecimal.ZERO, BigDecimal.ZERO);
         SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, List.of(invalid), 5L);
 
-        // WHEN / THEN
         assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
                 .isInstanceOf(InvalidCoverageCodeException.class)
                 .hasMessageContaining("COV-INVALID");
         verify(coverageOptionRepository, never()).replaceAll(any(), any());
     }
 
-    // --- CRITERIO-2.1: successful save → returns enriched options with version+1 ---
-
     @Test
     void shouldReturnEnrichedOptions_whenSaveIsSuccessful() {
-        // GIVEN
         doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
         doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
-        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(List.of(
-                new GuaranteeDto("GUA-FIRE", "Incendio edificios", true),
-                new GuaranteeDto("GUA-THEFT", "Robo", true)
-        ));
+        when(coverageDerivationService.knownDescriptions()).thenReturn(KNOWN);
         List<CoverageOption> input = List.of(
-                new CoverageOption("GUA-FIRE", null, true, new BigDecimal("2.0"), new BigDecimal("80.0")),
-                new CoverageOption("GUA-THEFT", null, true, new BigDecimal("5.0"), new BigDecimal("100.0"))
+                new CoverageOption("COV-FIRE", null, true, new BigDecimal("2.0"), new BigDecimal("80.0")),
+                new CoverageOption("COV-THEFT", null, true, new BigDecimal("5.0"), new BigDecimal("100.0"))
         );
         List<CoverageOption> persisted = List.of(
-                new CoverageOption("GUA-FIRE", "Incendio edificios", true, new BigDecimal("2.0"), new BigDecimal("80.0")),
-                new CoverageOption("GUA-THEFT", "Robo", true, new BigDecimal("5.0"), new BigDecimal("100.0"))
+                new CoverageOption("COV-FIRE", "Incendio y riesgos adicionales", true, new BigDecimal("2.0"), new BigDecimal("80.0")),
+                new CoverageOption("COV-THEFT", "Robo con violencia", true, new BigDecimal("5.0"), new BigDecimal("100.0"))
         );
         when(coverageOptionRepository.replaceAll(eq(FOLIO), any())).thenReturn(persisted);
         when(quoteLookupPort.getCurrentVersion(FOLIO)).thenReturn(7L);
-
         SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, input, 6L);
 
-        // WHEN
         CoverageOptionsResponse response = useCase.saveCoverageOptions(command);
 
-        // THEN
         assertThat(response.folioNumber()).isEqualTo(FOLIO);
         assertThat(response.coverageOptions()).hasSize(2);
-        assertThat(response.coverageOptions().get(0).description()).isEqualTo("Incendio edificios");
-        assertThat(response.coverageOptions().get(1).description()).isEqualTo("Robo");
+        assertThat(response.coverageOptions().get(0).description()).isEqualTo("Incendio y riesgos adicionales");
+        assertThat(response.coverageOptions().get(1).description()).isEqualTo("Robo con violencia");
         assertThat(response.version()).isEqualTo(7L);
 
-        // verify the enriched list was passed to replaceAll
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<CoverageOption>> captor = ArgumentCaptor.forClass(List.class);
         verify(coverageOptionRepository).replaceAll(eq(FOLIO), captor.capture());
-        assertThat(captor.getValue().get(0).description()).isEqualTo("Incendio edificios");
-        assertThat(captor.getValue().get(1).description()).isEqualTo("Robo");
+        assertThat(captor.getValue().get(0).description()).isEqualTo("Incendio y riesgos adicionales");
+        assertThat(captor.getValue().get(1).description()).isEqualTo("Robo con violencia");
     }
-
-    // --- R-004: duplicate codes in request → throws InvalidCoverageCodeException without persisting ---
 
     @Test
     void shouldThrowInvalidCoverageCodeException_whenRequestContainsDuplicateCodes() {
-        // GIVEN — duplicate check runs before catalog fetch, so no stub needed for fetchGuarantees
         doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
         doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
         List<CoverageOption> input = List.of(
-                new CoverageOption("GUA-FIRE", null, true, BigDecimal.ZERO, BigDecimal.ZERO),
-                new CoverageOption("GUA-FIRE", null, false, BigDecimal.ZERO, BigDecimal.ZERO)
+                new CoverageOption("COV-FIRE", null, true, BigDecimal.ZERO, BigDecimal.ZERO),
+                new CoverageOption("COV-FIRE", null, false, BigDecimal.ZERO, BigDecimal.ZERO)
         );
         SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, input, 6L);
 
-        // WHEN / THEN
         assertThatThrownBy(() -> useCase.saveCoverageOptions(command))
                 .isInstanceOf(InvalidCoverageCodeException.class)
-                .hasMessageContaining("GUA-FIRE");
+                .hasMessageContaining("COV-FIRE");
         verify(coverageOptionRepository, never()).replaceAll(any(), any());
-        verify(guaranteeCatalogClient, never()).fetchGuarantees();
+        verify(coverageDerivationService, never()).knownDescriptions();
     }
-
-    // --- CRITERIO-2.2: mix of selected true/false → both states persisted correctly ---
 
     @Test
     void shouldPersistBothSelectedStates_whenMixOfTrueAndFalse() {
-        // GIVEN
         doNothing().when(quoteLookupPort).assertFolioExists(FOLIO);
         doNothing().when(quoteLookupPort).assertVersionMatches(FOLIO, 6L);
-        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(List.of(
-                new GuaranteeDto("GUA-FIRE", "Incendio edificios", true),
-                new GuaranteeDto("GUA-THEFT", "Robo", true)
-        ));
+        when(coverageDerivationService.knownDescriptions()).thenReturn(KNOWN);
         List<CoverageOption> input = List.of(
-                new CoverageOption("GUA-FIRE", null, true, BigDecimal.ZERO, BigDecimal.ZERO),
-                new CoverageOption("GUA-THEFT", null, false, BigDecimal.ZERO, BigDecimal.ZERO)
+                new CoverageOption("COV-FIRE", null, true, BigDecimal.ZERO, BigDecimal.ZERO),
+                new CoverageOption("COV-THEFT", null, false, BigDecimal.ZERO, BigDecimal.ZERO)
         );
         List<CoverageOption> persisted = List.of(
-                new CoverageOption("GUA-FIRE", "Incendio edificios", true, BigDecimal.ZERO, BigDecimal.ZERO),
-                new CoverageOption("GUA-THEFT", "Robo", false, BigDecimal.ZERO, BigDecimal.ZERO)
+                new CoverageOption("COV-FIRE", "Incendio y riesgos adicionales", true, BigDecimal.ZERO, BigDecimal.ZERO),
+                new CoverageOption("COV-THEFT", "Robo con violencia", false, BigDecimal.ZERO, BigDecimal.ZERO)
         );
         when(coverageOptionRepository.replaceAll(eq(FOLIO), any())).thenReturn(persisted);
         when(quoteLookupPort.getCurrentVersion(FOLIO)).thenReturn(7L);
         SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(FOLIO, input, 6L);
 
-        // WHEN
         CoverageOptionsResponse response = useCase.saveCoverageOptions(command);
 
-        // THEN
         assertThat(response.coverageOptions().get(0).selected()).isTrue();
         assertThat(response.coverageOptions().get(1).selected()).isFalse();
 

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/domain/service/CoverageDerivationServiceTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/domain/service/CoverageDerivationServiceTest.java
@@ -1,0 +1,229 @@
+package com.sofka.insurancequoter.back.coverage.domain.service;
+
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// TDD: RED phase — tests written before CoverageDerivationService exists
+class CoverageDerivationServiceTest {
+
+    private CoverageDerivationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CoverageDerivationService();
+    }
+
+    // --- COV-BI is always present with selected=false ---
+
+    @Test
+    void shouldIncludeCovBi_always_withSelectedFalse() {
+        // GIVEN no active guarantees and no catastrophic zone
+        List<String> activeCodes = List.of();
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        assertThat(result).isNotEmpty();
+        CoverageOption bi = findByCode(result, "COV-BI");
+        assertThat(bi).isNotNull();
+        assertThat(bi.selected()).isFalse();
+        assertThat(bi.deductiblePercentage()).isEqualByComparingTo(new BigDecimal("3.0"));
+        assertThat(bi.coinsurancePercentage()).isEqualByComparingTo(new BigDecimal("80.0"));
+    }
+
+    // --- GUA-FIRE active → COV-FIRE ---
+
+    @Test
+    void shouldIncludeCovFire_whenGuaFireIsActive() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-FIRE");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        CoverageOption fire = findByCode(result, "COV-FIRE");
+        assertThat(fire).isNotNull();
+        assertThat(fire.selected()).isTrue();
+        assertThat(fire.deductiblePercentage()).isEqualByComparingTo(new BigDecimal("2.0"));
+        assertThat(fire.coinsurancePercentage()).isEqualByComparingTo(new BigDecimal("80.0"));
+    }
+
+    // --- GUA-CONT active → COV-FIRE (same coverage) ---
+
+    @Test
+    void shouldIncludeCovFire_whenGuaContIsActive() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-CONT");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        CoverageOption fire = findByCode(result, "COV-FIRE");
+        assertThat(fire).isNotNull();
+        assertThat(fire.selected()).isTrue();
+    }
+
+    // --- GUA-FIRE and GUA-CONT both active → COV-FIRE appears only once ---
+
+    @Test
+    void shouldIncludeCovFireOnlyOnce_whenBothGuaFireAndGuaContAreActive() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-FIRE", "GUA-CONT");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        long count = result.stream().filter(o -> "COV-FIRE".equals(o.code())).count();
+        assertThat(count).isEqualTo(1);
+    }
+
+    // --- GUA-THEFT active → COV-THEFT ---
+
+    @Test
+    void shouldIncludeCovTheft_whenGuaTheftIsActive() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-THEFT");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        CoverageOption theft = findByCode(result, "COV-THEFT");
+        assertThat(theft).isNotNull();
+        assertThat(theft.selected()).isTrue();
+        assertThat(theft.deductiblePercentage()).isEqualByComparingTo(new BigDecimal("5.0"));
+        assertThat(theft.coinsurancePercentage()).isEqualByComparingTo(new BigDecimal("100.0"));
+    }
+
+    // --- GUA-GLASS active → COV-GLASS ---
+
+    @Test
+    void shouldIncludeCovGlass_whenGuaGlassIsActive() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-GLASS");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        CoverageOption glass = findByCode(result, "COV-GLASS");
+        assertThat(glass).isNotNull();
+        assertThat(glass.selected()).isTrue();
+        assertThat(glass.deductiblePercentage()).isEqualByComparingTo(new BigDecimal("5.0"));
+        assertThat(glass.coinsurancePercentage()).isEqualByComparingTo(new BigDecimal("100.0"));
+    }
+
+    // --- GUA-ELEC active → COV-ELEC ---
+
+    @Test
+    void shouldIncludeCovElec_whenGuaElecIsActive() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-ELEC");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        CoverageOption elec = findByCode(result, "COV-ELEC");
+        assertThat(elec).isNotNull();
+        assertThat(elec.selected()).isTrue();
+        assertThat(elec.deductiblePercentage()).isEqualByComparingTo(new BigDecimal("10.0"));
+        assertThat(elec.coinsurancePercentage()).isEqualByComparingTo(new BigDecimal("100.0"));
+    }
+
+    // --- hasCatZone=true → COV-CAT included ---
+
+    @Test
+    void shouldIncludeCovCat_whenHasCatastrophicZone() {
+        // GIVEN no active guarantees, but has catastrophic zone
+        List<String> activeCodes = List.of();
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, true);
+
+        // THEN
+        CoverageOption cat = findByCode(result, "COV-CAT");
+        assertThat(cat).isNotNull();
+        assertThat(cat.selected()).isTrue();
+        assertThat(cat.deductiblePercentage()).isEqualByComparingTo(new BigDecimal("3.0"));
+        assertThat(cat.coinsurancePercentage()).isEqualByComparingTo(new BigDecimal("90.0"));
+    }
+
+    // --- hasCatZone=false → COV-CAT NOT included ---
+
+    @Test
+    void shouldNotIncludeCovCat_whenNoCatastrophicZone() {
+        // GIVEN
+        List<String> activeCodes = List.of();
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        assertThat(findByCode(result, "COV-CAT")).isNull();
+    }
+
+    // --- No active codes, no cat zone → only COV-BI ---
+
+    @Test
+    void shouldReturnOnlyCovBi_whenNoActiveGuaranteesAndNoCatZone() {
+        // GIVEN
+        List<String> activeCodes = List.of();
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).code()).isEqualTo("COV-BI");
+    }
+
+    // --- Full scenario: all guarantees + cat zone → all 6 coverages ---
+
+    @Test
+    void shouldReturnAllCoverages_whenAllGuaranteesActiveAndCatZone() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-FIRE", "GUA-CONT", "GUA-THEFT", "GUA-GLASS", "GUA-ELEC");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, true);
+
+        // THEN
+        assertThat(result).hasSize(6); // COV-FIRE, COV-THEFT, COV-GLASS, COV-ELEC, COV-CAT, COV-BI
+        assertThat(result.stream().map(CoverageOption::code))
+                .containsExactlyInAnyOrder("COV-FIRE", "COV-THEFT", "COV-GLASS", "COV-ELEC", "COV-CAT", "COV-BI");
+    }
+
+    // --- Unknown guarantee codes are ignored ---
+
+    @Test
+    void shouldIgnoreUnknownGuaranteeCodes() {
+        // GIVEN
+        List<String> activeCodes = List.of("GUA-UNKNOWN", "GUA-WHATEVER");
+
+        // WHEN
+        List<CoverageOption> result = service.deriveFrom(activeCodes, false);
+
+        // THEN — only COV-BI is present
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).code()).isEqualTo("COV-BI");
+    }
+
+    // Helper
+    private CoverageOption findByCode(List<CoverageOption> options, String code) {
+        return options.stream()
+                .filter(o -> code.equals(o.code()))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/GuaranteeCatalogClientAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/http/GuaranteeCatalogClientAdapterTest.java
@@ -66,7 +66,8 @@ class GuaranteeCatalogClientAdapterTest {
                 .willReturn(serverError()));
 
         // WHEN / THEN
-        assertThatThrownBy(() -> buildAdapter().fetchGuarantees())
+        var adapter = buildAdapter();
+        assertThatThrownBy(adapter::fetchGuarantees)
                 .isInstanceOf(CoreServiceException.class)
                 .hasMessageContaining("Core service error");
     }
@@ -80,7 +81,8 @@ class GuaranteeCatalogClientAdapterTest {
                 .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
         // WHEN / THEN
-        assertThatThrownBy(() -> buildAdapter().fetchGuarantees())
+        var adapter = buildAdapter();
+        assertThatThrownBy(adapter::fetchGuarantees)
                 .isInstanceOf(CoreServiceException.class)
                 .hasMessageContaining("Core service unavailable");
     }

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/CoverageOptionJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/infrastructure/adapter/out/persistence/CoverageOptionJpaAdapterTest.java
@@ -95,7 +95,7 @@ class CoverageOptionJpaAdapterTest {
                 .coinsurancePercentage(new BigDecimal("80.0"))
                 .build();
         when(coverageOptionJpaRepository.saveAll(any())).thenReturn(List.of(savedJpa));
-        when(quoteJpaRepository.save(any())).thenReturn(quote);
+        when(quoteJpaRepository.saveAndFlush(any())).thenReturn(quote);
 
         // WHEN
         List<CoverageOption> result = adapter.replaceAll(FOLIO, List.of(option));
@@ -106,7 +106,7 @@ class CoverageOptionJpaAdapterTest {
         assertThat(result.get(0).description()).isEqualTo("Incendio edificios");
         verify(coverageOptionJpaRepository).deleteAllByQuote_Id(1L);
         verify(coverageOptionJpaRepository).saveAll(any());
-        verify(quoteJpaRepository).save(any());
+        verify(quoteJpaRepository).saveAndFlush(any());
     }
 
     // --- #186: assertFolioExists throws FolioNotFoundException when folio missing ---

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/integration/CoverageOptionsIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/integration/CoverageOptionsIntegrationTest.java
@@ -191,26 +191,31 @@ class CoverageOptionsIntegrationTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
     }
 
-    // --- #200: GET on folio with no coverage options returns 200 with empty array ---
+    // --- #200 / #251: GET on folio with no saved coverage options derives them from guarantees.
+    // The test folio has no locations, so no active guarantees -> only COV-BI is derived (always present). ---
 
     @Test
-    void shouldReturn200WithEmptyArray_whenFolioHasNoCoverageOptions() throws Exception {
+    void shouldReturn200WithDerivedCovBi_whenFolioHasNoCoverageOptionsAndNoLocations() throws Exception {
         mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                         .get("/v1/quotes/{folio}/coverage-options", FOLIO))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.folioNumber").value(FOLIO))
                 .andExpect(jsonPath("$.coverageOptions").isArray())
-                .andExpect(jsonPath("$.coverageOptions").isEmpty());
+                .andExpect(jsonPath("$.coverageOptions.length()").value(1))
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("COV-BI"))
+                .andExpect(jsonPath("$.coverageOptions[0].selected").value(false));
     }
 
-    // --- R-009: PUT with empty list deletes all existing options and returns empty array ---
+    // --- R-009 / #251: PUT with empty list deletes all persisted options.
+    // PUT response itself returns the empty list (what was saved).
+    // Subsequent GET derives from guarantees: folio has no locations -> only COV-BI is returned. ---
 
     @Test
-    void shouldReturnEmptyArray_whenPutWithEmptyCoverageOptionsList() throws Exception {
+    void shouldDeriveFromGuarantees_afterPutWithEmptyCoverageOptionsList() throws Exception {
         stubGuaranteeCatalog();
         long version = quoteJpaRepository.findByFolioNumber(FOLIO).orElseThrow().getVersion();
 
-        // First PUT: persist two options
+        // First PUT: persist one option
         mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -225,7 +230,7 @@ class CoverageOptionsIntegrationTest {
 
         long versionAfterFirstPut = quoteJpaRepository.findByFolioNumber(FOLIO).orElseThrow().getVersion();
 
-        // Second PUT: replace with empty list — all previous options should be deleted
+        // Second PUT: replace with empty list — all previous options are deleted; PUT response is empty
         mockMvc.perform(put("/v1/quotes/{folio}/coverage-options", FOLIO)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -238,10 +243,12 @@ class CoverageOptionsIntegrationTest {
                 .andExpect(jsonPath("$.coverageOptions").isArray())
                 .andExpect(jsonPath("$.coverageOptions").isEmpty());
 
-        // GET confirms no options remain
+        // GET: no persisted options -> derivation kicks in -> folio has no locations -> only COV-BI
         mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                         .get("/v1/quotes/{folio}/coverage-options", FOLIO))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.coverageOptions").isEmpty());
+                .andExpect(jsonPath("$.coverageOptions.length()").value(1))
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("COV-BI"))
+                .andExpect(jsonPath("$.coverageOptions[0].selected").value(false));
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImplTest.java
@@ -18,8 +18,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class CreateFolioUseCaseImplTest {
+
+    private static final String SUB_001 = "SUB-001";
+    private static final String SUB_999 = "SUB-999";
+    private static final String AGT_123 = "AGT-123";
+    private static final String AGT_999 = "AGT-999";
+    private static final String FOLIO = "FOL-2026-00042";
 
     @Mock
     private QuoteRepository quoteRepository;
@@ -35,9 +42,9 @@ class CreateFolioUseCaseImplTest {
     @Test
     void shouldReturnExistingQuote_whenActiveCreatedFolioAlreadyExists() {
         // GIVEN
-        var existingQuote = buildQuote("FOL-2026-00042", QuoteStatus.CREATED);
-        var command = new CreateFolioCommand("SUB-001", "AGT-123");
-        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-123"))
+        var existingQuote = buildQuote(FOLIO, QuoteStatus.CREATED);
+        var command = new CreateFolioCommand(SUB_001, AGT_123);
+        when(quoteRepository.findActiveBySubscriberAndAgent(SUB_001, AGT_123))
                 .thenReturn(Optional.of(existingQuote));
 
         // WHEN
@@ -45,7 +52,7 @@ class CreateFolioUseCaseImplTest {
 
         // THEN
         assertThat(result.created()).isFalse();
-        assertThat(result.quote().folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(result.quote().folioNumber()).isEqualTo(FOLIO);
         // Core service must NOT be called when idempotency applies
         verifyNoInteractions(coreServiceClient);
         verify(quoteRepository, never()).save(any());
@@ -56,13 +63,13 @@ class CreateFolioUseCaseImplTest {
     @Test
     void shouldCreateNewFolio_whenNoActiveFolioExistsAndReferencesAreValid() {
         // GIVEN
-        var command = new CreateFolioCommand("SUB-001", "AGT-123");
-        var savedQuote = buildQuote("FOL-2026-00042", QuoteStatus.CREATED);
-        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-123"))
+        var command = new CreateFolioCommand(SUB_001, AGT_123);
+        var savedQuote = buildQuote(FOLIO, QuoteStatus.CREATED);
+        when(quoteRepository.findActiveBySubscriberAndAgent(SUB_001, AGT_123))
                 .thenReturn(Optional.empty());
-        when(coreServiceClient.existsSubscriber("SUB-001")).thenReturn(true);
-        when(coreServiceClient.existsAgent("AGT-123")).thenReturn(true);
-        when(coreServiceClient.nextFolioNumber()).thenReturn("FOL-2026-00042");
+        when(coreServiceClient.existsSubscriber(SUB_001)).thenReturn(true);
+        when(coreServiceClient.existsAgent(AGT_123)).thenReturn(true);
+        when(coreServiceClient.nextFolioNumber()).thenReturn(FOLIO);
         when(quoteRepository.save(any())).thenReturn(savedQuote);
 
         // WHEN
@@ -70,7 +77,7 @@ class CreateFolioUseCaseImplTest {
 
         // THEN
         assertThat(result.created()).isTrue();
-        assertThat(result.quote().folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(result.quote().folioNumber()).isEqualTo(FOLIO);
         assertThat(result.quote().quoteStatus()).isEqualTo(QuoteStatus.CREATED);
         verify(quoteRepository).save(any(Quote.class));
     }
@@ -80,10 +87,10 @@ class CreateFolioUseCaseImplTest {
     @Test
     void shouldThrowInvalidReferenceException_whenSubscriberDoesNotExist() {
         // GIVEN
-        var command = new CreateFolioCommand("SUB-999", "AGT-123");
-        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-999", "AGT-123"))
+        var command = new CreateFolioCommand(SUB_999, AGT_123);
+        when(quoteRepository.findActiveBySubscriberAndAgent(SUB_999, AGT_123))
                 .thenReturn(Optional.empty());
-        when(coreServiceClient.existsSubscriber("SUB-999")).thenReturn(false);
+        when(coreServiceClient.existsSubscriber(SUB_999)).thenReturn(false);
 
         // WHEN / THEN
         assertThatThrownBy(() -> useCase.createFolio(command))
@@ -97,11 +104,11 @@ class CreateFolioUseCaseImplTest {
     @Test
     void shouldThrowInvalidReferenceException_whenAgentDoesNotExist() {
         // GIVEN
-        var command = new CreateFolioCommand("SUB-001", "AGT-999");
-        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-999"))
+        var command = new CreateFolioCommand(SUB_001, AGT_999);
+        when(quoteRepository.findActiveBySubscriberAndAgent(SUB_001, AGT_999))
                 .thenReturn(Optional.empty());
-        when(coreServiceClient.existsSubscriber("SUB-001")).thenReturn(true);
-        when(coreServiceClient.existsAgent("AGT-999")).thenReturn(false);
+        when(coreServiceClient.existsSubscriber(SUB_001)).thenReturn(true);
+        when(coreServiceClient.existsAgent(AGT_999)).thenReturn(false);
 
         // WHEN / THEN
         assertThatThrownBy(() -> useCase.createFolio(command))
@@ -114,12 +121,12 @@ class CreateFolioUseCaseImplTest {
     @Test
     void shouldCreateNewFolio_whenExistingFolioIsInProgress() {
         // GIVEN — repository returns empty (only CREATED status is considered active for idempotency)
-        var command = new CreateFolioCommand("SUB-001", "AGT-123");
+        var command = new CreateFolioCommand(SUB_001, AGT_123);
         var savedQuote = buildQuote("FOL-2026-00099", QuoteStatus.CREATED);
-        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-001", "AGT-123"))
+        when(quoteRepository.findActiveBySubscriberAndAgent(SUB_001, AGT_123))
                 .thenReturn(Optional.empty());
-        when(coreServiceClient.existsSubscriber("SUB-001")).thenReturn(true);
-        when(coreServiceClient.existsAgent("AGT-123")).thenReturn(true);
+        when(coreServiceClient.existsSubscriber(SUB_001)).thenReturn(true);
+        when(coreServiceClient.existsAgent(AGT_123)).thenReturn(true);
         when(coreServiceClient.nextFolioNumber()).thenReturn("FOL-2026-00099");
         when(quoteRepository.save(any())).thenReturn(savedQuote);
 
@@ -137,8 +144,8 @@ class CreateFolioUseCaseImplTest {
         return new Quote(
                 folioNumber,
                 status,
-                "SUB-001",
-                "AGT-123",
+                SUB_001,
+                AGT_123,
                 1L,
                 Instant.parse("2026-04-20T14:30:00Z"),
                 Instant.parse("2026-04-20T14:30:00Z")

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
@@ -30,8 +30,14 @@ class GetQuoteStateUseCaseImplTest {
 
     private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
 
+    // hasGeneralInfo = false (insured_name null)
     private QuoteSnapshot snapshot(String status, Integer numLocations, String locationType) {
-        return new QuoteSnapshot("FOL-001", status, numLocations, locationType, 3L, NOW);
+        return new QuoteSnapshot("FOL-001", status, numLocations, locationType, 3L, NOW, false);
+    }
+
+    // hasGeneralInfo = true (insured_name present)
+    private QuoteSnapshot snapshotWithGeneralInfo(String status, Integer numLocations, String locationType) {
+        return new QuoteSnapshot("FOL-001", status, numLocations, locationType, 3L, NOW, true);
     }
 
     @Test
@@ -102,7 +108,7 @@ class GetQuoteStateUseCaseImplTest {
 
     @Test
     void getState_whenGeneralInfoFieldsNull_returnsGeneralInfoPending() {
-        // GIVEN — general-info not yet implemented
+        // GIVEN — insured_name is null → hasGeneralInfo = false
         when(quoteStateQuery.findByFolioNumber("FOL-001"))
                 .thenReturn(snapshot("IN_PROGRESS", 3, "MULTIPLE"));
         when(locationStateReader.readByFolioNumber("FOL-001"))
@@ -111,8 +117,23 @@ class GetQuoteStateUseCaseImplTest {
         // WHEN
         QuoteState state = useCase.getState("FOL-001");
 
-        // THEN — generalInfo and coverageOptions always PENDING until their specs are implemented
+        // THEN
         assertThat(state.sections().generalInfo()).isEqualTo(SectionStatus.PENDING);
         assertThat(state.sections().coverageOptions()).isEqualTo(SectionStatus.PENDING);
+    }
+
+    @Test
+    void getState_whenGeneralInfoSaved_returnsGeneralInfoComplete() {
+        // GIVEN — insured_name is present → hasGeneralInfo = true
+        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+                .thenReturn(snapshotWithGeneralInfo("IN_PROGRESS", 3, "MULTIPLE"));
+        when(locationStateReader.readByFolioNumber("FOL-001"))
+                .thenReturn(new LocationStateSummary(0, 0, 0));
+
+        // WHEN
+        QuoteState state = useCase.getState("FOL-001");
+
+        // THEN
+        assertThat(state.sections().generalInfo()).isEqualTo(SectionStatus.COMPLETE);
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
@@ -74,7 +74,7 @@ class GetQuoteStateUseCaseImplTest {
         QuoteState state = useCase.getState("FOL-001");
 
         // THEN
-        assertThat(state.completionPercentage()).isEqualTo(0);
+        assertThat(state.completionPercentage()).isZero();
         assertThat(state.sections().layout()).isEqualTo(SectionStatus.PENDING);
         assertThat(state.sections().locations()).isEqualTo(SectionStatus.PENDING);
     }

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImplTest.java
@@ -1,6 +1,7 @@
 package com.sofka.insurancequoter.back.folio.application.usecase;
 
 import com.sofka.insurancequoter.back.folio.domain.model.*;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoverageOptionsStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
 import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
@@ -25,34 +26,38 @@ class GetQuoteStateUseCaseImplTest {
     @Mock
     private LocationStateReader locationStateReader;
 
+    @Mock
+    private CoverageOptionsStateReader coverageOptionsStateReader;
+
     @InjectMocks
     private GetQuoteStateUseCaseImpl useCase;
 
+    private static final String FOLIO = "FOL-001";
     private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
 
-    // hasGeneralInfo = false (insured_name null)
     private QuoteSnapshot snapshot(String status, Integer numLocations, String locationType) {
-        return new QuoteSnapshot("FOL-001", status, numLocations, locationType, 3L, NOW, false);
+        return new QuoteSnapshot(FOLIO, status, numLocations, locationType, 3L, NOW, false);
     }
 
-    // hasGeneralInfo = true (insured_name present)
     private QuoteSnapshot snapshotWithGeneralInfo(String status, Integer numLocations, String locationType) {
-        return new QuoteSnapshot("FOL-001", status, numLocations, locationType, 3L, NOW, true);
+        return new QuoteSnapshot(FOLIO, status, numLocations, locationType, 3L, NOW, true);
     }
 
     @Test
     void getState_withLayoutCompleteAndOneIncompleteLocation_returnsPartialProgress() {
         // GIVEN — layout COMPLETE, one incomplete location → 1/5 = 20%
-        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+        when(quoteStateQuery.findByFolioNumber(FOLIO))
                 .thenReturn(snapshot("IN_PROGRESS", 2, "MULTIPLE"));
-        when(locationStateReader.readByFolioNumber("FOL-001"))
-                .thenReturn(new LocationStateSummary(2, 1, 1)); // 1 complete, 1 incomplete
+        when(locationStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(new LocationStateSummary(2, 1, 1));
+        when(coverageOptionsStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(SectionStatus.PENDING);
 
         // WHEN
-        QuoteState state = useCase.getState("FOL-001");
+        QuoteState state = useCase.getState(FOLIO);
 
         // THEN
-        assertThat(state.folioNumber()).isEqualTo("FOL-001");
+        assertThat(state.folioNumber()).isEqualTo(FOLIO);
         assertThat(state.quoteStatus()).isEqualTo("IN_PROGRESS");
         assertThat(state.sections().layout()).isEqualTo(SectionStatus.COMPLETE);
         assertThat(state.sections().locations()).isEqualTo(SectionStatus.INCOMPLETE);
@@ -64,14 +69,16 @@ class GetQuoteStateUseCaseImplTest {
 
     @Test
     void getState_withFreshFolio_returnsZeroPercentage() {
-        // GIVEN — no layout, no locations
-        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+        // GIVEN — no layout, no locations, no coverage options
+        when(quoteStateQuery.findByFolioNumber(FOLIO))
                 .thenReturn(snapshot("CREATED", null, null));
-        when(locationStateReader.readByFolioNumber("FOL-001"))
+        when(locationStateReader.readByFolioNumber(FOLIO))
                 .thenReturn(new LocationStateSummary(0, 0, 0));
+        when(coverageOptionsStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(SectionStatus.PENDING);
 
         // WHEN
-        QuoteState state = useCase.getState("FOL-001");
+        QuoteState state = useCase.getState(FOLIO);
 
         // THEN
         assertThat(state.completionPercentage()).isZero();
@@ -82,13 +89,15 @@ class GetQuoteStateUseCaseImplTest {
     @Test
     void getState_withCalculatedFolio_returns100Percent() {
         // GIVEN — quoteStatus = CALCULATED → forced 100%
-        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+        when(quoteStateQuery.findByFolioNumber(FOLIO))
                 .thenReturn(snapshot("CALCULATED", 2, "MULTIPLE"));
-        when(locationStateReader.readByFolioNumber("FOL-001"))
+        when(locationStateReader.readByFolioNumber(FOLIO))
                 .thenReturn(new LocationStateSummary(2, 2, 0));
+        when(coverageOptionsStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(SectionStatus.COMPLETE);
 
         // WHEN
-        QuoteState state = useCase.getState("FOL-001");
+        QuoteState state = useCase.getState(FOLIO);
 
         // THEN
         assertThat(state.completionPercentage()).isEqualTo(100);
@@ -109,13 +118,15 @@ class GetQuoteStateUseCaseImplTest {
     @Test
     void getState_whenGeneralInfoFieldsNull_returnsGeneralInfoPending() {
         // GIVEN — insured_name is null → hasGeneralInfo = false
-        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+        when(quoteStateQuery.findByFolioNumber(FOLIO))
                 .thenReturn(snapshot("IN_PROGRESS", 3, "MULTIPLE"));
-        when(locationStateReader.readByFolioNumber("FOL-001"))
+        when(locationStateReader.readByFolioNumber(FOLIO))
                 .thenReturn(new LocationStateSummary(3, 3, 0));
+        when(coverageOptionsStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(SectionStatus.PENDING);
 
         // WHEN
-        QuoteState state = useCase.getState("FOL-001");
+        QuoteState state = useCase.getState(FOLIO);
 
         // THEN
         assertThat(state.sections().generalInfo()).isEqualTo(SectionStatus.PENDING);
@@ -125,15 +136,52 @@ class GetQuoteStateUseCaseImplTest {
     @Test
     void getState_whenGeneralInfoSaved_returnsGeneralInfoComplete() {
         // GIVEN — insured_name is present → hasGeneralInfo = true
-        when(quoteStateQuery.findByFolioNumber("FOL-001"))
+        when(quoteStateQuery.findByFolioNumber(FOLIO))
                 .thenReturn(snapshotWithGeneralInfo("IN_PROGRESS", 3, "MULTIPLE"));
-        when(locationStateReader.readByFolioNumber("FOL-001"))
+        when(locationStateReader.readByFolioNumber(FOLIO))
                 .thenReturn(new LocationStateSummary(0, 0, 0));
+        when(coverageOptionsStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(SectionStatus.PENDING);
 
         // WHEN
-        QuoteState state = useCase.getState("FOL-001");
+        QuoteState state = useCase.getState(FOLIO);
 
         // THEN
         assertThat(state.sections().generalInfo()).isEqualTo(SectionStatus.COMPLETE);
+    }
+
+    @Test
+    void getState_whenCoverageOptionsInProgress_returnsCoverageOptionsInProgress() {
+        // GIVEN — options saved but none selected
+        when(quoteStateQuery.findByFolioNumber(FOLIO))
+                .thenReturn(snapshot("IN_PROGRESS", 2, "MULTIPLE"));
+        when(locationStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(new LocationStateSummary(2, 2, 0));
+        when(coverageOptionsStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(SectionStatus.IN_PROGRESS);
+
+        // WHEN
+        QuoteState state = useCase.getState(FOLIO);
+
+        // THEN
+        assertThat(state.sections().coverageOptions()).isEqualTo(SectionStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void getState_whenCoverageOptionsComplete_countedInPercentage() {
+        // GIVEN — layout + locations + coverageOptions all COMPLETE → 3/5 = 60%
+        when(quoteStateQuery.findByFolioNumber(FOLIO))
+                .thenReturn(snapshotWithGeneralInfo("IN_PROGRESS", 2, "MULTIPLE"));
+        when(locationStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(new LocationStateSummary(2, 2, 0));
+        when(coverageOptionsStateReader.readByFolioNumber(FOLIO))
+                .thenReturn(SectionStatus.COMPLETE);
+
+        // WHEN
+        QuoteState state = useCase.getState(FOLIO);
+
+        // THEN — generalInfo + layout + locations + coverageOptions = 4 COMPLETE → 80%
+        assertThat(state.sections().coverageOptions()).isEqualTo(SectionStatus.COMPLETE);
+        assertThat(state.completionPercentage()).isEqualTo(80);
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImplTest.java
@@ -1,0 +1,169 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.FolioRaw;
+import com.sofka.insurancequoter.back.folio.domain.model.FolioSummary;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteState;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteSections;
+import com.sofka.insurancequoter.back.folio.domain.model.SectionStatus;
+import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.FolioListQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ListFoliosUseCaseImplTest {
+
+    @Mock
+    private FolioListQuery folioListQuery;
+
+    @Mock
+    private GetQuoteStateUseCase getQuoteStateUseCase;
+
+    @Mock
+    private CoreServiceClient coreServiceClient;
+
+    private ListFoliosUseCase useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-20T10:00:00Z");
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ListFoliosUseCaseImpl(folioListQuery, getQuoteStateUseCase, coreServiceClient);
+    }
+
+    // --- Happy path: lista con un folio ---
+
+    @Test
+    void shouldReturnFolioSummaries_whenFoliosExist() {
+        // GIVEN
+        FolioRaw raw = new FolioRaw("FOL-2026-00001", "Empresa Alfa SA de CV",
+                "AGT-001", "CREATED", 1, NOW);
+        when(folioListQuery.findAll()).thenReturn(List.of(raw));
+        when(coreServiceClient.getAgentName("AGT-001")).thenReturn("Carlos López");
+
+        QuoteState state = buildState("FOL-2026-00001", 10);
+        when(getQuoteStateUseCase.getState("FOL-2026-00001")).thenReturn(state);
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        FolioSummary summary = result.get(0);
+        assertThat(summary.folioNumber()).isEqualTo("FOL-2026-00001");
+        assertThat(summary.client()).isEqualTo("Empresa Alfa SA de CV");
+        assertThat(summary.agentCode()).isEqualTo("AGT-001");
+        assertThat(summary.agentName()).isEqualTo("Carlos López");
+        assertThat(summary.status()).isEqualTo("CREATED");
+        assertThat(summary.locationCount()).isEqualTo(1);
+        assertThat(summary.completionPct()).isEqualTo(10);
+        assertThat(summary.commercialPremium()).isNull();
+        assertThat(summary.updatedAt()).isEqualTo(NOW);
+    }
+
+    // --- Empty list ---
+
+    @Test
+    void shouldReturnEmptyList_whenNoFoliosExist() {
+        // GIVEN
+        when(folioListQuery.findAll()).thenReturn(List.of());
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    // --- Null insuredName maps to null client ---
+
+    @Test
+    void shouldReturnNullClient_whenInsuredNameIsNull() {
+        // GIVEN
+        FolioRaw raw = new FolioRaw("FOL-2026-00002", null, "AGT-002", "CREATED", 0, NOW);
+        when(folioListQuery.findAll()).thenReturn(List.of(raw));
+        when(coreServiceClient.getAgentName("AGT-002")).thenReturn("Ana Gómez");
+        when(getQuoteStateUseCase.getState("FOL-2026-00002")).thenReturn(buildState("FOL-2026-00002", 0));
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).client()).isNull();
+    }
+
+    // --- Null numberOfLocations falls back to 0 ---
+
+    @Test
+    void shouldReturnZeroLocationCount_whenNumberOfLocationsIsNull() {
+        // GIVEN
+        FolioRaw raw = new FolioRaw("FOL-2026-00003", "Corp X", "AGT-003", "CREATED", 0, NOW);
+        when(folioListQuery.findAll()).thenReturn(List.of(raw));
+        when(coreServiceClient.getAgentName("AGT-003")).thenReturn("Pedro Ruiz");
+        when(getQuoteStateUseCase.getState("FOL-2026-00003")).thenReturn(buildState("FOL-2026-00003", 0));
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result.get(0).locationCount()).isZero();
+    }
+
+    // --- Core service unavailable: agentName falls back to null, does not crash ---
+
+    @Test
+    void shouldReturnNullAgentName_whenCoreServiceThrows() {
+        // GIVEN
+        FolioRaw raw = new FolioRaw("FOL-2026-00004", "Corp Y", "AGT-004", "CREATED", 1, NOW);
+        when(folioListQuery.findAll()).thenReturn(List.of(raw));
+        when(coreServiceClient.getAgentName("AGT-004"))
+                .thenThrow(new CoreServiceException("Core unavailable"));
+        when(getQuoteStateUseCase.getState("FOL-2026-00004")).thenReturn(buildState("FOL-2026-00004", 10));
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).agentName()).isNull();
+    }
+
+    // --- completionPct comes from GetQuoteStateUseCase ---
+
+    @Test
+    void shouldUseCompletionPctFromGetQuoteStateUseCase() {
+        // GIVEN
+        FolioRaw raw = new FolioRaw("FOL-2026-00005", "Corp Z", "AGT-005", "IN_PROGRESS", 2, NOW);
+        when(folioListQuery.findAll()).thenReturn(List.of(raw));
+        when(coreServiceClient.getAgentName("AGT-005")).thenReturn("Laura Vega");
+        when(getQuoteStateUseCase.getState("FOL-2026-00005")).thenReturn(buildState("FOL-2026-00005", 60));
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result.get(0).completionPct()).isEqualTo(60);
+    }
+
+    // --- Helper ---
+
+    private QuoteState buildState(String folioNumber, int completionPct) {
+        QuoteSections sections = new QuoteSections(
+                SectionStatus.PENDING, SectionStatus.PENDING,
+                SectionStatus.PENDING, SectionStatus.PENDING, SectionStatus.PENDING);
+        return new QuoteState(folioNumber, "CREATED", completionPct, sections, 1L, NOW);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioControllerTest.java
@@ -5,6 +5,8 @@ import com.sofka.insurancequoter.back.folio.application.usecase.InvalidReference
 import com.sofka.insurancequoter.back.folio.domain.model.Quote;
 import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
 import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioListRestMapper;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,9 @@ class FolioControllerTest {
     @Mock
     private CreateFolioUseCase createFolioUseCase;
 
+    @Mock
+    private ListFoliosUseCase listFoliosUseCase;
+
     private MockMvc mockMvc;
 
     private static final Instant FIXED = Instant.parse("2026-04-20T14:30:00Z");
@@ -40,7 +45,9 @@ class FolioControllerTest {
         validator.afterPropertiesSet();
 
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new FolioController(createFolioUseCase, new FolioRestMapper()))
+                .standaloneSetup(new FolioController(
+                        createFolioUseCase, listFoliosUseCase,
+                        new FolioRestMapper(), new FolioListRestMapper()))
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .setValidator(validator)
                 .build();

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioListControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/in/rest/FolioListControllerTest.java
@@ -1,0 +1,85 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.domain.model.FolioSummary;
+import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
+import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioListRestMapper;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class FolioListControllerTest {
+
+    @Mock
+    private ListFoliosUseCase listFoliosUseCase;
+
+    @Mock
+    private CreateFolioUseCase createFolioUseCase;
+
+    private MockMvc mockMvc;
+
+    private static final Instant NOW = Instant.parse("2026-04-20T10:00:00Z");
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new FolioController(
+                        createFolioUseCase, listFoliosUseCase,
+                        new FolioRestMapper(), new FolioListRestMapper()))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    // --- Happy path: returns list with one folio ---
+
+    @Test
+    void shouldReturn200WithFolioList_whenFoliosExist() throws Exception {
+        // GIVEN
+        FolioSummary summary = new FolioSummary(
+                "FOL-2026-00001", "Empresa Alfa SA de CV",
+                "AGT-001", "Carlos López",
+                "CREATED", 1, 10, null, NOW);
+        when(listFoliosUseCase.listFolios()).thenReturn(List.of(summary));
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/folios"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folios").isArray())
+                .andExpect(jsonPath("$.folios[0].folioNumber").value("FOL-2026-00001"))
+                .andExpect(jsonPath("$.folios[0].client").value("Empresa Alfa SA de CV"))
+                .andExpect(jsonPath("$.folios[0].agentCode").value("AGT-001"))
+                .andExpect(jsonPath("$.folios[0].agentName").value("Carlos López"))
+                .andExpect(jsonPath("$.folios[0].status").value("CREATED"))
+                .andExpect(jsonPath("$.folios[0].locationCount").value(1))
+                .andExpect(jsonPath("$.folios[0].completionPct").value(10))
+                .andExpect(jsonPath("$.folios[0].commercialPremium").doesNotExist());
+    }
+
+    // --- Empty list ---
+
+    @Test
+    void shouldReturn200WithEmptyList_whenNoFoliosExist() throws Exception {
+        // GIVEN
+        when(listFoliosUseCase.listFolios()).thenReturn(List.of());
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/folios"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folios").isArray())
+                .andExpect(jsonPath("$.folios").isEmpty());
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/CoreServiceClientAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/http/CoreServiceClientAdapterTest.java
@@ -10,6 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("java:S100")
 class CoreServiceClientAdapterTest {
 
     @RegisterExtension

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/CoverageOptionsStateJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/CoverageOptionsStateJpaAdapterTest.java
@@ -1,0 +1,92 @@
+package com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.entities.CoverageOptionJpa;
+import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
+import com.sofka.insurancequoter.back.folio.domain.model.SectionStatus;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.adapter.CoverageOptionsStateJpaAdapter;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CoverageOptionsStateJpaAdapterTest {
+
+    @Mock private QuoteJpaRepository quoteJpaRepository;
+    @Mock private CoverageOptionJpaRepository coverageOptionJpaRepository;
+
+    private CoverageOptionsStateJpaAdapter adapter;
+
+    private static final String FOLIO = "FOL-2026-00042";
+    private static final Long QUOTE_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new CoverageOptionsStateJpaAdapter(quoteJpaRepository, coverageOptionJpaRepository);
+    }
+
+    private QuoteJpa buildQuoteJpa() {
+        return QuoteJpa.builder()
+                .id(QUOTE_ID).folioNumber(FOLIO).quoteStatus("IN_PROGRESS")
+                .subscriberId("SUB-001").agentCode("AGT-001").version(1L)
+                .createdAt(Instant.now()).updatedAt(Instant.now())
+                .build();
+    }
+
+    @Test
+    void readByFolioNumber_returnsPending_whenFolioNotFound() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.empty());
+
+        // WHEN / THEN
+        assertThat(adapter.readByFolioNumber(FOLIO)).isEqualTo(SectionStatus.PENDING);
+    }
+
+    @Test
+    void readByFolioNumber_returnsPending_whenNoOptionsExist() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(buildQuoteJpa()));
+        when(coverageOptionJpaRepository.findAllByQuote_Id(QUOTE_ID)).thenReturn(List.of());
+
+        // WHEN / THEN
+        assertThat(adapter.readByFolioNumber(FOLIO)).isEqualTo(SectionStatus.PENDING);
+    }
+
+    @Test
+    void readByFolioNumber_returnsInProgress_whenOptionsExistButNoneSelected() {
+        // GIVEN
+        QuoteJpa quote = buildQuoteJpa();
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quote));
+        CoverageOptionJpa unselected = CoverageOptionJpa.builder()
+                .id(1L).quote(quote).code("FIRE").selected(false).build();
+        when(coverageOptionJpaRepository.findAllByQuote_Id(QUOTE_ID)).thenReturn(List.of(unselected));
+
+        // WHEN / THEN
+        assertThat(adapter.readByFolioNumber(FOLIO)).isEqualTo(SectionStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void readByFolioNumber_returnsComplete_whenAtLeastOneOptionSelected() {
+        // GIVEN
+        QuoteJpa quote = buildQuoteJpa();
+        when(quoteJpaRepository.findByFolioNumber(FOLIO)).thenReturn(Optional.of(quote));
+        CoverageOptionJpa selected = CoverageOptionJpa.builder()
+                .id(1L).quote(quote).code("FIRE").selected(true).build();
+        CoverageOptionJpa unselected = CoverageOptionJpa.builder()
+                .id(2L).quote(quote).code("CAT").selected(false).build();
+        when(coverageOptionJpaRepository.findAllByQuote_Id(QUOTE_ID)).thenReturn(List.of(selected, unselected));
+
+        // WHEN / THEN
+        assertThat(adapter.readByFolioNumber(FOLIO)).isEqualTo(SectionStatus.COMPLETE);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/LocationStateJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/LocationStateJpaAdapterTest.java
@@ -62,9 +62,9 @@ class LocationStateJpaAdapterTest {
         LocationStateSummary result = adapter.readByFolioNumber("FOL-001");
 
         // THEN
-        assertThat(result.total()).isEqualTo(0);
-        assertThat(result.completeCount()).isEqualTo(0);
-        assertThat(result.incompleteCount()).isEqualTo(0);
+        assertThat(result.total()).isZero();
+        assertThat(result.completeCount()).isZero();
+        assertThat(result.incompleteCount()).isZero();
     }
 
     @Test
@@ -95,6 +95,6 @@ class LocationStateJpaAdapterTest {
         LocationStateSummary result = adapter.readByFolioNumber("UNKNOWN");
 
         // THEN
-        assertThat(result.total()).isEqualTo(0);
+        assertThat(result.total()).isZero();
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/QuoteJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/QuoteJpaAdapterTest.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +50,7 @@ class QuoteJpaAdapterTest {
         // THEN
         assertThat(result).isEmpty();
         verify(jpaRepository).findBySubscriberIdAndAgentCodeAndQuoteStatus(
-                eq("SUB-001"), eq("AGT-123"), eq("CREATED"));
+                "SUB-001", "AGT-123", "CREATED");
     }
 
     // --- save ---

--- a/src/test/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/GetGeneralInfoUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/GetGeneralInfoUseCaseImplTest.java
@@ -1,0 +1,74 @@
+package com.sofka.insurancequoter.back.generalinfo.application.usecase;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.RiskClassification;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.BusinessType;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.out.GeneralInfoRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetGeneralInfoUseCaseImplTest {
+
+    @Mock
+    private GeneralInfoRepository generalInfoRepository;
+
+    @InjectMocks
+    private GetGeneralInfoUseCaseImpl useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-23T19:55:12Z");
+
+    private GeneralInfo buildGeneralInfo() {
+        return new GeneralInfo(
+                "FOL-2026-00001",
+                "CREATED",
+                new InsuredData("Empresa SA", "EMP123456ABC", "empresa@test.com", "5551234567"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                NOW,
+                1L
+        );
+    }
+
+    @Test
+    void getGeneralInfo_whenFolioExists_returnsGeneralInfo() {
+        // GIVEN
+        when(generalInfoRepository.findByFolioNumber("FOL-2026-00001"))
+                .thenReturn(Optional.of(buildGeneralInfo()));
+
+        // WHEN
+        GeneralInfo result = useCase.getGeneralInfo("FOL-2026-00001");
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-2026-00001");
+        assertThat(result.quoteStatus()).isEqualTo("CREATED");
+        assertThat(result.insuredData().name()).isEqualTo("Empresa SA");
+        assertThat(result.insuredData().rfc()).isEqualTo("EMP123456ABC");
+        assertThat(result.underwritingInfo().subscriberId()).isEqualTo("SUB-001");
+        assertThat(result.underwritingInfo().riskClassification()).isEqualTo(RiskClassification.STANDARD);
+        assertThat(result.version()).isEqualTo(1L);
+    }
+
+    @Test
+    void getGeneralInfo_whenFolioNotFound_throwsFolioNotFoundException() {
+        // GIVEN
+        when(generalInfoRepository.findByFolioNumber("UNKNOWN"))
+                .thenReturn(Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.getGeneralInfo("UNKNOWN"))
+                .isInstanceOf(FolioNotFoundException.class);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoUseCaseImplTest.java
@@ -87,13 +87,13 @@ class UpdateGeneralInfoUseCaseImplTest {
                 .thenReturn(Optional.empty());
 
         // WHEN / THEN
-        assertThatThrownBy(() -> useCase.updateGeneralInfo(
-                new UpdateGeneralInfoCommand(
-                        "UNKNOWN",
-                        new InsuredData("N", "X", "x@x.com", "1"),
-                        new UnderwritingInfo("S", "A", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
-                        0L
-                )))
+        var command = new UpdateGeneralInfoCommand(
+                "UNKNOWN",
+                new InsuredData("N", "X", "x@x.com", "1"),
+                new UnderwritingInfo("S", "A", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                0L
+        );
+        assertThatThrownBy(() -> useCase.updateGeneralInfo(command))
                 .isInstanceOf(FolioNotFoundException.class);
     }
 
@@ -104,7 +104,8 @@ class UpdateGeneralInfoUseCaseImplTest {
                 .thenReturn(Optional.of(storedGeneralInfo(2L)));
 
         // WHEN / THEN
-        assertThatThrownBy(() -> useCase.updateGeneralInfo(buildCommand(1L)))
+        var command = buildCommand(1L);
+        assertThatThrownBy(() -> useCase.updateGeneralInfo(command))
                 .isInstanceOf(VersionConflictException.class);
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/generalinfo/application/usecase/UpdateGeneralInfoUseCaseImplTest.java
@@ -1,0 +1,110 @@
+package com.sofka.insurancequoter.back.generalinfo.application.usecase;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.BusinessType;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.RiskClassification;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.out.GeneralInfoRepository;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateGeneralInfoUseCaseImplTest {
+
+    @Mock
+    private GeneralInfoRepository generalInfoRepository;
+
+    @InjectMocks
+    private UpdateGeneralInfoUseCaseImpl useCase;
+
+    private static final Instant NOW = Instant.parse("2026-04-23T19:55:12Z");
+
+    private GeneralInfo storedGeneralInfo(Long version) {
+        return new GeneralInfo(
+                "FOL-2026-00001",
+                "CREATED",
+                new InsuredData("Old Name", "OLD123456ABC", "old@test.com", "5550000000"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                NOW,
+                version
+        );
+    }
+
+    private UpdateGeneralInfoCommand buildCommand(Long version) {
+        return new UpdateGeneralInfoCommand(
+                "FOL-2026-00001",
+                new InsuredData("Empresa SA", "EMP123456ABC", "empresa@test.com", "5551234567"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                version
+        );
+    }
+
+    @Test
+    void updateGeneralInfo_whenVersionMatches_returnsUpdatedGeneralInfo() {
+        // GIVEN
+        when(generalInfoRepository.findByFolioNumber("FOL-2026-00001"))
+                .thenReturn(Optional.of(storedGeneralInfo(1L)));
+
+        GeneralInfo savedResult = new GeneralInfo(
+                "FOL-2026-00001",
+                "CREATED",
+                new InsuredData("Empresa SA", "EMP123456ABC", "empresa@test.com", "5551234567"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                NOW,
+                2L
+        );
+        when(generalInfoRepository.save(any())).thenReturn(savedResult);
+
+        // WHEN
+        GeneralInfo result = useCase.updateGeneralInfo(buildCommand(1L));
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-2026-00001");
+        assertThat(result.insuredData().name()).isEqualTo("Empresa SA");
+        assertThat(result.insuredData().rfc()).isEqualTo("EMP123456ABC");
+        assertThat(result.underwritingInfo().riskClassification()).isEqualTo(RiskClassification.STANDARD);
+        assertThat(result.version()).isEqualTo(2L);
+    }
+
+    @Test
+    void updateGeneralInfo_whenFolioNotFound_throwsFolioNotFoundException() {
+        // GIVEN
+        when(generalInfoRepository.findByFolioNumber("UNKNOWN"))
+                .thenReturn(Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.updateGeneralInfo(
+                new UpdateGeneralInfoCommand(
+                        "UNKNOWN",
+                        new InsuredData("N", "X", "x@x.com", "1"),
+                        new UnderwritingInfo("S", "A", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                        0L
+                )))
+                .isInstanceOf(FolioNotFoundException.class);
+    }
+
+    @Test
+    void updateGeneralInfo_whenVersionConflict_throwsVersionConflictException() {
+        // GIVEN - stored version is 2, client sends 1
+        when(generalInfoRepository.findByFolioNumber("FOL-2026-00001"))
+                .thenReturn(Optional.of(storedGeneralInfo(2L)));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.updateGeneralInfo(buildCommand(1L)))
+                .isInstanceOf(VersionConflictException.class);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/GeneralInfoControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/GeneralInfoControllerTest.java
@@ -1,0 +1,238 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.in.rest.GlobalExceptionHandler;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.BusinessType;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.RiskClassification;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.GetGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.domain.port.in.UpdateGeneralInfoUseCase;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.mapper.GeneralInfoRestMapper;
+import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
+import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class GeneralInfoControllerTest {
+
+    @Mock
+    private GetGeneralInfoUseCase getGeneralInfoUseCase;
+
+    @Mock
+    private UpdateGeneralInfoUseCase updateGeneralInfoUseCase;
+
+    private MockMvc mockMvc;
+
+    private static final Instant FIXED = Instant.parse("2026-04-23T19:55:12Z");
+
+    private GeneralInfo buildGeneralInfo() {
+        return new GeneralInfo(
+                "FOL-2026-00001",
+                "CREATED",
+                new InsuredData("Empresa SA", "EMP123456ABC", "empresa@test.com", "5551234567"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                FIXED,
+                1L
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new GeneralInfoController(
+                        getGeneralInfoUseCase,
+                        updateGeneralInfoUseCase,
+                        new GeneralInfoRestMapper()))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    // --- GET happy path ---
+
+    @Test
+    void getGeneralInfo_whenFolioExists_returns200WithBody() throws Exception {
+        // GIVEN
+        when(getGeneralInfoUseCase.getGeneralInfo("FOL-2026-00001"))
+                .thenReturn(buildGeneralInfo());
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/FOL-2026-00001/general-info"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00001"))
+                .andExpect(jsonPath("$.quoteStatus").value("CREATED"))
+                .andExpect(jsonPath("$.insuredData.name").value("Empresa SA"))
+                .andExpect(jsonPath("$.insuredData.rfc").value("EMP123456ABC"))
+                .andExpect(jsonPath("$.underwritingData.subscriberId").value("SUB-001"))
+                .andExpect(jsonPath("$.underwritingData.riskClassification").value("STANDARD"))
+                .andExpect(jsonPath("$.version").value(1));
+    }
+
+    // --- GET 404 ---
+
+    @Test
+    void getGeneralInfo_whenFolioNotFound_returns404() throws Exception {
+        // GIVEN
+        when(getGeneralInfoUseCase.getGeneralInfo("UNKNOWN"))
+                .thenThrow(new FolioNotFoundException("UNKNOWN"));
+
+        // WHEN / THEN
+        mockMvc.perform(get("/v1/quotes/UNKNOWN/general-info"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+    }
+
+    // --- PUT happy path ---
+
+    @Test
+    void updateGeneralInfo_whenValid_returns200WithUpdatedBody() throws Exception {
+        // GIVEN
+        GeneralInfo updated = new GeneralInfo(
+                "FOL-2026-00001",
+                "CREATED",
+                new InsuredData("Empresa SA", "EMP123456ABC", "empresa@test.com", "5551234567"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                FIXED,
+                2L
+        );
+        when(updateGeneralInfoUseCase.updateGeneralInfo(any())).thenReturn(updated);
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-2026-00001/general-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "insuredData": {
+                                    "name": "Empresa SA",
+                                    "rfc": "EMP123456ABC",
+                                    "email": "empresa@test.com",
+                                    "phone": "5551234567"
+                                  },
+                                  "underwritingData": {
+                                    "subscriberId": "SUB-001",
+                                    "agentCode": "AGT-123",
+                                    "riskClassification": "STANDARD",
+                                    "businessType": "COMMERCIAL"
+                                  },
+                                  "version": 1
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00001"))
+                .andExpect(jsonPath("$.version").value(2))
+                .andExpect(jsonPath("$.insuredData.name").value("Empresa SA"));
+    }
+
+    // --- PUT 404 ---
+
+    @Test
+    void updateGeneralInfo_whenFolioNotFound_returns404() throws Exception {
+        // GIVEN
+        when(updateGeneralInfoUseCase.updateGeneralInfo(any()))
+                .thenThrow(new FolioNotFoundException("FOL-UNKNOWN"));
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-UNKNOWN/general-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "insuredData": {
+                                    "name": "Empresa SA",
+                                    "rfc": "EMP123456ABC",
+                                    "email": "empresa@test.com",
+                                    "phone": "5551234567"
+                                  },
+                                  "underwritingData": {
+                                    "subscriberId": "SUB-001",
+                                    "agentCode": "AGT-123",
+                                    "riskClassification": "STANDARD",
+                                    "businessType": "COMMERCIAL"
+                                  },
+                                  "version": 0
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+    }
+
+    // --- PUT 409 version conflict ---
+
+    @Test
+    void updateGeneralInfo_whenVersionConflict_returns409() throws Exception {
+        // GIVEN
+        when(updateGeneralInfoUseCase.updateGeneralInfo(any()))
+                .thenThrow(new VersionConflictException("FOL-2026-00001", 1L, 3L));
+
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-2026-00001/general-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "insuredData": {
+                                    "name": "Empresa SA",
+                                    "rfc": "EMP123456ABC",
+                                    "email": "empresa@test.com",
+                                    "phone": "5551234567"
+                                  },
+                                  "underwritingData": {
+                                    "subscriberId": "SUB-001",
+                                    "agentCode": "AGT-123",
+                                    "riskClassification": "STANDARD",
+                                    "businessType": "COMMERCIAL"
+                                  },
+                                  "version": 1
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("VERSION_CONFLICT"));
+    }
+
+    // --- PUT 422 validation error ---
+
+    @Test
+    void updateGeneralInfo_whenNameMissing_returns422() throws Exception {
+        // WHEN / THEN
+        mockMvc.perform(put("/v1/quotes/FOL-2026-00001/general-info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "insuredData": {
+                                    "rfc": "EMP123456ABC",
+                                    "email": "empresa@test.com",
+                                    "phone": "5551234567"
+                                  },
+                                  "underwritingData": {
+                                    "subscriberId": "SUB-001",
+                                    "agentCode": "AGT-123",
+                                    "riskClassification": "STANDARD",
+                                    "businessType": "COMMERCIAL"
+                                  },
+                                  "version": 1
+                                }
+                                """))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/GeneralInfoRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/in/rest/GeneralInfoRestMapperTest.java
@@ -1,0 +1,55 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.back.generalinfo.domain.model.BusinessType;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.RiskClassification;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.dto.GeneralInfoResponse;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.in.rest.mapper.GeneralInfoRestMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeneralInfoRestMapperTest {
+
+    private final GeneralInfoRestMapper mapper = new GeneralInfoRestMapper();
+
+    private static final Instant NOW = Instant.parse("2026-04-23T19:55:12Z");
+
+    private GeneralInfo buildDomain() {
+        return new GeneralInfo(
+                "FOL-2026-00001",
+                "CREATED",
+                new InsuredData("Empresa SA", "EMP123456ABC", "empresa@test.com", "5551234567"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                NOW,
+                1L
+        );
+    }
+
+    @Test
+    void toResponse_mapsAllFieldsCorrectly() {
+        // GIVEN
+        GeneralInfo domain = buildDomain();
+
+        // WHEN
+        GeneralInfoResponse response = mapper.toResponse(domain);
+
+        // THEN
+        assertThat(response.folioNumber()).isEqualTo("FOL-2026-00001");
+        assertThat(response.quoteStatus()).isEqualTo("CREATED");
+        assertThat(response.insuredData().name()).isEqualTo("Empresa SA");
+        assertThat(response.insuredData().rfc()).isEqualTo("EMP123456ABC");
+        assertThat(response.insuredData().email()).isEqualTo("empresa@test.com");
+        assertThat(response.insuredData().phone()).isEqualTo("5551234567");
+        assertThat(response.underwritingData().subscriberId()).isEqualTo("SUB-001");
+        assertThat(response.underwritingData().agentCode()).isEqualTo("AGT-123");
+        assertThat(response.underwritingData().riskClassification()).isEqualTo("STANDARD");
+        assertThat(response.underwritingData().businessType()).isEqualTo("COMMERCIAL");
+        assertThat(response.updatedAt()).isEqualTo(NOW);
+        assertThat(response.version()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/GeneralInfoJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/GeneralInfoJpaAdapterTest.java
@@ -1,0 +1,105 @@
+package com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
+import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.BusinessType;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.GeneralInfo;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.InsuredData;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.RiskClassification;
+import com.sofka.insurancequoter.back.generalinfo.domain.model.UnderwritingInfo;
+import com.sofka.insurancequoter.back.generalinfo.infrastructure.adapter.out.persistence.adapter.GeneralInfoJpaAdapter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GeneralInfoJpaAdapterTest {
+
+    @Mock
+    private QuoteJpaRepository quoteJpaRepository;
+
+    @InjectMocks
+    private GeneralInfoJpaAdapter adapter;
+
+    private static final Instant NOW = Instant.parse("2026-04-23T19:55:12Z");
+
+    private QuoteJpa buildJpaEntity() {
+        return QuoteJpa.builder()
+                .folioNumber("FOL-2026-00001")
+                .quoteStatus("CREATED")
+                .subscriberId("SUB-001")
+                .agentCode("AGT-123")
+                .insuredName("Empresa SA")
+                .insuredRfc("EMP123456ABC")
+                .insuredEmail("empresa@test.com")
+                .insuredPhone("5551234567")
+                .riskClassification("STANDARD")
+                .businessType("COMMERCIAL")
+                .version(1L)
+                .updatedAt(NOW)
+                .build();
+    }
+
+    @Test
+    void findByFolioNumber_whenExists_returnsGeneralInfo() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber("FOL-2026-00001"))
+                .thenReturn(Optional.of(buildJpaEntity()));
+
+        // WHEN
+        Optional<GeneralInfo> result = adapter.findByFolioNumber("FOL-2026-00001");
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().folioNumber()).isEqualTo("FOL-2026-00001");
+        assertThat(result.get().insuredData().name()).isEqualTo("Empresa SA");
+        assertThat(result.get().underwritingInfo().riskClassification()).isEqualTo(RiskClassification.STANDARD);
+        assertThat(result.get().version()).isEqualTo(1L);
+    }
+
+    @Test
+    void findByFolioNumber_whenNotFound_returnsEmpty() {
+        // GIVEN
+        when(quoteJpaRepository.findByFolioNumber("UNKNOWN"))
+                .thenReturn(Optional.empty());
+
+        // WHEN
+        Optional<GeneralInfo> result = adapter.findByFolioNumber("UNKNOWN");
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void save_persistsAndReturnsMappedDomain() {
+        // GIVEN
+        GeneralInfo toSave = new GeneralInfo(
+                "FOL-2026-00001",
+                "CREATED",
+                new InsuredData("Empresa SA", "EMP123456ABC", "empresa@test.com", "5551234567"),
+                new UnderwritingInfo("SUB-001", "AGT-123", RiskClassification.STANDARD, BusinessType.COMMERCIAL),
+                NOW,
+                1L
+        );
+        when(quoteJpaRepository.findByFolioNumber("FOL-2026-00001"))
+                .thenReturn(Optional.of(buildJpaEntity()));
+        when(quoteJpaRepository.save(any())).thenReturn(buildJpaEntity());
+
+        // WHEN
+        GeneralInfo result = adapter.save(toSave);
+
+        // THEN
+        assertThat(result.folioNumber()).isEqualTo("FOL-2026-00001");
+        assertThat(result.insuredData().rfc()).isEqualTo("EMP123456ABC");
+        assertThat(result.underwritingInfo().agentCode()).isEqualTo("AGT-123");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/location/domain/service/LocationValidationServiceTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/domain/service/LocationValidationServiceTest.java
@@ -3,6 +3,9 @@ package com.sofka.insurancequoter.back.location.domain.service;
 import com.sofka.insurancequoter.back.location.domain.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -10,7 +13,16 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("java:S100")
 class LocationValidationServiceTest {
+
+    private static final String BODEGA = "Bodega";
+    private static final String BL_001 = "BL-001";
+    private static final String ZIP_CODE = "06600";
+    private static final String FIRE_KEY = "FK-01";
+    private static final String MUNICIPALITY = "Cuauhtemoc";
+    private static final String GUA_FIRE = "GUA-FIRE";
+    private static final String ZONE = "ZONE_A";
 
     private LocationValidationService service;
 
@@ -25,56 +37,52 @@ class LocationValidationServiceTest {
                 businessLine, guarantees, null, ValidationStatus.INCOMPLETE, List.of());
     }
 
-    @Test
-    void nullZipCode_generates_MISSING_ZIP_CODE_alert() {
-        Location location = locationWith(null, new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
-        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.empty());
-        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_ZIP_CODE.name()));
+    private ZipCodeInfo validZipInfo() {
+        return new ZipCodeInfo(ZIP_CODE, "CDMX", MUNICIPALITY, "CDMX", ZONE, true);
     }
 
-    @Test
-    void emptyZipCode_generates_MISSING_ZIP_CODE_alert() {
-        Location location = locationWith("", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
-        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.empty());
-        assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_ZIP_CODE.name()));
-    }
-
-    @Test
-    void zipCodeInfoEmpty_generates_MISSING_ZIP_CODE_alert() {
-        Location location = locationWith("99999", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"99999"})
+    void missingOrUnknownZipCode_generates_MISSING_ZIP_CODE_alert(String zipCode) {
+        Location location = locationWith(zipCode,
+                new BusinessLine(BL_001, FIRE_KEY, BODEGA),
+                List.of(new Guarantee(GUA_FIRE, BigDecimal.valueOf(1000000))));
         List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.empty());
         assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_ZIP_CODE.name()));
     }
 
     @Test
     void nullBusinessLine_generates_MISSING_FIRE_KEY_alert() {
-        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
-        Location location = locationWith("06600", null, List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
-        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        Location location = locationWith(ZIP_CODE, null,
+                List.of(new Guarantee(GUA_FIRE, BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(validZipInfo()));
         assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_FIRE_KEY.name()));
     }
 
     @Test
     void businessLineWithNullFireKey_generates_MISSING_FIRE_KEY_alert() {
-        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
-        Location location = locationWith("06600", new BusinessLine("BL-001", null, "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
-        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        Location location = locationWith(ZIP_CODE,
+                new BusinessLine(BL_001, null, BODEGA),
+                List.of(new Guarantee(GUA_FIRE, BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(validZipInfo()));
         assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.MISSING_FIRE_KEY.name()));
     }
 
     @Test
     void emptyGuarantees_generates_NO_TARIFABLE_GUARANTEES_alert() {
-        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
-        Location location = locationWith("06600", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of());
-        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        Location location = locationWith(ZIP_CODE,
+                new BusinessLine(BL_001, FIRE_KEY, BODEGA), List.of());
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(validZipInfo()));
         assertThat(alerts).anyMatch(a -> a.code().equals(BlockingAlertCode.NO_TARIFABLE_GUARANTEES.name()));
     }
 
     @Test
     void validData_generates_no_alerts_and_status_is_COMPLETE() {
-        ZipCodeInfo zipInfo = new ZipCodeInfo("06600", "CDMX", "Cuauhtemoc", "CDMX", "ZONE_A", true);
-        Location location = locationWith("06600", new BusinessLine("BL-001", "FK-01", "Bodega"), List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1000000))));
-        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(zipInfo));
+        Location location = locationWith(ZIP_CODE,
+                new BusinessLine(BL_001, FIRE_KEY, BODEGA),
+                List.of(new Guarantee(GUA_FIRE, BigDecimal.valueOf(1000000))));
+        List<BlockingAlert> alerts = service.calculateAlerts(location, Optional.of(validZipInfo()));
         assertThat(alerts).isEmpty();
         assertThat(service.deriveStatus(alerts)).isEqualTo(ValidationStatus.COMPLETE);
     }

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationControllerTest.java
@@ -22,7 +22,6 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutControllerTest.java
@@ -23,15 +23,21 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import java.time.Instant;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class LocationLayoutControllerTest {
+
+    private static final String FOLIO = "FOL-2026-00042";
+    private static final String FOLIO_NOT_FOUND = "FOL-9999-99999";
+    private static final String LAYOUT_URL = "/v1/quotes/FOL-2026-00042/locations/layout";
+    private static final String LAYOUT_URL_NOT_FOUND = "/v1/quotes/FOL-9999-99999/locations/layout";
+    private static final String JSON_CODE = "$.code";
 
     @Mock
     private GetLocationLayoutUseCase getLayoutUseCase;
@@ -61,16 +67,16 @@ class LocationLayoutControllerTest {
     void shouldReturn200WithLayout_whenGetLayoutAndFolioExists() throws Exception {
         // GIVEN
         GetLayoutResult result = new GetLayoutResult(
-                "FOL-2026-00042",
+                FOLIO,
                 new LayoutConfiguration(3, LocationType.MULTIPLE),
                 2L
         );
-        when(getLayoutUseCase.getLayout("FOL-2026-00042")).thenReturn(result);
+        when(getLayoutUseCase.getLayout(FOLIO)).thenReturn(result);
 
         // WHEN / THEN
-        mockMvc.perform(get("/v1/quotes/FOL-2026-00042/locations/layout"))
+        mockMvc.perform(get(LAYOUT_URL))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00042"))
+                .andExpect(jsonPath("$.folioNumber").value(FOLIO))
                 .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(3))
                 .andExpect(jsonPath("$.layoutConfiguration.locationType").value("MULTIPLE"))
                 .andExpect(jsonPath("$.version").value(2));
@@ -80,14 +86,14 @@ class LocationLayoutControllerTest {
     @Test
     void shouldReturn404_whenGetLayoutAndFolioNotFound() throws Exception {
         // GIVEN
-        when(getLayoutUseCase.getLayout("FOL-9999-99999"))
-                .thenThrow(new FolioNotFoundException("FOL-9999-99999"));
+        when(getLayoutUseCase.getLayout(FOLIO_NOT_FOUND))
+                .thenThrow(new FolioNotFoundException(FOLIO_NOT_FOUND));
 
         // WHEN / THEN
-        mockMvc.perform(get("/v1/quotes/FOL-9999-99999/locations/layout"))
+        mockMvc.perform(get(LAYOUT_URL_NOT_FOUND))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error").value("Folio not found"))
-                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+                .andExpect(jsonPath(JSON_CODE).value("FOLIO_NOT_FOUND"));
     }
 
     // CRITERIO-2.1: PUT 200 saves layout successfully
@@ -95,7 +101,7 @@ class LocationLayoutControllerTest {
     void shouldReturn200_whenSaveLayoutSucceeds() throws Exception {
         // GIVEN
         SaveLayoutResult result = new SaveLayoutResult(
-                "FOL-2026-00042",
+                FOLIO,
                 new LayoutConfiguration(3, LocationType.MULTIPLE),
                 NOW,
                 2L
@@ -103,7 +109,7 @@ class LocationLayoutControllerTest {
         when(saveLayoutUseCase.saveLayout(any())).thenReturn(result);
 
         // WHEN / THEN
-        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+        mockMvc.perform(put(LAYOUT_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -115,7 +121,7 @@ class LocationLayoutControllerTest {
                                 }
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.folioNumber").value("FOL-2026-00042"))
+                .andExpect(jsonPath("$.folioNumber").value(FOLIO))
                 .andExpect(jsonPath("$.layoutConfiguration.numberOfLocations").value(3))
                 .andExpect(jsonPath("$.version").value(2));
     }
@@ -125,10 +131,10 @@ class LocationLayoutControllerTest {
     void shouldReturn404_whenSaveLayoutAndFolioNotFound() throws Exception {
         // GIVEN
         when(saveLayoutUseCase.saveLayout(any()))
-                .thenThrow(new FolioNotFoundException("FOL-9999-99999"));
+                .thenThrow(new FolioNotFoundException(FOLIO_NOT_FOUND));
 
         // WHEN / THEN
-        mockMvc.perform(put("/v1/quotes/FOL-9999-99999/locations/layout")
+        mockMvc.perform(put(LAYOUT_URL_NOT_FOUND)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -140,7 +146,7 @@ class LocationLayoutControllerTest {
                                 }
                                 """))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("FOLIO_NOT_FOUND"));
+                .andExpect(jsonPath(JSON_CODE).value("FOLIO_NOT_FOUND"));
     }
 
     // CRITERIO-2.4: PUT 409 on optimistic lock conflict
@@ -151,7 +157,7 @@ class LocationLayoutControllerTest {
                 .thenThrow(new OptimisticLockingFailureException("version conflict"));
 
         // WHEN / THEN
-        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+        mockMvc.perform(put(LAYOUT_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -164,14 +170,14 @@ class LocationLayoutControllerTest {
                                 """))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error").value("Optimistic lock conflict"))
-                .andExpect(jsonPath("$.code").value("VERSION_CONFLICT"));
+                .andExpect(jsonPath(JSON_CODE).value("VERSION_CONFLICT"));
     }
 
     // CRITERIO-2.6: PUT 422 when layoutConfiguration is null
     @Test
     void shouldReturn422_whenLayoutConfigurationIsMissing() throws Exception {
         // WHEN / THEN
-        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+        mockMvc.perform(put(LAYOUT_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -179,14 +185,14 @@ class LocationLayoutControllerTest {
                                 }
                                 """))
                 .andExpect(status().is(422))
-                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+                .andExpect(jsonPath(JSON_CODE).value("VALIDATION_ERROR"));
     }
 
     // PUT 422 when version is null
     @Test
     void shouldReturn422_whenVersionIsMissing() throws Exception {
         // WHEN / THEN
-        mockMvc.perform(put("/v1/quotes/FOL-2026-00042/locations/layout")
+        mockMvc.perform(put(LAYOUT_URL)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -197,6 +203,6 @@ class LocationLayoutControllerTest {
                                 }
                                 """))
                 .andExpect(status().is(422))
-                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+                .andExpect(jsonPath(JSON_CODE).value("VALIDATION_ERROR"));
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/in/rest/LocationLayoutRestMapperTest.java
@@ -20,6 +20,7 @@ class LocationLayoutRestMapperTest {
 
     private final LocationLayoutRestMapper mapper = new LocationLayoutRestMapper();
 
+    private static final String FOLIO = "FOL-2026-00042";
     private static final Instant NOW = Instant.parse("2026-04-21T10:00:00Z");
 
     // GetLayoutResult → GetLayoutResponse
@@ -27,7 +28,7 @@ class LocationLayoutRestMapperTest {
     void shouldMapGetLayoutResultToResponse() {
         // GIVEN
         GetLayoutResult result = new GetLayoutResult(
-                "FOL-2026-00042",
+                FOLIO,
                 new LayoutConfiguration(3, LocationType.MULTIPLE),
                 2L
         );
@@ -36,7 +37,7 @@ class LocationLayoutRestMapperTest {
         GetLayoutResponse response = mapper.toGetResponse(result);
 
         // THEN
-        assertThat(response.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(response.folioNumber()).isEqualTo(FOLIO);
         assertThat(response.version()).isEqualTo(2L);
         assertThat(response.layoutConfiguration().numberOfLocations()).isEqualTo(3);
         assertThat(response.layoutConfiguration().locationType()).isEqualTo("MULTIPLE");
@@ -47,7 +48,7 @@ class LocationLayoutRestMapperTest {
     void shouldMapNullLayoutConfigurationToNullFields() {
         // GIVEN
         GetLayoutResult result = new GetLayoutResult(
-                "FOL-2026-00042",
+                FOLIO,
                 new LayoutConfiguration(null, null),
                 1L
         );
@@ -70,10 +71,10 @@ class LocationLayoutRestMapperTest {
         );
 
         // WHEN
-        SaveLayoutCommand command = mapper.toCommand("FOL-2026-00042", request);
+        SaveLayoutCommand command = mapper.toCommand(FOLIO, request);
 
         // THEN
-        assertThat(command.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(command.folioNumber()).isEqualTo(FOLIO);
         assertThat(command.version()).isEqualTo(3L);
         assertThat(command.layoutConfiguration().numberOfLocations()).isEqualTo(2);
         assertThat(command.layoutConfiguration().locationType()).isEqualTo(LocationType.SINGLE);
@@ -84,7 +85,7 @@ class LocationLayoutRestMapperTest {
     void shouldMapSaveLayoutResultToResponse() {
         // GIVEN
         SaveLayoutResult result = new SaveLayoutResult(
-                "FOL-2026-00042",
+                FOLIO,
                 new LayoutConfiguration(2, LocationType.SINGLE),
                 NOW,
                 4L
@@ -94,7 +95,7 @@ class LocationLayoutRestMapperTest {
         SaveLayoutResponse response = mapper.toSaveResponse(result);
 
         // THEN
-        assertThat(response.folioNumber()).isEqualTo("FOL-2026-00042");
+        assertThat(response.folioNumber()).isEqualTo(FOLIO);
         assertThat(response.updatedAt()).isEqualTo(NOW);
         assertThat(response.version()).isEqualTo(4L);
         assertThat(response.layoutConfiguration().locationType()).isEqualTo("SINGLE");


### PR DESCRIPTION
## Resumen

Fixes de integración descubiertos al navegar el flujo completo del cotizador con backends reales.

## Cambios

### feat: GET /v1/folios — endpoint de lista para dashboard
- Stack hexagonal completo: `FolioSummary`, `ListFoliosUseCase`, `FolioListJpaAdapter`
- Enriquece con `agentName` desde Core y porcentaje de completitud

### feat(coverage): derivación de coberturas desde garantías activas
- `CoverageDerivationService` — mapeo GUA-* → COV-* (lógica de negocio en backend)
- `ActiveGuaranteeJpaAdapter` — lee garantías activas de ubicaciones

### fix: PUT /v1/quotes/{folio}/coverage-options retornaba 422
- `SaveCoverageOptionsUseCaseImpl` validaba COV-* contra catálogo GUA-* → nunca matcheaba
- Reemplazado con `CoverageDerivationService.knownDescriptions()`

### fix: estado de coberturas evaluado desde DB
- `GetQuoteStateUseCaseImpl` usaba PENDING hardcodeado para coberturas

## Tests
- Tests unitarios actualizados para `SaveCoverageOptionsUseCaseImpl`
- `./gradlew test` pasa sin errores