### PR TITLE
release: v1.2.1 — fix locationCount and commercialPremium in folio list

### DIFF
--- a/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImpl.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.back.folio.application.usecase;
 
+import com.sofka.insurancequoter.back.calculation.domain.port.in.GetCalculationResultUseCase;
 import com.sofka.insurancequoter.back.folio.domain.model.FolioRaw;
 import com.sofka.insurancequoter.back.folio.domain.model.FolioSummary;
 import com.sofka.insurancequoter.back.folio.domain.port.in.GetQuoteStateUseCase;
@@ -7,22 +8,27 @@ import com.sofka.insurancequoter.back.folio.domain.port.in.ListFoliosUseCase;
 import com.sofka.insurancequoter.back.folio.domain.port.out.CoreServiceClient;
 import com.sofka.insurancequoter.back.folio.domain.port.out.FolioListQuery;
 
+import java.math.BigDecimal;
 import java.util.List;
 
-// Use case: retrieves all folios and enriches each entry with agentName (from core)
-// and completionPct (from GetQuoteStateUseCase). Registered as @Bean in FolioConfig.
+// Use case: retrieves all folios and enriches each entry with agentName (from core),
+// completionPct (from GetQuoteStateUseCase) and commercialPremium (from GetCalculationResultUseCase).
+// Registered as @Bean in FolioConfig.
 public class ListFoliosUseCaseImpl implements ListFoliosUseCase {
 
     private final FolioListQuery folioListQuery;
     private final GetQuoteStateUseCase getQuoteStateUseCase;
     private final CoreServiceClient coreServiceClient;
+    private final GetCalculationResultUseCase getCalculationResultUseCase;
 
     public ListFoliosUseCaseImpl(FolioListQuery folioListQuery,
                                   GetQuoteStateUseCase getQuoteStateUseCase,
-                                  CoreServiceClient coreServiceClient) {
+                                  CoreServiceClient coreServiceClient,
+                                  GetCalculationResultUseCase getCalculationResultUseCase) {
         this.folioListQuery = folioListQuery;
         this.getQuoteStateUseCase = getQuoteStateUseCase;
         this.coreServiceClient = coreServiceClient;
+        this.getCalculationResultUseCase = getCalculationResultUseCase;
     }
 
     @Override
@@ -36,6 +42,7 @@ public class ListFoliosUseCaseImpl implements ListFoliosUseCase {
     private FolioSummary enrich(FolioRaw raw) {
         String agentName = resolveAgentName(raw.agentCode());
         int completionPct = resolveCompletionPct(raw.folioNumber());
+        BigDecimal commercialPremium = resolveCommercialPremium(raw.folioNumber());
 
         return new FolioSummary(
                 raw.folioNumber(),
@@ -45,7 +52,7 @@ public class ListFoliosUseCaseImpl implements ListFoliosUseCase {
                 raw.status(),
                 raw.locationCount(),
                 completionPct,
-                null,           // commercialPremium: not yet in schema
+                commercialPremium,
                 raw.updatedAt()
         );
     }
@@ -65,6 +72,15 @@ public class ListFoliosUseCaseImpl implements ListFoliosUseCase {
             return getQuoteStateUseCase.getState(folioNumber).completionPercentage();
         } catch (Exception ex) {
             return 0;
+        }
+    }
+
+    // Graceful degradation: if no calculation result exists yet, return null.
+    private BigDecimal resolveCommercialPremium(String folioNumber) {
+        try {
+            return getCalculationResultUseCase.get(folioNumber).commercialPremium();
+        } catch (Exception ex) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/FolioListJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/FolioListJpaAdapter.java
@@ -4,6 +4,7 @@ import com.sofka.insurancequoter.back.folio.domain.model.FolioRaw;
 import com.sofka.insurancequoter.back.folio.domain.port.out.FolioListQuery;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.entities.QuoteJpa;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persistence.repositories.QuoteJpaRepository;
+import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,11 +12,13 @@ import java.util.List;
 
 // Persistence adapter: implements FolioListQuery using QuoteJpaRepository.findAll().
 // Maps QuoteJpa -> FolioRaw; agentName and completionPct are NOT resolved here.
+// locationCount is resolved from the locations table via LocationJpaRepository.
 @Component
 @RequiredArgsConstructor
 public class FolioListJpaAdapter implements FolioListQuery {
 
     private final QuoteJpaRepository quoteJpaRepository;
+    private final LocationJpaRepository locationJpaRepository;
 
     @Override
     public List<FolioRaw> findAll() {
@@ -30,7 +33,7 @@ public class FolioListJpaAdapter implements FolioListQuery {
                 jpa.getInsuredName(),
                 jpa.getAgentCode(),
                 jpa.getQuoteStatus(),
-                jpa.getNumberOfLocations() != null ? jpa.getNumberOfLocations() : 0,
+                locationJpaRepository.countByQuoteId(jpa.getId()),
                 jpa.getUpdatedAt()
         );
     }

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.back.folio.infrastructure.config;
 
+import com.sofka.insurancequoter.back.calculation.domain.port.in.GetCalculationResultUseCase;
 import com.sofka.insurancequoter.back.folio.application.usecase.CreateFolioUseCaseImpl;
 import com.sofka.insurancequoter.back.folio.application.usecase.GetQuoteStateUseCaseImpl;
 import com.sofka.insurancequoter.back.folio.application.usecase.ListFoliosUseCaseImpl;
@@ -51,7 +52,9 @@ public class FolioConfig {
     @Bean
     public ListFoliosUseCase listFoliosUseCase(FolioListQuery folioListQuery,
                                                 GetQuoteStateUseCase getQuoteStateUseCase,
-                                                CoreServiceClient coreServiceClient) {
-        return new ListFoliosUseCaseImpl(folioListQuery, getQuoteStateUseCase, coreServiceClient);
+                                                CoreServiceClient coreServiceClient,
+                                                GetCalculationResultUseCase getCalculationResultUseCase) {
+        return new ListFoliosUseCaseImpl(folioListQuery, getQuoteStateUseCase, coreServiceClient,
+                getCalculationResultUseCase);
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/repositories/LocationJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/adapter/out/persistence/repositories/LocationJpaRepository.java
@@ -21,6 +21,8 @@ public interface LocationJpaRepository extends JpaRepository<LocationJpa, Long> 
 
     boolean existsByQuoteIdAndIndex(Long quoteId, Integer index);
 
+    int countByQuoteId(Long quoteId);
+
     @Modifying
     @Query("DELETE FROM LocationJpa l WHERE l.quoteId = :quoteId")
     void deleteByQuoteId(@Param("quoteId") Long quoteId);

--- a/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/application/usecase/ListFoliosUseCaseImplTest.java
@@ -1,5 +1,7 @@
 package com.sofka.insurancequoter.back.folio.application.usecase;
 
+import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
+import com.sofka.insurancequoter.back.calculation.domain.port.in.GetCalculationResultUseCase;
 import com.sofka.insurancequoter.back.folio.domain.model.FolioRaw;
 import com.sofka.insurancequoter.back.folio.domain.model.FolioSummary;
 import com.sofka.insurancequoter.back.folio.domain.model.QuoteState;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
@@ -34,16 +37,20 @@ class ListFoliosUseCaseImplTest {
     @Mock
     private CoreServiceClient coreServiceClient;
 
+    @Mock
+    private GetCalculationResultUseCase getCalculationResultUseCase;
+
     private ListFoliosUseCase useCase;
 
     private static final Instant NOW = Instant.parse("2026-04-20T10:00:00Z");
 
     @BeforeEach
     void setUp() {
-        useCase = new ListFoliosUseCaseImpl(folioListQuery, getQuoteStateUseCase, coreServiceClient);
+        useCase = new ListFoliosUseCaseImpl(folioListQuery, getQuoteStateUseCase, coreServiceClient,
+                getCalculationResultUseCase);
     }
 
-    // --- Happy path: lista con un folio ---
+    // --- Happy path: lista con un folio, con prima comercial calculada ---
 
     @Test
     void shouldReturnFolioSummaries_whenFoliosExist() {
@@ -52,9 +59,9 @@ class ListFoliosUseCaseImplTest {
                 "AGT-001", "CREATED", 1, NOW);
         when(folioListQuery.findAll()).thenReturn(List.of(raw));
         when(coreServiceClient.getAgentName("AGT-001")).thenReturn("Carlos López");
-
-        QuoteState state = buildState("FOL-2026-00001", 10);
-        when(getQuoteStateUseCase.getState("FOL-2026-00001")).thenReturn(state);
+        when(getQuoteStateUseCase.getState("FOL-2026-00001")).thenReturn(buildState("FOL-2026-00001", 10));
+        when(getCalculationResultUseCase.get("FOL-2026-00001"))
+                .thenReturn(buildCalculationResult("FOL-2026-00001", new BigDecimal("12500.00")));
 
         // WHEN
         List<FolioSummary> result = useCase.listFolios();
@@ -69,7 +76,7 @@ class ListFoliosUseCaseImplTest {
         assertThat(summary.status()).isEqualTo("CREATED");
         assertThat(summary.locationCount()).isEqualTo(1);
         assertThat(summary.completionPct()).isEqualTo(10);
-        assertThat(summary.commercialPremium()).isNull();
+        assertThat(summary.commercialPremium()).isEqualByComparingTo(new BigDecimal("12500.00"));
         assertThat(summary.updatedAt()).isEqualTo(NOW);
     }
 
@@ -150,6 +157,8 @@ class ListFoliosUseCaseImplTest {
         when(folioListQuery.findAll()).thenReturn(List.of(raw));
         when(coreServiceClient.getAgentName("AGT-005")).thenReturn("Laura Vega");
         when(getQuoteStateUseCase.getState("FOL-2026-00005")).thenReturn(buildState("FOL-2026-00005", 60));
+        when(getCalculationResultUseCase.get("FOL-2026-00005"))
+                .thenReturn(buildCalculationResult("FOL-2026-00005", new BigDecimal("5000.00")));
 
         // WHEN
         List<FolioSummary> result = useCase.listFolios();
@@ -158,12 +167,56 @@ class ListFoliosUseCaseImplTest {
         assertThat(result.get(0).completionPct()).isEqualTo(60);
     }
 
-    // --- Helper ---
+    // --- commercialPremium populated from GetCalculationResultUseCase ---
+
+    @Test
+    void shouldPopulateCommercialPremium_whenCalculationResultExists() {
+        // GIVEN
+        FolioRaw raw = new FolioRaw("FOL-2026-00006", "Corp W", "AGT-006", "IN_PROGRESS", 3, NOW);
+        when(folioListQuery.findAll()).thenReturn(List.of(raw));
+        when(coreServiceClient.getAgentName("AGT-006")).thenReturn("Mario Flores");
+        when(getQuoteStateUseCase.getState("FOL-2026-00006")).thenReturn(buildState("FOL-2026-00006", 80));
+        when(getCalculationResultUseCase.get("FOL-2026-00006"))
+                .thenReturn(buildCalculationResult("FOL-2026-00006", new BigDecimal("98765.43")));
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result.get(0).commercialPremium()).isEqualByComparingTo(new BigDecimal("98765.43"));
+    }
+
+    // --- commercialPremium is null when calculation result is not available ---
+
+    @Test
+    void shouldReturnNullCommercialPremium_whenGetCalculationResultUseCaseThrows() {
+        // GIVEN
+        FolioRaw raw = new FolioRaw("FOL-2026-00007", "Corp V", "AGT-007", "CREATED", 0, NOW);
+        when(folioListQuery.findAll()).thenReturn(List.of(raw));
+        when(coreServiceClient.getAgentName("AGT-007")).thenReturn("Sofia Ramos");
+        when(getQuoteStateUseCase.getState("FOL-2026-00007")).thenReturn(buildState("FOL-2026-00007", 0));
+        when(getCalculationResultUseCase.get("FOL-2026-00007"))
+                .thenThrow(new RuntimeException("Calculation result not found"));
+
+        // WHEN
+        List<FolioSummary> result = useCase.listFolios();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).commercialPremium()).isNull();
+    }
+
+    // --- Helpers ---
 
     private QuoteState buildState(String folioNumber, int completionPct) {
         QuoteSections sections = new QuoteSections(
                 SectionStatus.PENDING, SectionStatus.PENDING,
                 SectionStatus.PENDING, SectionStatus.PENDING, SectionStatus.PENDING);
         return new QuoteState(folioNumber, "CREATED", completionPct, sections, 1L, NOW);
+    }
+
+    private CalculationResult buildCalculationResult(String folioNumber, BigDecimal commercialPremium) {
+        return new CalculationResult(folioNumber, commercialPremium.multiply(new BigDecimal("0.9")),
+                commercialPremium, List.of(), NOW, 1L);
     }
 }


### PR DESCRIPTION
Patch release. Fixes en el endpoint GET /v1/folios: locationCount ahora cuenta desde la tabla de ubicaciones, commercialPremium se lee del resultado de cálculo persistido.