### PR TITLE
release: v1.2.0 — observability con spring-boot-starter-opentelemetry

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,6 +32,8 @@ management.tracing.sampling.probability=${TRACING_SAMPLING_PROBABILITY:1.0}
 management.observations.annotations.enabled=true
 management.opentelemetry.tracing.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4320/v1/traces}
 management.opentelemetry.resource-attributes.service.name=${spring.application.name}
+# Disable OTLP metrics export — Jaeger does not support /v1/metrics; Prometheus is used instead
+management.otlp.metrics.export.enabled=false
 
 # Logging — solo lo relevante para el proyecto
 logging.pattern.level=%5p [${spring.application.name},%X{traceId:-},%X{spanId:-}]


### PR DESCRIPTION
## Release v1.2.0

Migración de observabilidad a `spring-boot-starter-opentelemetry` (SB4 nativo):

- Reemplaza `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp` con el starter oficial
- OtelCurrentTraceContext, OtelBaggageManager, OtelTracer, DefaultTracingObservationHandler auto-configurados
- W3C `traceparent` propagation automática
- MDC (`traceId`/`spanId`) en logs automático
- Endpoint corregido: gRPC 4319 → HTTP 4320/v1/traces
- OTLP metrics export deshabilitado (Jaeger no soporta `/v1/metrics`; métricas via Prometheus)

## Commits
- `f0bd959` fix(observability): switch to spring-boot-starter-opentelemetry (SB4 native)
- `f7d36be` fix(observability): disable OTLP metrics export to avoid 404 on Jaeger