### PR TITLE
release: v1.1.0 — observabilidad completa (SPEC-008)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ Métricas expuestas en `/actuator/prometheus`. El endpoint `/actuator/health` mu
 | `core.service.base-url` | `http://localhost:8081` | URL base del core service |
 | `core.service.connect-timeout-ms` | `5000` | Timeout de conexión al core (ms) |
 | `core.service.read-timeout-ms` | `10000` | Timeout de lectura al core (ms) |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4319` | Endpoint OTLP gRPC para Jaeger |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4320/v1/traces` | Endpoint OTLP HTTP completo para Jaeger (debe incluir `/v1/traces`) |
 | `TRACING_SAMPLING_PROBABILITY` | `1.0` | Proporción de trazas exportadas (0.0–1.0) |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,11 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
 
-    // Observability: actuator endpoints + Micrometer tracing (OTel bridge) + Prometheus metrics
+    // Observability: actuator endpoints + native OTel tracing + Prometheus metrics
+    // spring-boot-starter-opentelemetry is the SB4 native approach: wires OTel SDK
+    // and exposes management.opentelemetry.tracing.export.otlp.* properties automatically.
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("io.micrometer:micrometer-tracing-bridge-otel")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+    implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
     implementation("io.micrometer:micrometer-registry-prometheus")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")

--- a/src/main/java/com/sofka/insurancequoter/back/shared/infrastructure/config/ObservabilityConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/shared/infrastructure/config/ObservabilityConfig.java
@@ -5,7 +5,9 @@ import io.micrometer.observation.aop.ObservedAspect;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-// Enables @Observed AOP support across all use cases
+// Enables @Observed AOP support.
+// OTel OTLP export is auto-configured by spring-boot-starter-opentelemetry via
+// management.opentelemetry.tracing.export.otlp.endpoint — no manual SpanExporter bean needed.
 @Configuration
 public class ObservabilityConfig {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,7 +29,9 @@ springdoc.swagger-ui.path=/swagger-ui/index.html
 management.endpoints.web.exposure.include=health,prometheus,metrics
 management.endpoint.health.show-details=always
 management.tracing.sampling.probability=${TRACING_SAMPLING_PROBABILITY:1.0}
-management.otlp.tracing.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4319}
+management.observations.annotations.enabled=true
+management.opentelemetry.tracing.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4320/v1/traces}
+management.opentelemetry.resource-attributes.service.name=${spring.application.name}
 
 # Logging — solo lo relevante para el proyecto
 logging.pattern.level=%5p [${spring.application.name},%X{traceId:-},%X{spanId:-}]


### PR DESCRIPTION
## Cambios

- Observabilidad completa: métricas Prometheus, trazas Jaeger (OTLP HTTP), logs con traceId/spanId en MDC
- Fix SB4: switch a `spring-boot-starter-opentelemetry` (módulo `spring-boot-micrometer-tracing-opentelemetry` era el que faltaba)
- Fix endpoint OTLP: OTel SDK 1.x requiere path completo `/v1/traces`
- Fix 5 tests pre-existentes: saveAndFlush, COV-codes, RANDOM_PORT actuator
- Jaeger en puertos 16687/4319/4320 (no colisiona con core)

## Verificado
- 247 tests verdes
- `insurance-quoter-back` aparece en Jaeger con spans HTTP + use cases
- Métricas en `/actuator/prometheus`
- Logs con traceId/spanId correlacionados