### PR TITLE
release: v1.2.2

### DIFF
--- a/src/main/java/com/sofka/insurancequoter/back/calculation/domain/service/CalculationService.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/domain/service/CalculationService.java
@@ -65,7 +65,7 @@ public class CalculationService {
         // Intermediate-scale fire sum: avoids propagating rounding error into derived components
         BigDecimal firePremiumIntermediate = sumInsuredValueByCode(location, "GUA-FIRE")
                 .multiply(tariff.fireRate())
-                .add(sumInsuredValueByCode(location, "GUA-FIRE-CONT")
+                .add(sumInsuredValueByCode(location, "GUA-CONT")
                         .multiply(tariff.fireContentsRate()))
                 .setScale(INTERMEDIATE_SCALE, ROUNDING);
 
@@ -130,7 +130,7 @@ public class CalculationService {
     }
 
     private BigDecimal calculateFireContents(Location location, Tariff tariff) {
-        return sumInsuredValueByCode(location, "GUA-FIRE-CONT")
+        return sumInsuredValueByCode(location, "GUA-CONT")
                 .multiply(tariff.fireContentsRate())
                 .setScale(RESULT_SCALE, ROUNDING);
     }

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/CalculationController.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/adapter/in/rest/CalculationController.java
@@ -2,6 +2,7 @@ package com.sofka.insurancequoter.back.calculation.infrastructure.adapter.in.res
 
 import com.sofka.insurancequoter.back.calculation.application.usecase.command.AcceptQuoteCommand;
 import com.sofka.insurancequoter.back.calculation.application.usecase.command.CalculatePremiumCommand;
+import com.sofka.insurancequoter.back.calculation.application.usecase.exception.CalculationResultNotFoundException;
 import com.sofka.insurancequoter.back.calculation.domain.model.AcceptQuoteResult;
 import com.sofka.insurancequoter.back.calculation.domain.model.CalculationResult;
 import com.sofka.insurancequoter.back.calculation.domain.port.in.AcceptQuoteUseCase;
@@ -49,8 +50,12 @@ public class CalculationController implements CalculationApi {
 
     @Override
     public ResponseEntity<CalculationResponse> getCalculationResult(@PathVariable String folio) {
-        CalculationResult result = getCalculationResultUseCase.get(folio);
-        return ResponseEntity.ok(calculationRestMapper.toResponse(result));
+        try {
+            CalculationResult result = getCalculationResultUseCase.get(folio);
+            return ResponseEntity.ok(calculationRestMapper.toResponse(result));
+        } catch (CalculationResultNotFoundException e) {
+            return ResponseEntity.noContent().build();
+        }
     }
 
     @Override

--- a/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/config/CalculationConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/calculation/infrastructure/config/CalculationConfig.java
@@ -23,6 +23,7 @@ import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.persisten
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.mappers.LocationPersistenceMapper;
 import com.sofka.insurancequoter.back.location.infrastructure.adapter.out.persistence.repositories.LocationJpaRepository;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +43,7 @@ public class CalculationConfig {
 
     @Bean
     public TariffClient tariffClient(
+            ObservationRegistry observationRegistry,
             @Value("${core.service.base-url:http://localhost:8081}") String baseUrl,
             @Value("${core.service.connect-timeout-ms:5000}") int connectTimeoutMs,
             @Value("${core.service.read-timeout-ms:10000}") int readTimeoutMs) {
@@ -51,6 +53,7 @@ public class CalculationConfig {
         RestClient restClient = RestClient.builder()
                 .baseUrl(baseUrl)
                 .requestFactory(factory)
+                .observationRegistry(observationRegistry)
                 .build();
         return new TariffClientAdapter(restClient);
     }

--- a/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/coverage/infrastructure/config/CoverageConfig.java
@@ -27,9 +27,14 @@ public class CoverageConfig {
 
     @Bean
     public GuaranteeCatalogClient guaranteeCatalogClient(
+            io.micrometer.observation.ObservationRegistry observationRegistry,
             @Value("${core.service.base-url:http://localhost:8081}") String baseUrl) {
-        RestClient restClient = RestClient.builder().baseUrl(baseUrl).build();
-        return new GuaranteeCatalogClientAdapter(restClient);
+        return new GuaranteeCatalogClientAdapter(
+                RestClient.builder()
+                        .baseUrl(baseUrl)
+                        .observationRegistry(observationRegistry)
+                        .build()
+        );
     }
 
     @Bean

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/LocationStateJpaAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/adapter/LocationStateJpaAdapter.java
@@ -21,7 +21,7 @@ public class LocationStateJpaAdapter implements LocationStateReader {
     public LocationStateSummary readByFolioNumber(String folioNumber) {
         return quoteJpaRepository.findByFolioNumber(folioNumber)
                 .map(quote -> {
-                    List<LocationJpa> locations = locationJpaRepository.findByQuoteId(quote.getId());
+                    List<LocationJpa> locations = locationJpaRepository.findByQuoteIdAndActiveTrue(quote.getId());
                     long completeCount = locations.stream()
                             .filter(l -> "COMPLETE".equals(l.getValidationStatus()))
                             .count();

--- a/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/folio/infrastructure/config/FolioConfig.java
@@ -15,6 +15,7 @@ import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteRepository;
 import com.sofka.insurancequoter.back.folio.domain.port.out.QuoteStateQuery;
 import com.sofka.insurancequoter.back.folio.infrastructure.adapter.out.http.adapter.CoreServiceClientAdapter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,9 +25,12 @@ import org.springframework.web.client.RestClient;
 public class FolioConfig {
 
     @Bean
-    public RestClient coreRestClient(@Value("${core.service.base-url}") String baseUrl) {
+    public RestClient coreRestClient(
+            ObservationRegistry observationRegistry,
+            @Value("${core.service.base-url}") String baseUrl) {
         return RestClient.builder()
                 .baseUrl(baseUrl)
+                .observationRegistry(observationRegistry)
                 .build();
     }
 

--- a/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/config/LocationConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/back/location/infrastructure/config/LocationConfig.java
@@ -28,11 +28,14 @@ public class LocationConfig {
 
     @Bean
     public ZipCodeValidationClient zipCodeValidationClient(
+            io.micrometer.observation.ObservationRegistry observationRegistry,
             @Value("${core.service.base-url:http://localhost:8081}") String baseUrl) {
-        RestClient restClient = RestClient.builder()
-                .baseUrl(baseUrl)
-                .build();
-        return new ZipCodeValidationClientAdapter(restClient);
+        return new ZipCodeValidationClientAdapter(
+                RestClient.builder()
+                        .baseUrl(baseUrl)
+                        .observationRegistry(observationRegistry)
+                        .build()
+        );
     }
 
     @Bean

--- a/src/test/java/com/sofka/insurancequoter/back/calculation/domain/service/CalculationServiceTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/calculation/domain/service/CalculationServiceTest.java
@@ -43,7 +43,7 @@ class CalculationServiceTest {
             BigDecimal.valueOf(1.16)      // commercialFactor
     );
 
-    private static final Set<String> TARIFABLE_CODES = Set.of("GUA-FIRE", "GUA-FIRE-CONT", "GUA-THEFT");
+    private static final Set<String> TARIFABLE_CODES = Set.of("GUA-FIRE", "GUA-CONT", "GUA-THEFT");
 
     @BeforeEach
     void setUp() {
@@ -178,10 +178,10 @@ class CalculationServiceTest {
 
     @Test
     void calculateLocation_fireContents_returnsInsuredValueTimesRate() {
-        // GIVEN — GUA-FIRE-CONT: 500,000 × 0.0012 = 600.00
-        Set<String> codes = Set.of("GUA-FIRE", "GUA-FIRE-CONT");
+        // GIVEN — GUA-CONT: 500,000 × 0.0012 = 600.00
+        Set<String> codes = Set.of("GUA-FIRE", "GUA-CONT");
         Location location = locationWith("06600", "FK-001",
-                List.of(new Guarantee("GUA-FIRE-CONT", BigDecimal.valueOf(500_000))));
+                List.of(new Guarantee("GUA-CONT", BigDecimal.valueOf(500_000))));
         // WHEN
         PremiumByLocation result = calculationService.calculateLocation(location, TARIFF, codes);
         // THEN
@@ -190,7 +190,7 @@ class CalculationServiceTest {
     }
 
     @Test
-    void calculateLocation_fireContents_returnsZero_whenNoGUAFIRECONTGuarantee() {
+    void calculateLocation_fireContents_returnsZero_whenNoGUACONTGuarantee() {
         // GIVEN — only GUA-FIRE
         Location location = locationWith("06600", "FK-001",
                 List.of(new Guarantee("GUA-FIRE", BigDecimal.valueOf(1_000_000))));

--- a/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/LocationStateJpaAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/back/folio/infrastructure/adapter/out/persistence/LocationStateJpaAdapterTest.java
@@ -56,7 +56,7 @@ class LocationStateJpaAdapterTest {
     void readByFolioNumber_withNoLocations_returnsTotalZero() {
         // GIVEN
         when(quoteJpaRepository.findByFolioNumber("FOL-001")).thenReturn(Optional.of(quoteJpa(10L)));
-        when(locationJpaRepository.findByQuoteId(10L)).thenReturn(List.of());
+        when(locationJpaRepository.findByQuoteIdAndActiveTrue(10L)).thenReturn(List.of());
 
         // WHEN
         LocationStateSummary result = adapter.readByFolioNumber("FOL-001");
@@ -71,7 +71,7 @@ class LocationStateJpaAdapterTest {
     void readByFolioNumber_withMixedLocations_returnsCorrectCounts() {
         // GIVEN — 3 locations: 2 COMPLETE, 1 INCOMPLETE (has blocking alerts)
         when(quoteJpaRepository.findByFolioNumber("FOL-001")).thenReturn(Optional.of(quoteJpa(10L)));
-        when(locationJpaRepository.findByQuoteId(10L)).thenReturn(List.of(
+        when(locationJpaRepository.findByQuoteIdAndActiveTrue(10L)).thenReturn(List.of(
                 location("COMPLETE", List.of()),
                 location("COMPLETE", List.of()),
                 location("INCOMPLETE", List.of(new BlockingAlertEmbeddable("MISSING_ZIP_CODE", "Código postal requerido")))


### PR DESCRIPTION
Release v1.2.2 — OTel trace propagation fix + bug fixes #261 #262 #263

- RestClient usa ObservationRegistry para propagar W3C traceparent (back→core visible en Grafana)
- locationCount correcto en dashboard (solo ubicaciones activas)
- GET cálculo retorna 204 cuando no existe (ya no lanza 500)
- GUA-CONT calculado correctamente (rename de GUA-FIRE-CONT)