### PR TITLE
release: v1.1.0 — observabilidad completa (SPEC-008)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(gh project *)",
-      "Bash(gh api graphql -f 'query= *)"
+      "Bash(gh api graphql -f 'query= *)",
+      "Bash(powershell *)",
+      "Bash(netstat -ano)"
     ]
   }
 }

--- a/.claude/specs/observability.spec.md
+++ b/.claude/specs/observability.spec.md
@@ -1,0 +1,439 @@
+---
+id: SPEC-008
+status: DRAFT
+feature: observability
+created: 2026-04-27
+updated: 2026-04-27
+author: spec-generator
+version: "1.0"
+related-specs: []
+---
+
+# Spec: Observabilidad Completa — Logs, Métricas y Trazas
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+Agregar los tres pilares de observabilidad al microservicio `Insurance-Quoter-Back`: logs estructurados con correlación por `traceId`/`spanId`, métricas de JVM + HTTP + negocio (cotizaciones, cálculo de prima, aceptaciones) exportadas a Prometheus, y trazas distribuidas HTTP+DB+use cases exportadas a Jaeger vía OTLP. El stack de visualización local queda levantado mediante Docker Compose (Jaeger + Prometheus + Grafana).
+
+Esta funcionalidad es puramente de infraestructura: no modifica el dominio, no crea tablas nuevas y no expone endpoints de negocio nuevos.
+
+### Requerimiento de Negocio
+
+> Añadir observabilidad completa al backend para poder diagnosticar problemas en producción,
+> monitorear el comportamiento en tiempo real y entender cómo se usan las funcionalidades de
+> negocio (cotizaciones por tipo de negocio, errores de cálculo, latencias por endpoint).
+> Debe ser posible correlacionar un log con la traza completa de la request que lo generó.
+
+### Historias de Usuario
+
+#### HU-01: Correlación de logs con trazas
+
+```
+Como:        desarrollador diagnosticando un error en producción
+Quiero:      ver el traceId y spanId en cada línea de log
+Para:        buscar todos los logs de una request fallida específica y reconstruir su historia completa
+
+Prioridad:   Alta
+Estimación:  XS
+Dependencias: Ninguna
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: traceId aparece en cada log de una request
+  Dado que:  el servicio está levantado con observabilidad habilitada
+  Cuando:    llega una request POST /v1/quotes
+  Entonces:  cada línea de log generada durante esa request contiene un campo traceId no vacío
+             Y cada línea de log contiene un campo spanId no vacío
+             Y el traceId es el mismo en todos los logs de esa request
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-1.2: logs sin request activa no rompen el formato
+  Dado que:  el servicio arranca y ejecuta tareas de inicialización (Flyway, Spring context)
+  Cuando:    se imprime un log fuera del contexto de una request HTTP
+  Entonces:  el log se imprime sin traceId (campo vacío o ausente) sin lanzar excepción
+```
+
+---
+
+#### HU-02: Métricas de infraestructura y negocio
+
+```
+Como:        operador monitoreando el servicio en producción
+Quiero:      ver dashboards con métricas de JVM, HTTP, DB pool y negocio en Grafana
+Para:        detectar cuellos de botella, degradaciones y anomalías antes de que afecten usuarios
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: HU-01
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-02
+
+**Happy Path**
+```gherkin
+CRITERIO-2.1: endpoint de métricas Prometheus disponible
+  Dado que:  el servicio está levantado
+  Cuando:    se hace GET /actuator/prometheus
+  Entonces:  la respuesta es HTTP 200
+             Y el Content-Type es text/plain
+             Y el cuerpo contiene métricas jvm_memory_used_bytes
+             Y el cuerpo contiene métricas http_server_requests_seconds
+             Y el cuerpo contiene métricas hikaricp_connections_active
+```
+
+```gherkin
+CRITERIO-2.2: métricas de negocio se registran al crear cotización
+  Dado que:  el servicio está levantado con métricas habilitadas
+  Cuando:    se ejecuta CreateFolioUseCaseImpl.createFolio() exitosamente
+  Entonces:  el counter quotes_created_total se incrementa en 1
+             Y el counter contiene el tag businessType con el valor de la cotización
+```
+
+```gherkin
+CRITERIO-2.3: métricas de cálculo se registran al calcular prima
+  Dado que:  el servicio está levantado con métricas habilitadas
+  Cuando:    se ejecuta CalculatePremiumUseCaseImpl.calculatePremium() exitosamente
+  Entonces:  el counter premium_calculated_total se incrementa en 1
+             Y el timer premium_calculate_duration_seconds registra la duración
+             Y ambos contienen el tag riskClassification con el valor calculado
+```
+
+```gherkin
+CRITERIO-2.4: errores de cálculo se cuentan por tipo
+  Dado que:  el servicio está levantado con métricas habilitadas
+  Cuando:    CalculatePremiumUseCaseImpl lanza NoCalculableLocationsException
+  Entonces:  el counter calculation_errors_total se incrementa
+             Y el counter contiene el tag errorType = "NoCalculableLocations"
+```
+
+---
+
+#### HU-03: Trazas distribuidas HTTP + DB + use cases
+
+```
+Como:        desarrollador investigando por qué un endpoint es lento
+Quiero:      ver en Jaeger el waterfall completo: HTTP request → use case → queries SQL
+Para:        identificar exactamente qué operación consume el tiempo y optimizarla
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: HU-01
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-03
+
+**Happy Path**
+```gherkin
+CRITERIO-3.1: traza completa de request POST /v1/quotes visible en Jaeger
+  Dado que:  el servicio está levantado con tracing habilitado y conectado a Jaeger
+  Cuando:    se ejecuta POST /v1/quotes exitosamente
+  Entonces:  en Jaeger aparece una traza del servicio "insurance-quoter-back"
+             Y la traza tiene un span raíz de tipo http.server.request con ruta /v1/quotes
+             Y la traza tiene spans hijos para CreateFolioUseCaseImpl.createFolio
+             Y la traza tiene spans hijos para cada query SQL ejecutada
+             Y la duración total coincide (±5%) con el tiempo de respuesta HTTP
+```
+
+```gherkin
+CRITERIO-3.2: traza propagada a llamada HTTP a Insurance-Quoter-Core
+  Dado que:  el servicio está configurado con context propagation
+  Cuando:    CreateFolioUseCaseImpl llama a CoreServiceClient
+  Entonces:  el header traceparent se propaga en la request saliente a Core
+             Y el span de la llamada HTTP saliente es hijo del span del use case
+```
+
+```gherkin
+CRITERIO-3.3: span de use case registrado con @Observed
+  Dado que:  ObservedAspect está activo en el contexto Spring
+  Cuando:    se invoca cualquier use case anotado con @Observed
+  Entonces:  aparece un span hijo con el nombre definido en la anotación
+             Y el span incluye el tag del bounded context correspondiente
+```
+
+---
+
+#### HU-04: Stack de observabilidad local en Docker Compose
+
+```
+Como:        desarrollador ejecutando el proyecto localmente
+Quiero:      levantar Jaeger, Prometheus y Grafana con un solo docker compose up
+Para:        explorar trazas y métricas sin infraestructura externa
+
+Prioridad:   Media
+Estimación:  S
+Dependencias: HU-02, HU-03
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-04
+
+**Happy Path**
+```gherkin
+CRITERIO-4.1: servicios de observabilidad accesibles tras compose up
+  Dado que:  se ejecuta docker compose up en Insurance-Quoter-Back/
+  Cuando:    los contenedores terminan de inicializarse
+  Entonces:  Jaeger UI responde en http://localhost:16686
+             Y Prometheus responde en http://localhost:9090
+             Y Grafana responde en http://localhost:3000
+             Y Prometheus tiene el target "insurance-quoter-back" en estado UP
+```
+
+---
+
+### Reglas de Negocio
+
+1. El endpoint `/actuator/prometheus` es público en entorno local (no requiere auth). En producción debe securizarse — fuera del alcance de esta spec.
+2. Los tags de métricas de negocio usan **cardinalidad baja**: `businessType` y `riskClassification` son enumeraciones finitas. Prohibido usar `folioNumber` o `quoteId` como tag (causa explosión de cardinalidad).
+3. El sampling de trazas es `1.0` (100%) en entornos `local` y `test`. En `prod` se debe bajar a `0.1` vía variable de entorno `TRACING_SAMPLING_PROBABILITY`.
+4. El `ObservabilityConfig` vive en `infrastructure/config/` — es el único lugar donde se referencian `ObservedAspect`, `MeterRegistry` y `ObservationRegistry`.
+5. Las anotaciones `@Observed` van en los métodos públicos de los use case implementations (`application/usecase/`). El dominio no puede importar dependencias de Micrometer.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+No se requieren cambios de base de datos. Observabilidad es puramente infraestructura.
+
+### Métricas de Negocio Definidas
+
+| Nombre de métrica | Tipo | Tags | Dónde se registra |
+|------------------|------|------|--------------------|
+| `quotes.created` | Counter | `businessType` | `CreateFolioUseCaseImpl` |
+| `premium.calculated` | Counter | `riskClassification`, `businessType` | `CalculatePremiumUseCaseImpl` |
+| `premium.calculate.duration` | Timer | `riskClassification` | `CalculatePremiumUseCaseImpl` |
+| `quote.accepted` | Counter | — | `AcceptQuoteUseCaseImpl` |
+| `calculation.errors` | Counter | `errorType` | `CalculatePremiumUseCaseImpl` (catch) |
+| `coverage.options.saved` | Counter | — | `SaveCoverageOptionsUseCaseImpl` |
+
+### Use Cases instrumentados con `@Observed`
+
+| Use Case | Nombre de observación | Bounded Context |
+|----------|----------------------|-----------------|
+| `CreateFolioUseCaseImpl.createFolio()` | `folio.create` | folio |
+| `GetQuoteStateUseCaseImpl.getQuoteState()` | `folio.state.get` | folio |
+| `ListFoliosUseCaseImpl.listFolios()` | `folio.list` | folio |
+| `CalculatePremiumUseCaseImpl.calculatePremium()` | `premium.calculate` | calculation |
+| `AcceptQuoteUseCaseImpl.acceptQuote()` | `quote.accept` | calculation |
+| `GetCalculationResultUseCaseImpl.getCalculationResult()` | `calculation.result.get` | calculation |
+| `SaveCoverageOptionsUseCaseImpl.saveCoverageOptions()` | `coverage.options.save` | coverage |
+| `GetCoverageOptionsUseCaseImpl.getCoverageOptions()` | `coverage.options.get` | coverage |
+
+### API Endpoints (Actuator)
+
+No son endpoints de negocio. Se exponen vía Spring Boot Actuator:
+
+#### GET /actuator/health
+- Devuelve estado de salud del servicio y sus dependencias (DB)
+- **Response 200**: `{ "status": "UP", "components": { "db": { "status": "UP" } } }`
+
+#### GET /actuator/prometheus
+- Devuelve métricas en formato Prometheus text exposition format
+- **Response 200**: texto plano con todas las métricas registradas
+
+#### GET /actuator/metrics
+- Lista nombres de métricas disponibles
+- **Response 200**: JSON con array de metric names
+
+### Dependencias Nuevas (build.gradle.kts)
+
+```kotlin
+// Actuator + management endpoints
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+// Micrometer Tracing — abstracción sobre OTel
+implementation("io.micrometer:micrometer-tracing-bridge-otel")
+
+// OpenTelemetry OTLP exporter — envía trazas a Jaeger
+implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+
+// Prometheus registry — exporta métricas al formato Prometheus
+implementation("io.micrometer:micrometer-registry-prometheus")
+```
+
+Las versiones las gestiona el BOM de Spring Boot 4 — no se pinean manualmente.
+
+### Configuración application.properties (adiciones)
+
+```properties
+# Nombre del servicio (aparece en Jaeger y métricas)
+spring.application.name=insurance-quoter-back
+
+# Actuator: exponer health, prometheus, metrics
+management.endpoints.web.exposure.include=health,prometheus,metrics
+management.endpoint.health.show-details=always
+
+# Tracing: 100% sampling en local (override vía env var en prod)
+management.tracing.sampling.probability=${TRACING_SAMPLING_PROBABILITY:1.0}
+
+# OTLP: enviar trazas a Jaeger local (override vía env var)
+management.otlp.tracing.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
+
+# Logging: incluir traceId y spanId en cada línea de log
+logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
+```
+
+### Nuevos Archivos de Infraestructura
+
+#### `infrastructure/config/ObservabilityConfig.java`
+
+Responsabilidades:
+- Registrar el bean `ObservedAspect` (habilita `@Observed` en AOP)
+- Definir los `MeterBinder` beans para métricas de negocio custom (opcional, si no se inyectan directamente en los use cases)
+
+```java
+// Ejemplo de contenido
+@Configuration
+public class ObservabilityConfig {
+
+    @Bean
+    public ObservedAspect observedAspect(ObservationRegistry registry) {
+        return new ObservedAspect(registry);
+    }
+}
+```
+
+#### `compose.yaml` (adiciones)
+
+```yaml
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    ports:
+      - "16686:16686"   # UI
+      - "4317:4317"     # OTLP gRPC
+      - "4318:4318"     # OTLP HTTP
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./observability/grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./observability/grafana/dashboards:/etc/grafana/provisioning/dashboards
+```
+
+#### `observability/prometheus.yml`
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: insurance-quoter-back
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+```
+
+#### `observability/grafana/datasources/datasource.yml`
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+  - name: Jaeger
+    type: jaeger
+    url: http://jaeger:16686
+```
+
+### Arquitectura y Dependencias
+
+- Sin cambios al dominio ni a la capa de aplicación más allá de las anotaciones `@Observed`
+- `ObservabilityConfig` es el único punto de acoplamiento a Micrometer en `infrastructure/config/`
+- Inyección de `MeterRegistry` en use cases via constructor (cumple regla de no `@Autowired`)
+- `ObservedAspect` intercepta métodos `@Observed` en el proxy Spring — los use cases deben estar como beans Spring (ya lo están con `@Service`)
+
+### Notas de Implementación
+
+> - `micrometer-tracing-bridge-otel` actúa como puente: el código de la app usa la API de Micrometer Observation; el bridge traduce a OpenTelemetry SDK en runtime. Esto evita acoplamiento directo al SDK de OTel en código de aplicación.
+> - Spring Boot 4 autoconfigura `ObservationRegistry` y el bridge OTel cuando ambas dependencias están en classpath. Solo se necesita el bean `ObservedAspect` manual.
+> - El tag `businessType` en métricas proviene del campo `Quote.businessType` del dominio. El use case ya lo tiene disponible en el command.
+> - Para el timer `premium.calculate.duration`, usar `Observation.createNotStarted()` o inyectar `Timer.Sample` — más preciso que `@Observed` solo (que registra duración pero no la expone como Timer separado).
+> - Jaeger `all-in-one` solo para desarrollo local. No usar en producción — usar Jaeger distribuido o Grafana Tempo.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable para el agente backend. Marcar cada ítem (`[x]`) al completarlo.
+
+### Backend
+
+#### Dependencias y configuración base
+- [ ] Agregar 4 dependencias a `build.gradle.kts` (actuator, micrometer-tracing-bridge-otel, opentelemetry-exporter-otlp, micrometer-registry-prometheus)
+- [ ] Agregar bloque de observabilidad a `application.properties` (5 properties: spring.application.name, management.endpoints, tracing.sampling, otlp.endpoint, logging.pattern.level)
+- [ ] Crear `infrastructure/config/ObservabilityConfig.java` con bean `ObservedAspect`
+
+#### Pilar 1 — Logs correlacionados
+- [ ] Verificar que `logging.pattern.level` incluye `%X{traceId:-}` y `%X{spanId:-}` en `application.properties`
+- [ ] Crear `logback-spring.xml` en `src/main/resources/` con patrón JSON estructurado que incluya traceId/spanId
+
+#### Pilar 2 — Métricas
+- [ ] Inyectar `MeterRegistry` en `CreateFolioUseCaseImpl` y registrar counter `quotes.created` con tag `businessType`
+- [ ] Inyectar `MeterRegistry` en `CalculatePremiumUseCaseImpl` y registrar counter `premium.calculated` + timer `premium.calculate.duration` con tags `riskClassification` y `businessType`
+- [ ] Registrar counter `calculation.errors` en bloque catch de `CalculatePremiumUseCaseImpl` con tag `errorType`
+- [ ] Inyectar `MeterRegistry` en `AcceptQuoteUseCaseImpl` y registrar counter `quote.accepted`
+- [ ] Inyectar `MeterRegistry` en `SaveCoverageOptionsUseCaseImpl` y registrar counter `coverage.options.saved`
+
+#### Pilar 3 — Trazas distribuidas
+- [ ] Agregar `@Observed(name = "folio.create")` a `CreateFolioUseCaseImpl.createFolio()`
+- [ ] Agregar `@Observed(name = "folio.state.get")` a `GetQuoteStateUseCaseImpl.getQuoteState()`
+- [ ] Agregar `@Observed(name = "folio.list")` a `ListFoliosUseCaseImpl.listFolios()`
+- [ ] Agregar `@Observed(name = "premium.calculate")` a `CalculatePremiumUseCaseImpl.calculatePremium()`
+- [ ] Agregar `@Observed(name = "quote.accept")` a `AcceptQuoteUseCaseImpl.acceptQuote()`
+- [ ] Agregar `@Observed(name = "calculation.result.get")` a `GetCalculationResultUseCaseImpl.getCalculationResult()`
+- [ ] Agregar `@Observed(name = "coverage.options.save")` a `SaveCoverageOptionsUseCaseImpl.saveCoverageOptions()`
+- [ ] Agregar `@Observed(name = "coverage.options.get")` a `GetCoverageOptionsUseCaseImpl.getCoverageOptions()`
+
+#### Docker Compose (stack de observabilidad local)
+- [ ] Agregar servicios `jaeger`, `prometheus`, `grafana` a `compose.yaml`
+- [ ] Crear `observability/prometheus.yml` con scrape config para `insurance-quoter-back`
+- [ ] Crear `observability/grafana/datasources/datasource.yml` con datasources Prometheus y Jaeger
+
+#### Tests Backend
+- [ ] `ObservabilityConfigTest` — verifica que bean `ObservedAspect` existe en contexto Spring (`@SpringBootTest`)
+- [ ] `QuoteMetricsTest` — verifica que `quotes.created` counter se incrementa al ejecutar `CreateFolioUseCaseImpl` (test unitario con `SimpleMeterRegistry`)
+- [ ] `PremiumMetricsTest` — verifica que `premium.calculated` counter y `premium.calculate.duration` timer se registran al ejecutar `CalculatePremiumUseCaseImpl`
+- [ ] `CalculationErrorMetricsTest` — verifica que `calculation.errors` counter se incrementa cuando se lanza `NoCalculableLocationsException`
+- [ ] `ActuatorPrometheusIT` — integración: GET /actuator/prometheus retorna 200 y contiene `jvm_memory_used_bytes` (usa `@SpringBootTest` + Testcontainers)
+- [ ] `TracingMdcIT` — integración: verifica que una request a `POST /v1/quotes` genera logs con traceId no vacío en MDC
+
+### QA
+- [ ] Ejecutar skill `/gherkin-case-generator` → criterios CRITERIO-1.1, 2.1, 2.2, 3.1
+- [ ] Ejecutar skill `/risk-identifier` → clasificación ASD de riesgos (baja complejidad de negocio, media de infraestructura)
+- [ ] Levantar stack con `docker compose up` y verificar manualmente:
+  - Jaeger UI en `http://localhost:16686` muestra traces de `insurance-quoter-back`
+  - Prometheus en `http://localhost:9090` tiene target UP
+  - Grafana en `http://localhost:3000` muestra datasources conectados
+- [ ] Verificar que métricas custom aparecen en `/actuator/prometheus` tras ejecutar operaciones de negocio
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/.claude/specs/observability.spec.md
+++ b/.claude/specs/observability.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-008
-status: APPROVED
+status: IMPLEMENTED
 feature: observability
 created: 2026-04-27
 updated: 2026-04-27

--- a/.claude/specs/observability.spec.md
+++ b/.claude/specs/observability.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-008
-status: DRAFT
+status: APPROVED
 feature: observability
 created: 2026-04-27
 updated: 2026-04-27

--- a/README.md
+++ b/README.md
@@ -13,26 +13,30 @@ Backend del cotizador de seguros de daños. Microservicio responsable de la gest
 | Flyway | 11.x |
 | Lombok | — |
 | Springdoc OpenAPI | 2.8.x |
+| Micrometer + OTel Bridge | — |
+| Prometheus | 2.51 |
+| Jaeger | 1.57 |
+| Grafana | 10.4 |
 
 Arquitectura: **Hexagonal (Ports & Adapters)** con bounded contexts `folio`, `location`, `coverage`, `calculation`.
 
 ## Requisitos previos
 
 - Java 21+
-- Docker (para PostgreSQL vía Spring Boot Docker Compose)
-- Variables de entorno: `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD`
+- Docker Desktop corriendo
+- Variables de entorno: `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` (ver `.env` en el directorio padre `Insurance-Quoter/`)
 
 El servicio también consume el **core service** (`plataforma-core-ohs`) en `http://localhost:8081`. Debe estar levantado para que los endpoints de folios y cálculo funcionen.
 
 ## Ejecutar en local
 
 ```bash
-# Desde Insurance-Quoter-Back/
-DB_NAME=insurance_quoter_db DB_USERNAME=quoter DB_PASSWORD=quoter123 \
-  ./gradlew bootRun
-```
+# 1. Levantar infraestructura (PostgreSQL, Jaeger, Prometheus, Grafana)
+docker compose up -d
 
-Spring Boot Docker Compose levanta automáticamente el contenedor de PostgreSQL al arrancar y lo detiene al parar.
+# 2. Arrancar la aplicación (desde Insurance-Quoter-Back/)
+./gradlew bootRun
+```
 
 El backend queda disponible en `http://localhost:8080`.
 
@@ -138,6 +142,22 @@ Cada bounded context sigue la estructura hexagonal:
     └── config/         ← Wiring de beans y configuración
 ```
 
+## Observabilidad
+
+Los tres pilares están implementados (SPEC-008):
+
+| Pilar | Herramienta | Acceso |
+|-------|------------|--------|
+| Métricas | Prometheus + Grafana | `http://localhost:9090` / `http://localhost:3000` |
+| Trazas | Jaeger (OTLP gRPC) | `http://localhost:16687` |
+| Logs | Logback con `traceId`/`spanId` en MDC | consola / archivo |
+
+Grafana: usuario `admin`, contraseña `admin`. Prometheus y Jaeger ya están configurados como datasources.
+
+Métricas expuestas en `/actuator/prometheus`. El endpoint `/actuator/health` muestra estado de DB.
+
+> **Nota:** Jaeger de este back corre en puertos `16687` / `4319` / `4320` para no colisionar con `insurance-quoter-core` que usa `16686` / `4317` / `4318`.
+
 ## Variables de entorno
 
 | Variable | Default | Descripción |
@@ -150,3 +170,5 @@ Cada bounded context sigue la estructura hexagonal:
 | `core.service.base-url` | `http://localhost:8081` | URL base del core service |
 | `core.service.connect-timeout-ms` | `5000` | Timeout de conexión al core (ms) |
 | `core.service.read-timeout-ms` | `10000` | Timeout de lectura al core (ms) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4319` | Endpoint OTLP gRPC para Jaeger |
+| `TRACING_SAMPLING_PROBABILITY` | `1.0` | Proporción de trazas exportadas (0.0–1.0) |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,12 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
+
+    // Observability: actuator endpoints + Micrometer tracing (OTel bridge) + Prometheus metrics
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-tracing-bridge-otel")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+    implementation("io.micrometer:micrometer-registry-prometheus")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     runtimeOnly("org.postgresql:postgresql")

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,9 +11,9 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:1.57
     ports:
-      - '16686:16686'   # UI
-      - '4317:4317'     # OTLP gRPC
-      - '4318:4318'     # OTLP HTTP
+      - '16687:16686'   # UI  (16687 avoids conflict with insurance-quoter-core on 16686)
+      - '4319:4317'     # OTLP gRPC (4319 avoids conflict with core on 4317)
+      - '4320:4318'     # OTLP HTTP (4320 avoids conflict with core on 4318)
     environment:
       - COLLECTOR_OTLP_ENABLED=true
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,3 +7,29 @@ services:
       - 'POSTGRES_PASSWORD=${DB_PASSWORD}'
     ports:
       - '5432:5432'
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    ports:
+      - '16686:16686'   # UI
+      - '4317:4317'     # OTLP gRPC
+      - '4318:4318'     # OTLP HTTP
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    ports:
+      - '3000:3000'
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./observability/grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./observability/grafana/dashboards:/etc/grafana/provisioning/dashboards

--- a/observability/grafana/datasources/datasource.yml
+++ b/observability/grafana/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+  - name: Jaeger
+    type: jaeger
+    url: http://jaeger:16686

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: insurance-quoter-back
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/AcceptQuoteUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/AcceptQuoteUseCaseImpl.java
@@ -4,20 +4,29 @@ import com.sofka.insurancequoter.back.calculation.application.usecase.command.Ac
 import com.sofka.insurancequoter.back.calculation.domain.model.AcceptQuoteResult;
 import com.sofka.insurancequoter.back.calculation.domain.port.in.AcceptQuoteUseCase;
 import com.sofka.insurancequoter.back.calculation.domain.port.out.AcceptQuoteRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.annotation.Observed;
 
 import java.time.Instant;
 
 public class AcceptQuoteUseCaseImpl implements AcceptQuoteUseCase {
 
     private final AcceptQuoteRepository repository;
+    private final Counter acceptedCounter;
 
-    public AcceptQuoteUseCaseImpl(AcceptQuoteRepository repository) {
+    public AcceptQuoteUseCaseImpl(AcceptQuoteRepository repository, MeterRegistry meterRegistry) {
         this.repository = repository;
+        this.acceptedCounter = Counter.builder("quote.accepted")
+                .description("Quotes accepted and issued")
+                .register(meterRegistry);
     }
 
     @Override
+    @Observed(name = "quote.accept")
     public AcceptQuoteResult accept(AcceptQuoteCommand command) {
         long newVersion = repository.accept(command);
+        acceptedCounter.increment();
         return new AcceptQuoteResult(
                 command.folioNumber(),
                 "ISSUED",

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/CalculatePremiumUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/CalculatePremiumUseCaseImpl.java
@@ -13,6 +13,9 @@ import com.sofka.insurancequoter.back.calculation.domain.port.out.TariffClient;
 import com.sofka.insurancequoter.back.calculation.domain.service.CalculationService;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
 import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.annotation.Observed;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -29,20 +32,31 @@ public class CalculatePremiumUseCaseImpl implements CalculatePremiumUseCase {
     private final TariffClient tariffClient;
     private final GuaranteeCatalogClient guaranteeCatalogClient;
     private final CalculationService calculationService;
+    private final Counter calculatedCounter;
+    private final Counter errorCounter;
 
     public CalculatePremiumUseCaseImpl(QuoteCalculationReader quoteCalculationReader,
                                        CalculationResultRepository calculationResultRepository,
                                        TariffClient tariffClient,
                                        GuaranteeCatalogClient guaranteeCatalogClient,
-                                       CalculationService calculationService) {
+                                       CalculationService calculationService,
+                                       MeterRegistry meterRegistry) {
         this.quoteCalculationReader = quoteCalculationReader;
         this.calculationResultRepository = calculationResultRepository;
         this.tariffClient = tariffClient;
         this.guaranteeCatalogClient = guaranteeCatalogClient;
         this.calculationService = calculationService;
+        this.calculatedCounter = Counter.builder("premium.calculated")
+                .description("Successful premium calculations")
+                .register(meterRegistry);
+        this.errorCounter = Counter.builder("calculation.errors")
+                .tag("errorType", "NoCalculableLocations")
+                .description("Premium calculations failed due to no calculable locations")
+                .register(meterRegistry);
     }
 
     @Override
+    @Observed(name = "premium.calculate")
     public CalculationResult calculate(CalculatePremiumCommand command) {
         // 1. Load snapshot — throws FolioNotFoundException if not found
         QuoteCalculationSnapshot snapshot = quoteCalculationReader.getSnapshot(command.folioNumber());
@@ -69,6 +83,7 @@ public class CalculatePremiumUseCaseImpl implements CalculatePremiumUseCase {
         // 6. Validate at least one calculable location
         boolean hasCalculable = premiumsByLocation.stream().anyMatch(PremiumByLocation::calculable);
         if (!hasCalculable) {
+            errorCounter.increment();
             throw new NoCalculableLocationsException();
         }
 
@@ -97,6 +112,7 @@ public class CalculatePremiumUseCaseImpl implements CalculatePremiumUseCase {
         long newVersion = calculationResultRepository.persist(command.folioNumber(), result);
 
         // 11. Return result with the real version
+        calculatedCounter.increment();
         return new CalculationResult(
                 result.folioNumber(),
                 result.netPremium(),

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/GetCalculationResultUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/application/usecase/GetCalculationResultUseCaseImpl.java
@@ -14,6 +14,7 @@ public class GetCalculationResultUseCaseImpl implements GetCalculationResultUseC
     }
 
     @Override
+    @io.micrometer.observation.annotation.Observed(name = "calculation.result.get")
     public CalculationResult get(String folioNumber) {
         return repository.find(folioNumber)
                 .orElseThrow(() -> new CalculationResultNotFoundException(folioNumber));

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/config/CalculationConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/config/CalculationConfig.java
@@ -22,6 +22,7 @@ import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persis
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -84,13 +85,15 @@ public class CalculationConfig {
             CalculationResultJpaAdapter calculationResultJpaAdapter,
             TariffClient tariffClient,
             GuaranteeCatalogClient guaranteeCatalogClient,
-            CalculationService calculationService) {
+            CalculationService calculationService,
+            MeterRegistry meterRegistry) {
         return new CalculatePremiumUseCaseImpl(
                 (QuoteCalculationReader) calculationResultJpaAdapter,
                 (CalculationResultRepository) calculationResultJpaAdapter,
                 tariffClient,
                 guaranteeCatalogClient,
-                calculationService
+                calculationService,
+                meterRegistry
         );
     }
 
@@ -104,9 +107,11 @@ public class CalculationConfig {
 
     @Bean
     public AcceptQuoteUseCase acceptQuoteUseCase(
-            CalculationResultJpaAdapter calculationResultJpaAdapter) {
+            CalculationResultJpaAdapter calculationResultJpaAdapter,
+            MeterRegistry meterRegistry) {
         return new AcceptQuoteUseCaseImpl(
-                (AcceptQuoteRepository) calculationResultJpaAdapter
+                (AcceptQuoteRepository) calculationResultJpaAdapter,
+                meterRegistry
         );
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/GetCoverageOptionsUseCaseImpl.java
@@ -30,6 +30,7 @@ public class GetCoverageOptionsUseCaseImpl implements GetCoverageOptionsUseCase 
     }
 
     @Override
+    @io.micrometer.observation.annotation.Observed(name = "coverage.options.get")
     public CoverageOptionsResponse getCoverageOptions(String folioNumber) {
         quoteLookupPort.assertFolioExists(folioNumber);
 

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImpl.java
@@ -8,6 +8,9 @@ import com.sofka.insurancequoter.back.coverage.domain.port.in.SaveCoverageOption
 import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
 import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
 import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.annotation.Observed;
 
 import java.util.HashSet;
 import java.util.List;
@@ -20,16 +23,22 @@ public class SaveCoverageOptionsUseCaseImpl implements SaveCoverageOptionsUseCas
     private final QuoteLookupPort quoteLookupPort;
     private final CoverageOptionRepository coverageOptionRepository;
     private final CoverageDerivationService coverageDerivationService;
+    private final Counter savedCounter;
 
     public SaveCoverageOptionsUseCaseImpl(QuoteLookupPort quoteLookupPort,
                                           CoverageOptionRepository coverageOptionRepository,
-                                          CoverageDerivationService coverageDerivationService) {
+                                          CoverageDerivationService coverageDerivationService,
+                                          MeterRegistry meterRegistry) {
         this.quoteLookupPort = quoteLookupPort;
         this.coverageOptionRepository = coverageOptionRepository;
         this.coverageDerivationService = coverageDerivationService;
+        this.savedCounter = Counter.builder("coverage.options.saved")
+                .description("Coverage option sets saved")
+                .register(meterRegistry);
     }
 
     @Override
+    @Observed(name = "coverage.options.save")
     public CoverageOptionsResponse saveCoverageOptions(SaveCoverageOptionsCommand command) {
         quoteLookupPort.assertFolioExists(command.folioNumber());
         quoteLookupPort.assertVersionMatches(command.folioNumber(), command.version());
@@ -61,7 +70,7 @@ public class SaveCoverageOptionsUseCaseImpl implements SaveCoverageOptionsUseCas
         List<CoverageOption> saved = coverageOptionRepository.replaceAll(command.folioNumber(), enriched);
         long newVersion = quoteLookupPort.getCurrentVersion(command.folioNumber());
         java.time.Instant updatedAt = quoteLookupPort.getUpdatedAt(command.folioNumber());
-
+        savedCounter.increment();
         return new CoverageOptionsResponse(command.folioNumber(), saved, updatedAt, newVersion);
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
@@ -15,6 +15,7 @@ import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persis
 import com.sofka.insurancequoter.back.coverage.infrastructure.adapter.out.persistence.repositories.CoverageOptionJpaRepository;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -67,8 +68,9 @@ public class CoverageConfig {
     @Bean
     public SaveCoverageOptionsUseCase saveCoverageOptionsUseCase(
             CoverageOptionJpaAdapter adapter,
-            CoverageDerivationService coverageDerivationService) {
-        return new SaveCoverageOptionsUseCaseImpl(adapter, adapter, coverageDerivationService);
+            CoverageDerivationService coverageDerivationService,
+            MeterRegistry meterRegistry) {
+        return new SaveCoverageOptionsUseCaseImpl(adapter, adapter, coverageDerivationService, meterRegistry);
     }
 
     @Bean

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImpl.java
@@ -5,24 +5,43 @@ import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
 import com.sofka.insurancequoter.back.folio.domain.port.in.CreateFolioUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import java.time.Instant;
 import java.util.Optional;
 
 // Orchestrates idempotency check → reference validation → folio generation → persistence
-@RequiredArgsConstructor
 public class CreateFolioUseCaseImpl implements CreateFolioUseCase {
 
     private final QuoteRepository quoteRepository;
     private final CoreServiceClient coreServiceClient;
+    private final Counter newFolioCounter;
+    private final Counter existingFolioCounter;
+
+    public CreateFolioUseCaseImpl(QuoteRepository quoteRepository,
+                                   CoreServiceClient coreServiceClient,
+                                   MeterRegistry meterRegistry) {
+        this.quoteRepository = quoteRepository;
+        this.coreServiceClient = coreServiceClient;
+        this.newFolioCounter = Counter.builder("quotes.created")
+                .tag("outcome", "new")
+                .description("New folios created")
+                .register(meterRegistry);
+        this.existingFolioCounter = Counter.builder("quotes.created")
+                .tag("outcome", "existing")
+                .description("Existing folios returned (idempotency)")
+                .register(meterRegistry);
+    }
 
     @Override
+    @io.micrometer.observation.annotation.Observed(name = "folio.create")
     public FolioCreationResult createFolio(CreateFolioCommand command) {
         // Step 1: idempotency — return existing CREATED folio if found
         Optional<Quote> existing =
                 quoteRepository.findActiveBySubscriberAndAgent(command.subscriberId(), command.agentCode());
         if (existing.isPresent()) {
+            existingFolioCounter.increment();
             return new FolioCreationResult(existing.get(), false);
         }
 
@@ -55,6 +74,7 @@ public class CreateFolioUseCaseImpl implements CreateFolioUseCase {
         Quote saved = quoteRepository.save(newQuote);
 
         // Step 6: return result flagged as newly created
+        newFolioCounter.increment();
         return new FolioCreationResult(saved, true);
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/GetQuoteStateUseCaseImpl.java
@@ -21,6 +21,7 @@ public class GetQuoteStateUseCaseImpl implements GetQuoteStateUseCase {
     }
 
     @Override
+    @io.micrometer.observation.annotation.Observed(name = "folio.state.get")
     public QuoteState getState(String folioNumber) {
         QuoteSnapshot snapshot = quoteStateQuery.findByFolioNumber(folioNumber);
         LocationStateSummary locationSummary = locationStateReader.readByFolioNumber(folioNumber);

--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImpl.java
@@ -26,6 +26,7 @@ public class ListFoliosUseCaseImpl implements ListFoliosUseCase {
     }
 
     @Override
+    @io.micrometer.observation.annotation.Observed(name = "folio.list")
     public List<FolioSummary> listFolios() {
         return folioListQuery.findAll().stream()
                 .map(this::enrich)

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
@@ -13,6 +13,7 @@ import com.sofka.insurancequoter.back.folio.domain.port.out.LocationStateReader;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.adapter.CoreServiceClientAdapter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,8 +36,9 @@ public class FolioConfig {
 
     @Bean
     public CreateFolioUseCase createFolioUseCase(QuoteRepository quoteRepository,
-                                                  CoreServiceClient coreServiceClient) {
-        return new CreateFolioUseCaseImpl(quoteRepository, coreServiceClient);
+                                                  CoreServiceClient coreServiceClient,
+                                                  MeterRegistry meterRegistry) {
+        return new CreateFolioUseCaseImpl(quoteRepository, coreServiceClient, meterRegistry);
     }
 
     @Bean

--- a/src/main/java/com/sofka/insurancequoter/back/shared/infrastructure/config/ObservabilityConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/shared/infrastructure/config/ObservabilityConfig.java
@@ -1,0 +1,16 @@
+package com.sofka.insurancequoter.back.shared.infrastructure.config;
+
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservedAspect;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// Enables @Observed AOP support across all use cases
+@Configuration
+public class ObservabilityConfig {
+
+    @Bean
+    public ObservedAspect observedAspect(ObservationRegistry registry) {
+        return new ObservedAspect(registry);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=Insurance-Quoter
+spring.application.name=insurance-quoter-back
 server.port=8080
 
 # Datasource — PostgreSQL insurance_quoter_db (:5432)
@@ -25,7 +25,14 @@ core.service.base-url=http://localhost:8081
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui/index.html
 
+# Observability — Actuator, tracing (OTLP → Jaeger), metrics (Prometheus)
+management.endpoints.web.exposure.include=health,prometheus,metrics
+management.endpoint.health.show-details=always
+management.tracing.sampling.probability=${TRACING_SAMPLING_PROBABILITY:1.0}
+management.otlp.tracing.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
+
 # Logging — solo lo relevante para el proyecto
+logging.pattern.level=%5p [${spring.application.name},%X{traceId:-},%X{spanId:-}]
 logging.level.root=WARN
 logging.level.com.sofka.insurancequoter=INFO
 logging.level.org.flywaydb=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,7 +29,7 @@ springdoc.swagger-ui.path=/swagger-ui/index.html
 management.endpoints.web.exposure.include=health,prometheus,metrics
 management.endpoint.health.show-details=always
 management.tracing.sampling.probability=${TRACING_SAMPLING_PROBABILITY:1.0}
-management.otlp.tracing.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
+management.otlp.tracing.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4319}
 
 # Logging — solo lo relevante para el proyecto
 logging.pattern.level=%5p [${spring.application.name},%X{traceId:-},%X{spanId:-}]

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [${appName},%X{traceId:-},%X{spanId:-}] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <logger name="com.sofka.insurancequoter" level="INFO"/>
+    <logger name="org.flywaydb" level="INFO"/>
+    <logger name="org.springframework.web" level="WARN"/>
+    <logger name="org.springframework.boot.autoconfigure" level="ERROR"/>
+    <logger name="org.springframework.boot" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+    <logger name="org.apache.catalina" level="WARN"/>
+
+</configuration>

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/AcceptQuoteMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/AcceptQuoteMetricsTest.java
@@ -1,0 +1,45 @@
+package com.sofka.insurancequoter.back.calculation.application.usecase;
+
+import com.sofka.insurancequoter.back.calculation.application.usecase.command.AcceptQuoteCommand;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.AcceptQuoteRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AcceptQuoteMetricsTest {
+
+    @Mock
+    private AcceptQuoteRepository repository;
+
+    private SimpleMeterRegistry meterRegistry;
+    private AcceptQuoteUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        useCase = new AcceptQuoteUseCaseImpl(repository, meterRegistry);
+    }
+
+    @Test
+    void quoteAcceptedCounter_increments_whenQuoteIsAccepted() {
+        // GIVEN
+        when(repository.accept(any())).thenReturn(2L);
+
+        // WHEN
+        useCase.accept(new AcceptQuoteCommand("FOL-001", "USER-1", 1L));
+
+        // THEN
+        Counter counter = meterRegistry.find("quote.accepted").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/CalculatePremiumUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/CalculatePremiumUseCaseImplTest.java
@@ -81,7 +81,8 @@ class CalculatePremiumUseCaseImplTest {
         calculationService = new CalculationService();
         useCase = new CalculatePremiumUseCaseImpl(
                 quoteCalculationReader, calculationResultRepository,
-                tariffClient, guaranteeCatalogClient, calculationService
+                tariffClient, guaranteeCatalogClient, calculationService,
+                new io.micrometer.core.instrument.simple.SimpleMeterRegistry()
         );
     }
 

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/PremiumMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/application/usecase/PremiumMetricsTest.java
@@ -1,0 +1,111 @@
+package com.sofka.insurancequoter.back.calculation.application.usecase;
+
+import com.sofka.insurancequoter.back.calculation.application.usecase.command.CalculatePremiumCommand;
+import com.sofka.insurancequoter.back.calculation.application.usecase.dto.QuoteCalculationSnapshot;
+import com.sofka.insurancequoter.back.calculation.application.usecase.exception.NoCalculableLocationsException;
+import com.sofka.insurancequoter.back.calculation.domain.model.PremiumByLocation;
+import com.sofka.insurancequoter.back.calculation.domain.model.Tariff;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.CalculationResultRepository;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.QuoteCalculationReader;
+import com.sofka.insurancequoter.back.calculation.domain.port.out.TariffClient;
+import com.sofka.insurancequoter.back.calculation.domain.service.CalculationService;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.GuaranteeCatalogClient;
+import com.sofka.insurancequoter.back.location.domain.model.Location;
+import com.sofka.insurancequoter.back.location.domain.model.ValidationStatus;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PremiumMetricsTest {
+
+    @Mock private QuoteCalculationReader quoteCalculationReader;
+    @Mock private CalculationResultRepository calculationResultRepository;
+    @Mock private TariffClient tariffClient;
+    @Mock private GuaranteeCatalogClient guaranteeCatalogClient;
+    @Mock private CalculationService calculationService;
+
+    private SimpleMeterRegistry meterRegistry;
+    private CalculatePremiumUseCaseImpl useCase;
+
+    private static final Tariff TARIFF = new Tariff(
+            BigDecimal.valueOf(0.001), BigDecimal.valueOf(0.001), BigDecimal.ONE,
+            BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE,
+            BigDecimal.valueOf(0.001), BigDecimal.valueOf(0.001), BigDecimal.valueOf(0.001),
+            BigDecimal.valueOf(0.001), BigDecimal.valueOf(0.001), BigDecimal.valueOf(0.001),
+            BigDecimal.valueOf(0.001), BigDecimal.valueOf(1.1)
+    );
+
+    private static final Location DUMMY_LOCATION = new Location(
+            0, true, "loc1", "addr", "12345", "ST", "MUN",
+            "COL", "CITY", "C1", 1, 2000, null, List.of(),
+            null, ValidationStatus.COMPLETE, List.of()
+    );
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        useCase = new CalculatePremiumUseCaseImpl(
+                quoteCalculationReader, calculationResultRepository,
+                tariffClient, guaranteeCatalogClient, calculationService, meterRegistry);
+    }
+
+    @Test
+    void premiumCalculatedCounter_increments_whenCalculationSucceeds() {
+        // GIVEN
+        QuoteCalculationSnapshot snapshot = new QuoteCalculationSnapshot("FOL-001", 1L,
+                List.of(DUMMY_LOCATION), List.of());
+        PremiumByLocation calculable = new PremiumByLocation(0, "loc1",
+                BigDecimal.valueOf(100), BigDecimal.valueOf(110), true, null, List.of());
+
+        when(quoteCalculationReader.getSnapshot("FOL-001")).thenReturn(snapshot);
+        when(tariffClient.fetchTariffs()).thenReturn(TARIFF);
+        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(List.of());
+        when(calculationService.calculateLocation(any(), any(), anySet())).thenReturn(calculable);
+        when(calculationResultRepository.persist(any(), any())).thenReturn(2L);
+
+        // WHEN
+        useCase.calculate(new CalculatePremiumCommand("FOL-001", 1L));
+
+        // THEN
+        Counter counter = meterRegistry.find("premium.calculated").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void calculationErrorCounter_increments_whenNoCalculableLocations() {
+        // GIVEN
+        QuoteCalculationSnapshot snapshot = new QuoteCalculationSnapshot("FOL-001", 1L,
+                List.of(DUMMY_LOCATION), List.of());
+        PremiumByLocation nonCalculable = new PremiumByLocation(0, "loc1",
+                null, null, false, null, List.of());
+
+        when(quoteCalculationReader.getSnapshot("FOL-001")).thenReturn(snapshot);
+        when(tariffClient.fetchTariffs()).thenReturn(TARIFF);
+        when(guaranteeCatalogClient.fetchGuarantees()).thenReturn(List.of());
+        when(calculationService.calculateLocation(any(), any(), anySet())).thenReturn(nonCalculable);
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.calculate(new CalculatePremiumCommand("FOL-001", 1L)))
+                .isInstanceOf(NoCalculableLocationsException.class);
+
+        Counter errorCounter = meterRegistry.find("calculation.errors")
+                .tag("errorType", "NoCalculableLocations").counter();
+        assertThat(errorCounter).isNotNull();
+        assertThat(errorCounter.count()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/CoverageMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/CoverageMetricsTest.java
@@ -1,0 +1,65 @@
+package com.sofka.insurancequoter.back.coverage.application.usecase;
+
+import com.sofka.insurancequoter.back.coverage.application.usecase.command.SaveCoverageOptionsCommand;
+import com.sofka.insurancequoter.back.coverage.domain.model.CoverageOption;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.CoverageOptionRepository;
+import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
+import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CoverageMetricsTest {
+
+    @Mock private QuoteLookupPort quoteLookupPort;
+    @Mock private CoverageOptionRepository coverageOptionRepository;
+    @Mock private CoverageDerivationService coverageDerivationService;
+
+    private SimpleMeterRegistry meterRegistry;
+    private SaveCoverageOptionsUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        useCase = new SaveCoverageOptionsUseCaseImpl(
+                quoteLookupPort, coverageOptionRepository, coverageDerivationService, meterRegistry);
+    }
+
+    @Test
+    void coverageOptionsSavedCounter_increments_whenOptionsAreSaved() {
+        // GIVEN
+        CoverageOption option = new CoverageOption("COV-001", "Incendio", true,
+                java.math.BigDecimal.valueOf(5), java.math.BigDecimal.valueOf(10));
+        SaveCoverageOptionsCommand command = new SaveCoverageOptionsCommand(
+                "FOL-001", List.of(option), 1L);
+
+        when(coverageDerivationService.knownDescriptions())
+                .thenReturn(Map.of("COV-001", "Incendio"));
+        when(coverageOptionRepository.replaceAll(anyString(), any()))
+                .thenReturn(List.of(option));
+        when(quoteLookupPort.getCurrentVersion("FOL-001")).thenReturn(2L);
+        when(quoteLookupPort.getUpdatedAt("FOL-001")).thenReturn(Instant.now());
+
+        // WHEN
+        useCase.saveCoverageOptions(command);
+
+        // THEN
+        Counter counter = meterRegistry.find("coverage.options.saved").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/application/usecase/SaveCoverageOptionsUseCaseImplTest.java
@@ -9,10 +9,11 @@ import com.sofka.insurancequoter.back.coverage.domain.port.out.QuoteLookupPort;
 import com.sofka.insurancequoter.back.coverage.domain.service.CoverageDerivationService;
 import com.sofka.insurancequoter.back.location.application.usecase.FolioNotFoundException;
 import com.sofka.insurancequoter.back.location.application.usecase.VersionConflictException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -42,8 +43,14 @@ class SaveCoverageOptionsUseCaseImplTest {
     @Mock
     private CoverageDerivationService coverageDerivationService;
 
-    @InjectMocks
     private SaveCoverageOptionsUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new SaveCoverageOptionsUseCaseImpl(
+                quoteLookupPort, coverageOptionRepository, coverageDerivationService,
+                new SimpleMeterRegistry());
+    }
 
     private static final String FOLIO = "FOL-2026-00042";
 

--- a/src/test/java/com/sofka/insurancequoter/back/coverage/integration/CoverageOptionsIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/coverage/integration/CoverageOptionsIntegrationTest.java
@@ -111,18 +111,18 @@ class CoverageOptionsIntegrationTest {
                         .content("""
                                 {
                                   "coverageOptions": [
-                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0},
-                                    {"code":"GUA-THEFT","selected":false,"deductiblePercentage":5.0,"coinsurancePercentage":100.0}
+                                    {"code":"COV-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0},
+                                    {"code":"COV-THEFT","selected":false,"deductiblePercentage":5.0,"coinsurancePercentage":100.0}
                                   ],
                                   "version": %d
                                 }
                                 """.formatted(version)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.folioNumber").value(FOLIO))
-                .andExpect(jsonPath("$.coverageOptions[0].code").value("GUA-FIRE"))
-                .andExpect(jsonPath("$.coverageOptions[0].description").value("Incendio edificios"))
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("COV-FIRE"))
+                .andExpect(jsonPath("$.coverageOptions[0].description").value("Incendio y riesgos adicionales"))
                 .andExpect(jsonPath("$.coverageOptions[0].selected").value(true))
-                .andExpect(jsonPath("$.coverageOptions[1].code").value("GUA-THEFT"))
+                .andExpect(jsonPath("$.coverageOptions[1].code").value("COV-THEFT"))
                 .andExpect(jsonPath("$.coverageOptions[1].selected").value(false));
 
         // GET returns same persisted data
@@ -130,9 +130,9 @@ class CoverageOptionsIntegrationTest {
                         .get("/v1/quotes/{folio}/coverage-options", FOLIO))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.folioNumber").value(FOLIO))
-                .andExpect(jsonPath("$.coverageOptions[0].code").value("GUA-FIRE"))
-                .andExpect(jsonPath("$.coverageOptions[0].description").value("Incendio edificios"))
-                .andExpect(jsonPath("$.coverageOptions[1].code").value("GUA-THEFT"));
+                .andExpect(jsonPath("$.coverageOptions[0].code").value("COV-FIRE"))
+                .andExpect(jsonPath("$.coverageOptions[0].description").value("Incendio y riesgos adicionales"))
+                .andExpect(jsonPath("$.coverageOptions[1].code").value("COV-THEFT"));
     }
 
     // --- #198: PUT with stale version returns 409 and does not modify data ---
@@ -148,7 +148,7 @@ class CoverageOptionsIntegrationTest {
                         .content("""
                                 {
                                   "coverageOptions": [
-                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                    {"code":"COV-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
                                   ],
                                   "version": %d
                                 }
@@ -161,7 +161,7 @@ class CoverageOptionsIntegrationTest {
                         .content("""
                                 {
                                   "coverageOptions": [
-                                    {"code":"GUA-THEFT","selected":true,"deductiblePercentage":5.0,"coinsurancePercentage":100.0}
+                                    {"code":"COV-THEFT","selected":true,"deductiblePercentage":5.0,"coinsurancePercentage":100.0}
                                   ],
                                   "version": %d
                                 }
@@ -221,7 +221,7 @@ class CoverageOptionsIntegrationTest {
                         .content("""
                                 {
                                   "coverageOptions": [
-                                    {"code":"GUA-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
+                                    {"code":"COV-FIRE","selected":true,"deductiblePercentage":2.0,"coinsurancePercentage":80.0}
                                   ],
                                   "version": %d
                                 }

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/CreateFolioUseCaseImplTest.java
@@ -4,9 +4,10 @@ import com.sofka.insurancequoter.back.folio.domain.model.Quote;
 import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
 import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -34,8 +35,12 @@ class CreateFolioUseCaseImplTest {
     @Mock
     private CoreServiceClient coreServiceClient;
 
-    @InjectMocks
     private CreateFolioUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateFolioUseCaseImpl(quoteRepository, coreServiceClient, new SimpleMeterRegistry());
+    }
 
     // --- CRITERIO-1.2: Idempotencia — folio existente en CREATED ---
 

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/QuoteMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/QuoteMetricsTest.java
@@ -1,0 +1,73 @@
+package com.sofka.insurancequoter.back.folio.application.usecase;
+
+import com.sofka.insurancequoter.back.folio.domain.model.Quote;
+import com.sofka.insurancequoter.back.folio.domain.model.QuoteStatus;
+import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
+import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QuoteMetricsTest {
+
+    @Mock
+    private QuoteRepository quoteRepository;
+
+    @Mock
+    private CoreServiceClient coreServiceClient;
+
+    private SimpleMeterRegistry meterRegistry;
+    private CreateFolioUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        useCase = new CreateFolioUseCaseImpl(quoteRepository, coreServiceClient, meterRegistry);
+    }
+
+    @Test
+    void quotesCreatedCounter_increments_withOutcomeNew_whenFolioIsCreated() {
+        // GIVEN
+        Quote saved = new Quote("FOL-2026-00001", QuoteStatus.CREATED, "SUB-1", "AGT-1", 0L, Instant.now(), Instant.now());
+        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-1", "AGT-1")).thenReturn(Optional.empty());
+        when(coreServiceClient.existsSubscriber("SUB-1")).thenReturn(true);
+        when(coreServiceClient.existsAgent("AGT-1")).thenReturn(true);
+        when(coreServiceClient.nextFolioNumber()).thenReturn("FOL-2026-00001");
+        when(quoteRepository.save(any())).thenReturn(saved);
+
+        // WHEN
+        useCase.createFolio(new CreateFolioCommand("SUB-1", "AGT-1"));
+
+        // THEN
+        Counter counter = meterRegistry.find("quotes.created").tag("outcome", "new").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void quotesCreatedCounter_increments_withOutcomeExisting_whenFolioAlreadyExists() {
+        // GIVEN
+        Quote existing = new Quote("FOL-2026-00001", QuoteStatus.CREATED, "SUB-1", "AGT-1", 0L, Instant.now(), Instant.now());
+        when(quoteRepository.findActiveBySubscriberAndAgent("SUB-1", "AGT-1")).thenReturn(Optional.of(existing));
+
+        // WHEN
+        useCase.createFolio(new CreateFolioCommand("SUB-1", "AGT-1"));
+
+        // THEN
+        Counter counter = meterRegistry.find("quotes.created").tag("outcome", "existing").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/GeneralInfoJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/generalinfo/infrastructure/adapter/out/persistence/GeneralInfoJpaAdapterTest.java
@@ -92,7 +92,7 @@ class GeneralInfoJpaAdapterTest {
         );
         when(quoteJpaRepository.findByFolioNumber("FOL-2026-00001"))
                 .thenReturn(Optional.of(buildJpaEntity()));
-        when(quoteJpaRepository.save(any())).thenReturn(buildJpaEntity());
+        when(quoteJpaRepository.saveAndFlush(any())).thenReturn(buildJpaEntity());
 
         // WHEN
         GeneralInfo result = adapter.save(toSave);

--- a/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/QuoteLayoutJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/QuoteLayoutJpaAdapterTest.java
@@ -84,7 +84,7 @@ class QuoteLayoutJpaAdapterTest {
         QuoteJpa jpa = buildQuoteJpa("FOL-2026-00042", null, null, 1L);
         QuoteLayoutData inputData = new QuoteLayoutData(1L, "FOL-2026-00042", 3, "MULTIPLE", 1L, NOW);
         when(quoteJpaRepository.findById(1L)).thenReturn(Optional.of(jpa));
-        when(quoteJpaRepository.save(any(QuoteJpa.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(quoteJpaRepository.saveAndFlush(any(QuoteJpa.class))).thenAnswer(inv -> inv.getArgument(0));
         when(mapper.toQuoteLayoutData(any())).thenReturn(inputData);
 
         // WHEN
@@ -92,7 +92,7 @@ class QuoteLayoutJpaAdapterTest {
 
         // THEN
         ArgumentCaptor<QuoteJpa> captor = ArgumentCaptor.forClass(QuoteJpa.class);
-        verify(quoteJpaRepository).save(captor.capture());
+        verify(quoteJpaRepository).saveAndFlush(captor.capture());
         QuoteJpa persisted = captor.getValue();
         assertThat(persisted.getNumberOfLocations()).isEqualTo(3);
         assertThat(persisted.getLocationType()).isEqualTo("MULTIPLE");

--- a/src/test/java/com/sofka/insurancequoter/back/observability/ActuatorPrometheusIT.java
+++ b/src/test/java/com/sofka/insurancequoter/back/observability/ActuatorPrometheusIT.java
@@ -1,0 +1,81 @@
+package com.sofka.insurancequoter.back.observability;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.sofka.insurancequoter.InsuranceQuoterApplication;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = InsuranceQuoterApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Testcontainers
+class ActuatorPrometheusIT {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:16-alpine");
+
+    static WireMockServer wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMock.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMock.stop();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("core.service.base-url", () -> "http://localhost:" + wireMock.port());
+    }
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Test
+    void actuatorPrometheus_returns200_withJvmMetrics() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("jvm_memory_used_bytes")));
+    }
+
+    @Test
+    void actuatorPrometheus_returns200_withHttpServerMetrics() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("http_server_requests_seconds")));
+    }
+
+    @Test
+    void actuatorHealth_returns200_withDbUp() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"status\":\"UP\"")));
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/back/observability/ActuatorPrometheusIT.java
+++ b/src/test/java/com/sofka/insurancequoter/back/observability/ActuatorPrometheusIT.java
@@ -7,23 +7,23 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.client.RestClient;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = InsuranceQuoterApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest(
+        classes = InsuranceQuoterApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "management.endpoints.web.exposure.include=*"
+)
 @Testcontainers
 class ActuatorPrometheusIT {
 
@@ -33,10 +33,10 @@ class ActuatorPrometheusIT {
 
     static WireMockServer wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
 
-    @Autowired
-    private WebApplicationContext context;
+    @LocalServerPort
+    int port;
 
-    private MockMvc mockMvc;
+    RestClient client;
 
     @BeforeAll
     static void startWireMock() {
@@ -55,27 +55,36 @@ class ActuatorPrometheusIT {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        client = RestClient.create("http://localhost:" + port);
     }
 
     @Test
-    void actuatorPrometheus_returns200_withJvmMetrics() throws Exception {
-        mockMvc.perform(get("/actuator/prometheus"))
-                .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("jvm_memory_used_bytes")));
+    void actuatorPrometheus_returns200_withJvmMetrics() {
+        String body = client.get()
+                .uri("/actuator/prometheus")
+                .retrieve()
+                .body(String.class);
+        assertThat(body).contains("jvm_memory_used_bytes");
     }
 
     @Test
-    void actuatorPrometheus_returns200_withHttpServerMetrics() throws Exception {
-        mockMvc.perform(get("/actuator/prometheus"))
-                .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("http_server_requests_seconds")));
+    void actuatorPrometheus_returns200_withHttpServerMetrics() {
+        // Make a request first so the HTTP timer has at least one observation
+        client.get().uri("/actuator/health").retrieve().toBodilessEntity();
+
+        String body = client.get()
+                .uri("/actuator/prometheus")
+                .retrieve()
+                .body(String.class);
+        assertThat(body).contains("http_server_requests_seconds");
     }
 
     @Test
-    void actuatorHealth_returns200_withDbUp() throws Exception {
-        mockMvc.perform(get("/actuator/health"))
-                .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"status\":\"UP\"")));
+    void actuatorHealth_returns200_withDbUp() {
+        String body = client.get()
+                .uri("/actuator/health")
+                .retrieve()
+                .body(String.class);
+        assertThat(body).contains("\"status\":\"UP\"");
     }
 }

--- a/src/test/java/com/sofka/insurancequoter/back/observability/ObservabilityConfigTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/observability/ObservabilityConfigTest.java
@@ -1,0 +1,31 @@
+package com.sofka.insurancequoter.back.observability;
+
+import com.sofka.insurancequoter.InsuranceQuoterApplication;
+import io.micrometer.observation.aop.ObservedAspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.ApplicationContext;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = InsuranceQuoterApplication.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Testcontainers
+class ObservabilityConfigTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:16-alpine");
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void observedAspect_bean_exists_in_context() {
+        assertThat(context.getBean(ObservedAspect.class)).isNotNull();
+    }
+}


### PR DESCRIPTION
## v1.1.0

### Nuevas funcionalidades
- Logs estructurados con `traceId`/`spanId` en MDC
- Métricas JVM + HTTP + negocio custom (Micrometer → Prometheus)
- Trazas distribuidas en todos los use cases (`@Observed` → Jaeger OTLP)
- Docker Compose con Jaeger (16687/4319/4320), Prometheus (9090), Grafana (3000)

### Bugfixes
- `GeneralInfoJpaAdapterTest`: mock `saveAndFlush`
- `QuoteLayoutJpaAdapterTest`: mock y verify `saveAndFlush`
- `CoverageOptionsIntegrationTest`: códigos `COV-*` en PUT

### Estado
- 247 tests, 0 fallos
- SPEC-008 IMPLEMENTED